### PR TITLE
fix(examples): bind payment-identifier cache to the HTTP request

### DIFF
--- a/docs/extensions/payment-identifier.mdx
+++ b/docs/extensions/payment-identifier.mdx
@@ -16,8 +16,8 @@ The payment-identifier extension provides an idempotency mechanism for x402 paym
 
 1. Server advertises `payment-identifier` extension support in the `PaymentRequired` response
 2. Client generates a unique payment ID and includes it in the `PaymentPayload`
-3. Server caches responses keyed by payment ID (with configurable TTL)
-4. Retry requests with the same payment ID return cached responses without re-processing payment
+3. Server looks up the settled cache first, then holds an expiring in-flight reservation (fingerprint + timestamp) before payment middleware
+4. Retry requests with the same payment ID and the same request fingerprint return cached responses without re-processing payment. A different method, path, query, or body with that ID returns `409 Conflict` and must not grant access. A live reservation is never overwritten; the same in-flight fingerprint returns a controlled in-flight `409`, not a second settlement.
 
 ## Quickstart for Buyers (Clients)
 
@@ -191,7 +191,6 @@ response2, err := client.MakeRequest(url)
 </Tab>
 </Tabs>
 
-
 ### Best Practices
 
 1. **Generate payment IDs at the logical request level**, not per retry
@@ -240,61 +239,130 @@ const routes = {
 
 ```typescript
 // Payment ID is optional (clients can omit it)
-declarePaymentIdentifierExtension(false)
+declarePaymentIdentifierExtension(false);
 
 // Payment ID is required (clients must provide it or receive 400 Bad Request)
-declarePaymentIdentifierExtension(true)
+declarePaymentIdentifierExtension(true);
 ```
 
 ### Step 2: Cache Responses After Settlement
 
-Store responses after successful payment settlement:
+Store the HTTP request fingerprint with the payment ID. Hashing the payment payload (or the raw payment header) is not request binding: the same signed payload can be replayed against a different method, path, or body.
 
 ```typescript
+import { createHash } from "crypto";
 import { extractPaymentIdentifier } from "@x402/extensions/payment-identifier";
 
-// In-memory cache (use Redis in production)
-const idempotencyCache = new Map<string, { timestamp: number; response: unknown }>();
-const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+const idempotencyCache = new Map<
+  string,
+  { timestamp: number; fingerprint: string; response: unknown }
+>();
+const pendingReservations = new Map<
+  string,
+  { fingerprint: string; timestamp: number }
+>();
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour settled cache
+const RESERVATION_TTL_MS = 30 * 1000; // in-flight only; failed verify must expire
+
+function requestFingerprint(
+  req: { method: string; originalUrl: string },
+  body: Buffer,
+  payload: { accepted?: Record<string, string> },
+): string {
+  const url = new URL(req.originalUrl, "http://localhost");
+  url.searchParams.sort();
+  const accepted = payload.accepted ?? {};
+  const material = {
+    method: req.method.toUpperCase(),
+    url: url.pathname + url.search,
+    bodySha256: createHash("sha256").update(body).digest("hex"),
+    scheme: accepted.scheme ?? "",
+    network: accepted.network ?? "",
+    asset: accepted.asset ?? "",
+    amount: accepted.amount ?? "",
+    payTo: accepted.payTo ?? "",
+  };
+  return createHash("sha256").update(JSON.stringify(material)).digest("hex");
+}
 
 const resourceServer = new x402ResourceServer(facilitatorClient)
   .register("eip155:84532", new ExactEvmScheme())
   .onAfterSettle(async ({ paymentPayload }) => {
     const paymentId = extractPaymentIdentifier(paymentPayload);
-    if (paymentId) {
-      idempotencyCache.set(paymentId, {
-        timestamp: Date.now(),
-        response: { /* your response data */ },
-      });
+    const reserved = paymentId ? pendingReservations.get(paymentId) : undefined;
+    if (!paymentId || !reserved) {
+      return; // missing reservation: do not cache
     }
+    pendingReservations.delete(paymentId);
+    if (Date.now() - reserved.timestamp >= RESERVATION_TTL_MS) {
+      return; // expired reservation: do not cache
+    }
+    idempotencyCache.set(paymentId, {
+      timestamp: Date.now(),
+      fingerprint: reserved.fingerprint, // exact reserved fingerprint
+      response: {
+        /* your response data */
+      },
+    });
   });
 ```
 
 ### Step 3: Check Cache Before Payment
 
-Use the `onProtectedRequest` hook to return cached responses and skip payment processing:
+`onProtectedRequest` can only return `{ grantAccess: true }` (runs the resource handler) or `{ abort: true }` (HTTP 403). It cannot return 409. Check the fingerprint in application middleware **before** payment middleware, and never call `grantAccess` on drift. The official Express example is GET-only and does not install body-parsing middleware, so it hashes an empty body rather than capturing POST bodies:
 
 ```typescript
-const httpServer = new x402HTTPResourceServer(resourceServer, routes)
-  .onProtectedRequest(async (context) => {
-    if (!context.paymentHeader) return;
+app.use((req, res, next) => {
+  if (!req.headers["x-payment"] && !req.headers["payment-signature"])
+    return next();
+  try {
+    const header = String(
+      req.headers["payment-signature"] || req.headers["x-payment"],
+    );
+    const paymentPayload = JSON.parse(
+      Buffer.from(header, "base64").toString("utf-8"),
+    );
+    const paymentId = extractPaymentIdentifier(paymentPayload);
+    if (!paymentId) return next();
 
-    try {
-      const paymentPayload = JSON.parse(
-        Buffer.from(context.paymentHeader, "base64").toString("utf-8"),
-      );
-      const paymentId = extractPaymentIdentifier(paymentPayload);
-
-      if (paymentId) {
-        const cached = idempotencyCache.get(paymentId);
-        if (cached && Date.now() - cached.timestamp < CACHE_TTL_MS) {
-          return { grantAccess: true }; // Skip payment, serve from cache
-        }
+    // GET-only example: no body-parsing middleware, so the hashed body is empty.
+    const fingerprint = requestFingerprint(
+      req,
+      Buffer.alloc(0),
+      paymentPayload,
+    );
+    const cached = idempotencyCache.get(paymentId);
+    if (cached && Date.now() - cached.timestamp < CACHE_TTL_MS) {
+      if (cached.fingerprint !== fingerprint) {
+        return res.status(409).json({
+          error: "payment identifier already used with different request",
+          paymentId,
+        });
       }
-    } catch {
-      // Invalid payment header, continue to normal payment flow
+      return res.json(cached.response); // same request: skip payment, do not grantAccess
     }
-  });
+    const reserved = pendingReservations.get(paymentId);
+    if (reserved && Date.now() - reserved.timestamp < RESERVATION_TTL_MS) {
+      if (reserved.fingerprint === fingerprint) {
+        return res.status(409).json({
+          error:
+            "payment identifier is already being processed for this request",
+          paymentId,
+        });
+      }
+      return res.status(409).json({
+        error: "payment identifier already used with different request",
+        paymentId,
+      });
+    }
+    pendingReservations.set(paymentId, { fingerprint, timestamp: Date.now() });
+  } catch {
+    // Invalid payment header, continue to normal payment flow
+  }
+  next();
+});
+
+app.use(paymentMiddlewareFromHTTPServer(httpServer));
 ```
 
 </Tab>
@@ -344,24 +412,30 @@ declare_payment_identifier_extension(required=True)
 
 ### Step 2: Cache Responses After Settlement
 
-Store responses after successful payment settlement:
+Store the HTTP request fingerprint with the payment ID. Do not key the cache on payment ID alone.
 
 ```python
 import time
 from x402.schemas import SettleContext
 from x402.extensions.payment_identifier import extract_payment_identifier
 
-# In-memory cache (use Redis in production)
 idempotency_cache: dict = {}
-CACHE_TTL_SECONDS = 60 * 60  # 1 hour
+pending_reservations: dict[str, dict] = {}
+CACHE_TTL_SECONDS = 60 * 60  # 1 hour settled cache
+RESERVATION_TTL_SECONDS = 30  # in-flight only; failed verify must expire
 
 async def after_settle(ctx: SettleContext) -> None:
     payment_id = extract_payment_identifier(ctx.payment_payload)
-    if payment_id:
-        idempotency_cache[payment_id] = {
-            "timestamp": time.time(),
-            "response": {},  # your response data
-        }
+    reserved = pending_reservations.pop(payment_id, None) if payment_id else None
+    if not payment_id or not reserved:
+        return  # missing reservation: do not cache
+    if time.time() - reserved["timestamp"] >= RESERVATION_TTL_SECONDS:
+        return  # expired reservation: do not cache
+    idempotency_cache[payment_id] = {
+        "timestamp": time.time(),
+        "fingerprint": reserved["fingerprint"],  # exact reserved fingerprint
+        "response": {},  # your response data
+    }
 
 server = x402ResourceServer(facilitator)
 server.register("eip155:84532", ExactEvmServerScheme())
@@ -370,7 +444,7 @@ server.on_after_settle(after_settle)
 
 ### Step 3: Check Cache Before Payment
 
-Use FastAPI middleware to check the cache before the payment middleware processes the request:
+Register payment middleware first, then the idempotency middleware, so the cache check is outermost. On fingerprint mismatch return `409` and do not call the resource handler:
 
 ```python
 import base64
@@ -378,9 +452,11 @@ import json
 from fastapi import Request, Response
 from x402.schemas import PaymentPayload
 
+app.add_middleware(PaymentMiddlewareASGI, routes=routes, server=server)
+
 @app.middleware("http")
 async def idempotency_middleware(request: Request, call_next):
-    payment_header = request.headers.get("X-Payment")
+    payment_header = request.headers.get("PAYMENT-SIGNATURE") or request.headers.get("X-Payment")
     if payment_header:
         try:
             payment_data = json.loads(base64.b64decode(payment_header))
@@ -388,19 +464,47 @@ async def idempotency_middleware(request: Request, call_next):
             payment_id = extract_payment_identifier(payment_payload)
 
             if payment_id:
+                fingerprint = request_fingerprint(
+                    method=request.method,
+                    url=str(request.url),
+                    body=await request.body(),
+                    payload=payment_payload,
+                )
                 cached = idempotency_cache.get(payment_id)
                 if cached and time.time() - cached["timestamp"] < CACHE_TTL_SECONDS:
+                    if cached["fingerprint"] != fingerprint:
+                        return Response(
+                            content=json.dumps({
+                                "error": "payment identifier already used with different request",
+                                "paymentId": payment_id,
+                            }),
+                            media_type="application/json",
+                            status_code=409,
+                        )
                     return Response(
                         content=json.dumps(cached["response"]),
                         media_type="application/json",
                     )
+                reserved = pending_reservations.get(payment_id)
+                if reserved and time.time() - reserved["timestamp"] < RESERVATION_TTL_SECONDS:
+                    error = (
+                        "payment identifier is already being processed for this request"
+                        if reserved["fingerprint"] == fingerprint
+                        else "payment identifier already used with different request"
+                    )
+                    return Response(
+                        content=json.dumps({"error": error, "paymentId": payment_id}),
+                        media_type="application/json",
+                        status_code=409,
+                    )
+                pending_reservations[payment_id] = {
+                    "fingerprint": fingerprint,
+                    "timestamp": time.time(),
+                }
         except Exception:
             pass  # Invalid payment header, continue to normal flow
 
     return await call_next(request)
-
-# Add payment middleware AFTER idempotency middleware
-app.add_middleware(PaymentMiddlewareASGI, routes=routes, server=server)
 ```
 
 </Tab>
@@ -477,44 +581,55 @@ processedPayments[paymentID] = responseData
 </Tab>
 </Tabs>
 
-
 ### Request Binding
 
-Servers should bind each payment ID to a normalized fingerprint of the request before returning a cached result. The fingerprint should cover the parts of the request that make the paid operation unique:
+Servers should bind each payment ID to a normalized fingerprint of the HTTP request before returning a cached result. Hashing the payment payload or `PAYMENT-SIGNATURE` / `X-Payment` header is not sufficient: those values do not change when the same signed payload is sent as a different method, path, query, or body.
+
+The fingerprint should cover the parts of the request that make the paid operation unique:
 
 - `scheme`, `network`, `asset`, `amount`, `payTo`
-- Resource path and HTTP method
+- HTTP method and canonical resource path (query keys sorted, duplicate-key order preserved, no fragment)
+- Raw request body SHA-256 (the Express example is GET-only and hashes empty bytes; it does not parse POST bodies)
 - Application-level operation or order identifier (when available)
 
-Store the first observed fingerprint with the payment ID. Later requests with the same ID and the same fingerprint can return the cached response. Later requests with the same ID but a different fingerprint should return `409 Conflict` — not a cached response or a second execution.
+Store the first observed fingerprint with the payment ID. Later requests with the same ID and the same fingerprint can return the cached response. Later requests with the same ID but a different fingerprint should return `409 Conflict`, not a cached response, a second execution, or `grantAccess: true`.
+
+Before payment middleware, keep an expiring in-flight reservation (fingerprint + timestamp) distinct from the settled cache. A live reservation must never grant access, never start a second settlement, and never be overwritten. Same fingerprint while reserved is an in-flight `409`; a different fingerprint is the request-conflict `409`. If verification fails, drop the reservation after a short TTL (30 seconds in the official examples, not the one-hour cache TTL). `onAfterSettle` must consume only that live reservation and cache its exact fingerprint; if the reservation is missing or expired, do not cache.
 
 When the same backend handles multiple paid resources, scope the storage key by tenant, merchant, route, or facilitator account to avoid cross-resource collisions.
 
 ### Idempotency Behavior
 
-| Scenario | Server Response |
-|----------|-----------------|
-| New payment ID | Process payment normally, cache response |
-| Same payment ID, same request fingerprint (within TTL) | Return cached response, skip payment |
-| Same payment ID, different request fingerprint | Return 409 Conflict |
-| Same payment ID (after TTL) | Process payment normally, update cache |
-| No payment ID | Process payment normally (no caching) |
-| `required: true`, no payment ID provided | Return 400 Bad Request |
+| Scenario                                                     | Server Response                             |
+| ------------------------------------------------------------ | ------------------------------------------- |
+| New payment ID                                               | Reserve, process payment, cache on settle   |
+| Same payment ID, same request fingerprint (within cache TTL) | Return cached response, skip payment        |
+| Same payment ID, same fingerprint, live reservation          | 409 in-flight conflict, do not settle again |
+| Same payment ID, different request fingerprint               | Return 409 Conflict; do not overwrite       |
+| Same payment ID (after cache TTL)                            | Process payment normally, update cache      |
+| Reservation expired (failed verification)                    | Drop reservation; ID can proceed again      |
+| Settle with missing/expired reservation                      | Do not cache                                |
+| No payment ID                                                | Process payment normally (no caching)       |
+| `required: true`, no payment ID provided                     | Return 400 Bad Request                      |
 
 ### Configuration Options
 
 #### Cache TTL
 
 Adjust `CACHE_TTL_MS` (TypeScript/Go) or `CACHE_TTL_SECONDS` (Python) based on your use case:
+
 - Short TTL (5-15 min): For time-sensitive resources
 - Long TTL (1-24 hours): For static or infrequently changing resources
+
+Keep a separate in-flight reservation TTL (`RESERVATION_TTL_MS` / `RESERVATION_TTL_SECONDS`). The official examples use 30 seconds, not the one-hour settled cache TTL, so a failed verification cannot leak memory or block the payment ID.
 
 ### Production Considerations
 
 1. **Use Redis or similar** instead of in-memory cache for distributed systems
 2. **Handle cache failures gracefully** - if cache is unavailable, process payment normally
-3. **Bind payment IDs to request fingerprints** - store the fingerprint (scheme, network, asset, amount, payTo, route, and application operation ID) alongside the payment ID and return `409 Conflict` if the same ID is replayed with a different fingerprint
-4. **Monitor cache hit rates** to tune TTL and detect abuse
+3. **Bind payment IDs to request fingerprints** - store the fingerprint (scheme, network, asset, amount, payTo, HTTP method, canonical path, raw body SHA-256, and application operation ID) alongside the payment ID and return `409 Conflict` if the same ID is replayed with a different fingerprint. Do not fingerprint only the payment payload. The official Express example is GET-only and hashes an empty body; do not assume it captures POST bodies.
+4. **Reserve in-flight IDs** so two concurrent misses cannot bind the first settlement to the second request. Expire reservations on a short TTL.
+5. **Monitor cache hit rates** to tune TTL and detect abuse
 
 ## API Reference
 
@@ -545,7 +660,10 @@ Adds a payment identifier to the extensions object. Only modifies extensions if 
 import { appendPaymentIdentifierToExtensions } from "@x402/extensions/payment-identifier";
 
 const extensions = paymentRequired.extensions ?? {};
-appendPaymentIdentifierToExtensions(extensions, "pay_custom_id_1234567890abcdef");
+appendPaymentIdentifierToExtensions(
+  extensions,
+  "pay_custom_id_1234567890abcdef",
+);
 // extensions now contains the payment-identifier extension (only if server declared it)
 ```
 
@@ -607,10 +725,10 @@ if (!result.valid) {
 
 ```typescript
 import {
-  PAYMENT_IDENTIFIER,      // "payment-identifier"
-  PAYMENT_ID_MIN_LENGTH,   // 16
-  PAYMENT_ID_MAX_LENGTH,   // 128
-  PAYMENT_ID_PATTERN,      // /^[a-zA-Z0-9_-]+$/
+  PAYMENT_IDENTIFIER, // "payment-identifier"
+  PAYMENT_ID_MIN_LENGTH, // 16
+  PAYMENT_ID_MAX_LENGTH, // 128
+  PAYMENT_ID_PATTERN, // /^[a-zA-Z0-9_-]+$/
 } from "@x402/extensions/payment-identifier";
 ```
 
@@ -822,14 +940,17 @@ var PAYMENT_ID_PATTERN = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 Full working examples are available in the x402 repository:
 
 **TypeScript:**
+
 - [TypeScript Client Example](https://github.com/x402-foundation/x402/tree/main/examples/typescript/clients/payment-identifier)
 - [TypeScript Server Example](https://github.com/x402-foundation/x402/tree/main/examples/typescript/servers/payment-identifier)
 
 **Python:**
+
 - [Python Client Example](https://github.com/x402-foundation/x402/tree/main/examples/python/clients/payment-identifier)
 - [Python Server Example](https://github.com/x402-foundation/x402/tree/main/examples/python/servers/payment-identifier)
 
 **Go:**
+
 - [Go Client Example](https://github.com/x402-foundation/x402/tree/main/examples/go/clients/payment-identifier)
 - [Go Server Example](https://github.com/x402-foundation/x402/tree/main/examples/go/servers/payment-identifier)
 

--- a/docs/extensions/payment-identifier.mdx
+++ b/docs/extensions/payment-identifier.mdx
@@ -8,7 +8,7 @@ The payment-identifier extension provides an idempotency mechanism for x402 paym
 ## Use Cases
 
 - **Network failures**: Safely retry failed requests without duplicate payments
-- **Client crashes**: Resume requests after restart using persisted payment IDs
+- **Bounded same-process retries**: Reuse the captured exact header without creating a second payment credential
 - **Load balancing**: Same request can hit different servers with shared cache
 - **Testing**: Replay requests during development without spending funds
 
@@ -16,8 +16,8 @@ The payment-identifier extension provides an idempotency mechanism for x402 paym
 
 1. Server advertises `payment-identifier` extension support in the `PaymentRequired` response
 2. Client generates a unique payment ID and includes it in the `PaymentPayload`
-3. Server looks up the settled cache first, then holds an expiring in-flight reservation (fingerprint + timestamp) before payment middleware
-4. Retry requests with the same payment ID and the same request fingerprint return cached responses without re-processing payment. A different method, path, query, or body with that ID returns `409 Conflict` and must not grant access. A live reservation is never overwritten; the same in-flight fingerprint returns a controlled in-flight `409`, not a second settlement.
+3. Server looks up the settled cache first, then holds an expiring in-flight reservation (fingerprint + timestamp + token + state) before payment middleware, and only for protected paid routes. Reservation TTL and map capacity are server policy (300s, 1024 entries), not client `maxTimeoutSeconds`.
+4. Retry requests with the same payment ID and the same request-and-credential fingerprint return cached responses without re-processing payment. A different method, path, query, body, extra, timeout, or payment credential with that ID returns `409 Conflict` and must not grant access. A live reservation is never overwritten. Same in-flight fingerprint or a full pending map returns HTTP `503` with `Retry-After` (retryable), not `409`. Pre-settlement rejection releases only the matching tokenized reservation. After settlement has begun, a thrown timeout/network/facilitator error keeps a tokenized tombstone until the server TTL expires. A settle failure is not immediately safe to retry.
 
 ## Quickstart for Buyers (Clients)
 
@@ -44,11 +44,14 @@ const orderId = generatePaymentId("order_");
 Hook into the payment flow to add the payment ID before payload creation:
 
 ```typescript
-import { x402Client, wrapFetchWithPayment } from "@x402/fetch";
+import { x402Client, wrapFetchWithPayment, x402HTTPClient } from "@x402/fetch";
 import {
   appendPaymentIdentifierToExtensions,
   generatePaymentId,
 } from "@x402/extensions/payment-identifier";
+import { configureExactHeaderReplay } from "./header-replay.js";
+// configureExactHeaderReplay:
+// examples/typescript/clients/payment-identifier/header-replay.ts
 
 const client = new x402Client();
 // ... register schemes ...
@@ -64,14 +67,25 @@ client.onBeforePaymentCreation(async ({ paymentRequired }) => {
   }
 });
 
-const fetchWithPayment = wrapFetchWithPayment(fetch, client);
+const httpClient = new x402HTTPClient(client);
+// url is immutable configuration. PaymentCreatedContext has no request URL,
+// so a shared pendingUrl cannot correlate concurrent 402s. This helper is
+// sequential single-URL scope and fails closed if a non-target 402 arrives
+// before capture.
+configureExactHeaderReplay(client, httpClient, url);
 
-// First request - payment is processed
+const fetchWithPayment = wrapFetchWithPayment(fetch, httpClient);
+
+// First request - payment is processed and the exact encoded header is captured
 const response1 = await fetchWithPayment(url);
 
-// Retry with same payment ID - cached response returned (no payment)
+// Retry only the same request URL and selected accepted terms.
+// Do not replay cross-origin, cross-path, across query drift, or against
+// different accepted terms.
 const response2 = await fetchWithPayment(url);
 ```
+
+`configureExactHeaderReplay` is the helper in `examples/typescript/clients/payment-identifier/header-replay.ts`. It binds the in-memory header to the configured exact request URL and `acceptedTermsFingerprint` of selected terms (scheme, network, asset, amount, payTo, normalized maxTimeoutSeconds, recursively canonical extra). Do not reuse one helper across origins or paths. The raw header stays in memory only; do not log or persist it. Official TypeScript example: `examples/typescript/clients/payment-identifier`.
 
 </Tab>
 <Tab title="Python">
@@ -101,8 +115,12 @@ from x402.extensions.payment_identifier import (
     append_payment_identifier_to_extensions,
     generate_payment_id,
 )
+from x402.http import x402HTTPClient
 from x402.http.clients import x402HttpxClient
 from x402.schemas import PaymentCreationContext
+from main import configure_exact_header_replay
+
+# configure_exact_header_replay: examples/python/clients/payment-identifier/main.py
 
 client = x402Client()
 # ... register schemes ...
@@ -119,13 +137,24 @@ async def before_payment_creation(context: PaymentCreationContext) -> None:
 
 client.on_before_payment_creation(before_payment_creation)
 
-async with x402HttpxClient(client) as http:
-    # First request - payment is processed
+http_client = x402HTTPClient(client)
+# url is immutable configuration. PaymentCreatedContext has no request URL,
+# so a shared pending_url cannot correlate concurrent 402s. This helper is
+# sequential single-URL scope and fails closed if a non-target 402 arrives
+# before capture.
+configure_exact_header_replay(client, http_client, url)
+
+async with x402HttpxClient(http_client) as http:
+    # First request - payment is processed and the exact encoded header is captured
     response1 = await http.get(url)
 
-    # Retry with same payment ID - cached response returned (no payment)
+    # Retry only the same request URL and selected accepted terms.
+    # Do not replay cross-origin, cross-path, across query drift, or against
+    # different accepted terms.
     response2 = await http.get(url)
 ```
+
+`configure_exact_header_replay` is the helper in `examples/python/clients/payment-identifier/main.py`. It binds the in-memory header to the configured exact request URL and selected accepted terms. Do not reuse one helper across origins or paths. The raw header stays in memory only; do not log or persist it.
 
 </Tab>
 <Tab title="Go">
@@ -181,12 +210,14 @@ client.OnBeforePaymentCreation(func(ctx x402.PaymentCreationContext) (*x402.Befo
     return nil, nil
 })
 
-// First request - payment is processed
-response1, err := client.MakeRequest(url)
-
-// Retry with same payment ID - cached response returned (no payment)
-response2, err := client.MakeRequest(url)
 ```
+
+This Go fragment only injects the logical payment ID. It does not implement an
+HTTP request or safe credential replay. The Go client does not yet include the
+audited immutable-URL, accepted-terms-bound header replay helper shown for
+TypeScript and Python. Until that helper and its adversarial tests exist, use a
+fresh payment credential for each Go request and do not describe a repeated ID
+as a cache hit.
 
 </Tab>
 </Tabs>
@@ -194,9 +225,10 @@ response2, err := client.MakeRequest(url)
 ### Best Practices
 
 1. **Generate payment IDs at the logical request level**, not per retry
-2. **Persist payment IDs** for long-running operations so they survive restarts
+2. **Keep the payment ID and captured exact header together only in the bounded in-memory retry helper.** These examples do not support restart recovery. Persisting a raw payment credential requires a separate encrypted-storage design and threat review; persisting the ID alone creates a fresh credential and conflicts with credential-bound server state.
 3. **Use descriptive prefixes** (e.g., `generatePaymentId("order_")`) to identify payment types
 4. **Don't reuse payment IDs** across different logical requests
+5. **Replay the captured payment header only for the configured exact request URL and selected accepted terms.** Configure one helper per URL. Do not infer capture from a shared pending URL: `PaymentCreatedContext` has no request URL, so concurrent 402s cannot be correlated. A non-target 402 before capture fails closed. Do not replay it cross-origin, cross-path, across query drift, or against a 402 that no longer offers those terms. Do not log or persist the raw header.
 
 ## Quickstart for Sellers (Servers)
 
@@ -249,121 +281,256 @@ declarePaymentIdentifierExtension(true);
 
 Store the HTTP request fingerprint with the payment ID. Hashing the payment payload (or the raw payment header) is not request binding: the same signed payload can be replayed against a different method, path, or body.
 
+Copy the audited helpers from `examples/typescript/servers/payment-identifier/request-binding.ts` (`requestFingerprint`, `consumeReservation`, `releaseIfPending`, `releaseReservation`, `markOutcomeUnknown`, `tryReserve` / `bindPaymentId`). Do not `Map#delete` by payment ID. Consume, release, and mark-unknown require the adapter-derived exact ownership token. `tryReserve` enforces `MAX_PENDING_RESERVATIONS = 1024`.
+
+The official `requestFingerprint` binds HTTP identity, credential digest, normalized `maxTimeoutSeconds` / `max_timeout_seconds`, and recursively canonical `accepted.extra`:
+
 ```typescript
-import { createHash } from "crypto";
+const material = {
+  amount: String(accepted.amount ?? ""),
+  asset: String(accepted.asset ?? ""),
+  bodySha256,
+  credentialSha256,
+  extra: canonicalJson(accepted.extra ?? {}),
+  maxTimeoutSeconds: String(
+    accepted.maxTimeoutSeconds ?? accepted.max_timeout_seconds ?? "",
+  ),
+  method: req.method.toUpperCase(),
+  network: String(accepted.network ?? ""),
+  payTo: String(accepted.payTo ?? accepted.pay_to ?? ""),
+  scheme: String(accepted.scheme ?? ""),
+  url: canonicalRequestUrl(req.originalUrl),
+};
+```
+
+```typescript
 import { extractPaymentIdentifier } from "@x402/extensions/payment-identifier";
+import {
+  consumeReservation,
+  markOutcomeUnknown,
+  markSettlementStarted,
+  MAX_PENDING_RESERVATIONS,
+  releaseIfPending,
+  releaseReservation,
+  requestFingerprint,
+  reservationTokenFromTransportContext,
+  RESERVATION_TTL_MS,
+} from "./request-binding"; // examples/typescript/servers/payment-identifier/request-binding.ts
 
 const idempotencyCache = new Map<
   string,
   { timestamp: number; fingerprint: string; response: unknown }
 >();
-const pendingReservations = new Map<
-  string,
-  { fingerprint: string; timestamp: number }
->();
+// Capacity is MAX_PENDING_RESERVATIONS (1024) via tryReserve / bindPaymentId.
+// Do not Map#set directly; a raw Map is unbounded.
+const pendingReservations = new Map();
 const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour settled cache
-const RESERVATION_TTL_MS = 30 * 1000; // in-flight only; failed verify must expire
-
-function requestFingerprint(
-  req: { method: string; originalUrl: string },
-  body: Buffer,
-  payload: { accepted?: Record<string, string> },
-): string {
-  const url = new URL(req.originalUrl, "http://localhost");
-  url.searchParams.sort();
-  const accepted = payload.accepted ?? {};
-  const material = {
-    method: req.method.toUpperCase(),
-    url: url.pathname + url.search,
-    bodySha256: createHash("sha256").update(body).digest("hex"),
-    scheme: accepted.scheme ?? "",
-    network: accepted.network ?? "",
-    asset: accepted.asset ?? "",
-    amount: accepted.amount ?? "",
-    payTo: accepted.payTo ?? "",
-  };
-  return createHash("sha256").update(JSON.stringify(material)).digest("hex");
-}
 
 const resourceServer = new x402ResourceServer(facilitatorClient)
   .register("eip155:84532", new ExactEvmScheme())
-  .onAfterSettle(async ({ paymentPayload }) => {
+  .onBeforeSettle(async ({ paymentPayload, transportContext }) => {
     const paymentId = extractPaymentIdentifier(paymentPayload);
-    const reserved = paymentId ? pendingReservations.get(paymentId) : undefined;
-    if (!paymentId || !reserved) {
-      return; // missing reservation: do not cache
+    if (!paymentId) {
+      return;
     }
-    pendingReservations.delete(paymentId);
-    if (Date.now() - reserved.timestamp >= RESERVATION_TTL_MS) {
-      return; // expired reservation: do not cache
+    const started = markSettlementStarted(
+      pendingReservations,
+      paymentId,
+      requestFingerprint({
+        method: "GET",
+        url: "/weather",
+        body: Buffer.alloc(0),
+        payload: paymentPayload,
+      }),
+      Date.now(),
+      RESERVATION_TTL_MS,
+      reservationTokenFromTransportContext(transportContext),
+    );
+    if (!started) {
+      return { abort: true, reason: "payment_identifier_reservation_lost" };
+    }
+  })
+  .onAfterSettle(async ({ paymentPayload, result, transportContext }) => {
+    const paymentId = extractPaymentIdentifier(paymentPayload);
+    const token = reservationTokenFromTransportContext(transportContext);
+    const fingerprint = requestFingerprint({
+      method: "GET",
+      url: "/weather",
+      body: Buffer.alloc(0),
+      payload: paymentPayload,
+    });
+    if (!result.success) {
+      // Definitive unsuccessful settle result only. Thrown/timeout/network
+      // errors are outcome-unknown: handle in onSettleFailure, do not release.
+      if (paymentId) {
+        releaseReservation(
+          pendingReservations,
+          paymentId,
+          fingerprint,
+          Date.now(),
+          RESERVATION_TTL_MS,
+          token,
+        );
+      }
+      return;
+    }
+    if (!paymentId) {
+      return;
+    }
+    const reservedFingerprint = consumeReservation(
+      pendingReservations,
+      paymentId,
+      fingerprint,
+      Date.now(),
+      RESERVATION_TTL_MS,
+      token,
+    );
+    if (!reservedFingerprint) {
+      return; // missing, replaced, mismatched, or unknown: do not cache
     }
     idempotencyCache.set(paymentId, {
       timestamp: Date.now(),
-      fingerprint: reserved.fingerprint, // exact reserved fingerprint
+      fingerprint: reservedFingerprint,
       response: {
         /* your response data */
       },
     });
+  })
+  .onSettleFailure(async ({ paymentPayload, transportContext }) => {
+    const paymentId = extractPaymentIdentifier(paymentPayload);
+    if (!paymentId) {
+      return;
+    }
+    markOutcomeUnknown(
+      pendingReservations,
+      paymentId,
+      requestFingerprint({
+        method: "GET",
+        url: "/weather",
+        body: Buffer.alloc(0),
+        payload: paymentPayload,
+      }),
+      Date.now(),
+      RESERVATION_TTL_MS,
+      reservationTokenFromTransportContext(transportContext),
+    );
+  })
+  .onVerifyFailure(async (ctx) => {
+    const paymentId = extractPaymentIdentifier(ctx.paymentPayload);
+    if (!paymentId) {
+      return;
+    }
+    releaseIfPending(
+      pendingReservations,
+      paymentId,
+      requestFingerprint({
+        method: "GET",
+        url: "/weather",
+        body: Buffer.alloc(0),
+        payload: ctx.paymentPayload,
+      }),
+      Date.now(),
+      RESERVATION_TTL_MS,
+      reservationTokenFromTransportContext(ctx.transportContext),
+    );
   });
 ```
+
+`MAX_PENDING_RESERVATIONS` is 1024. This remains an educational example: the bounded map is still susceptible to availability pressure from unauthenticated but syntactically valid payloads.
 
 ### Step 3: Check Cache Before Payment
 
 `onProtectedRequest` can only return `{ grantAccess: true }` (runs the resource handler) or `{ abort: true }` (HTTP 403). It cannot return 409. Check the fingerprint in application middleware **before** payment middleware, and never call `grantAccess` on drift. The official Express example is GET-only and does not install body-parsing middleware, so it hashes an empty body rather than capturing POST bodies:
 
 ```typescript
+import {
+  bindPaymentId,
+  MAX_PENDING_RESERVATIONS,
+  requestFingerprint,
+  RETRY_AFTER_SECONDS,
+} from "./request-binding"; // examples/typescript/servers/payment-identifier/request-binding.ts
+
 app.use((req, res, next) => {
   if (!req.headers["x-payment"] && !req.headers["payment-signature"])
     return next();
+  let paymentPayload;
   try {
     const header = String(
       req.headers["payment-signature"] || req.headers["x-payment"],
     );
-    const paymentPayload = JSON.parse(
+    paymentPayload = JSON.parse(
       Buffer.from(header, "base64").toString("utf-8"),
     );
-    const paymentId = extractPaymentIdentifier(paymentPayload);
-    if (!paymentId) return next();
-
-    // GET-only example: no body-parsing middleware, so the hashed body is empty.
-    const fingerprint = requestFingerprint(
-      req,
-      Buffer.alloc(0),
-      paymentPayload,
-    );
-    const cached = idempotencyCache.get(paymentId);
-    if (cached && Date.now() - cached.timestamp < CACHE_TTL_MS) {
-      if (cached.fingerprint !== fingerprint) {
-        return res.status(409).json({
-          error: "payment identifier already used with different request",
-          paymentId,
-        });
-      }
-      return res.json(cached.response); // same request: skip payment, do not grantAccess
-    }
-    const reserved = pendingReservations.get(paymentId);
-    if (reserved && Date.now() - reserved.timestamp < RESERVATION_TTL_MS) {
-      if (reserved.fingerprint === fingerprint) {
-        return res.status(409).json({
-          error:
-            "payment identifier is already being processed for this request",
-          paymentId,
-        });
-      }
-      return res.status(409).json({
-        error: "payment identifier already used with different request",
-        paymentId,
-      });
-    }
-    pendingReservations.set(paymentId, { fingerprint, timestamp: Date.now() });
   } catch {
-    // Invalid payment header, continue to normal payment flow
+    return next(); // Only malformed header decoding may continue normal flow.
   }
-  next();
+  const paymentId = extractPaymentIdentifier(paymentPayload);
+  if (!paymentId) return next();
+  // Reserve only protected paid routes. /health and unmatched paths must next().
+  if (req.method !== "GET" || req.path !== "/weather") return next();
+
+  let fingerprint;
+  let decision;
+  let cached;
+  let reserved;
+  try {
+    // GET-only example: no body-parsing middleware, so the hashed body is empty.
+    fingerprint = requestFingerprint({
+      method: req.method,
+      url: req.originalUrl || req.url,
+      body: Buffer.alloc(0),
+      payload: paymentPayload,
+    });
+    decision = bindPaymentId({
+      cache: idempotencyCache,
+      reservations: pendingReservations,
+      paymentId,
+      fingerprint,
+      now: Date.now(),
+      cacheTtlMs: CACHE_TTL_MS,
+      reservationTtlMs: RESERVATION_TTL_MS,
+      maxPending: MAX_PENDING_RESERVATIONS, // 1024; fail closed at capacity
+    });
+    if (decision.kind === "hit") {
+      cached = idempotencyCache.get(paymentId);
+      if (!cached) throw new Error("cache hit disappeared");
+    } else if (decision.kind === "miss") {
+      reserved = pendingReservations.get(paymentId);
+      if (!reserved?.token) throw new Error("reservation missing after bind");
+    }
+  } catch {
+    res.setHeader("Retry-After", String(RETRY_AFTER_SECONDS));
+    return res.status(503).json({
+      error: "payment identifier storage unavailable",
+      retryable: true,
+    });
+  }
+
+  if (decision.kind === "conflict") {
+    return res.status(409).json({
+      error: "payment identifier already used with different request",
+      paymentId,
+    });
+  }
+  if (decision.kind === "in_flight" || decision.kind === "capacity") {
+    res.setHeader("Retry-After", String(RETRY_AFTER_SECONDS));
+    return res.status(503).json({
+      error: decision.kind,
+      paymentId,
+      retryable: true,
+    });
+  }
+  if (decision.kind === "hit") {
+    return res.json(cached.response); // same request: skip payment
+  }
+  req.x402ReservationToken = reserved.token;
+  return next();
 });
 
 app.use(paymentMiddlewareFromHTTPServer(httpServer));
 ```
+
+Do not call `pendingReservations.set` directly. `bindPaymentId` / `tryReserve` own the 1024-entry bound. See `examples/typescript/servers/payment-identifier/index.ts` for the full middleware.
 
 </Tab>
 <Tab title="Python">
@@ -414,33 +581,113 @@ declare_payment_identifier_extension(required=True)
 
 Store the HTTP request fingerprint with the payment ID. Do not key the cache on payment ID alone.
 
+Copy the audited helpers from `examples/python/servers/payment-identifier/request_binding.py`. Do not `dict.pop` by payment ID. Consume, release, and mark-unknown require the adapter-derived exact ownership token. `try_reserve` / `bind_payment_id` enforce `MAX_PENDING_RESERVATIONS = 1024`.
+
+`request_fingerprint` binds HTTP identity, credential digest, normalized `maxTimeoutSeconds` / `max_timeout_seconds`, and recursively canonical `accepted.extra`.
+
 ```python
 import time
-from x402.schemas import SettleContext
+from request_binding import (
+    MAX_PENDING_RESERVATIONS,
+    consume_reservation,
+    mark_outcome_unknown,
+    mark_settlement_started,
+    release_if_pending,
+    request_fingerprint,
+    reservation_token_from_transport,
+    reservation_ttl_seconds,
+)
+from x402.schemas import AbortResult, SettleContext
 from x402.extensions.payment_identifier import extract_payment_identifier
 
 idempotency_cache: dict = {}
-pending_reservations: dict[str, dict] = {}
+pending_reservations: dict = {}  # capacity 1024 via bind_payment_id / try_reserve
 CACHE_TTL_SECONDS = 60 * 60  # 1 hour settled cache
-RESERVATION_TTL_SECONDS = 30  # in-flight only; failed verify must expire
+RESERVATION_TTL_SECONDS = 300  # server-owned; do not use client maxTimeoutSeconds
+
+def _hook_reservation_token(ctx):
+    return reservation_token_from_transport(getattr(ctx, "transport_context", None))
+
+async def before_settle(ctx: SettleContext) -> AbortResult | None:
+    payment_id = extract_payment_identifier(ctx.payment_payload)
+    if not payment_id:
+        return None
+    started = mark_settlement_started(
+        pending_reservations,
+        payment_id=payment_id,
+        fingerprint=request_fingerprint(
+            method="GET", url="/weather", body=b"", payload=ctx.payment_payload
+        ),
+        now=time.time(),
+        ttl_seconds=reservation_ttl_seconds(),
+        token=_hook_reservation_token(ctx),
+    )
+    if not started:
+        return AbortResult(reason="payment_identifier_reservation_lost")
+    return None
 
 async def after_settle(ctx: SettleContext) -> None:
     payment_id = extract_payment_identifier(ctx.payment_payload)
-    reserved = pending_reservations.pop(payment_id, None) if payment_id else None
-    if not payment_id or not reserved:
-        return  # missing reservation: do not cache
-    if time.time() - reserved["timestamp"] >= RESERVATION_TTL_SECONDS:
-        return  # expired reservation: do not cache
+    if not payment_id:
+        return
+    fingerprint = consume_reservation(
+        pending_reservations,
+        payment_id=payment_id,
+        fingerprint=request_fingerprint(
+            method="GET", url="/weather", body=b"", payload=ctx.payment_payload
+        ),
+        now=time.time(),
+        ttl_seconds=reservation_ttl_seconds(),
+        token=_hook_reservation_token(ctx),
+    )
+    if not fingerprint:
+        return  # missing, replaced, mismatched, or unknown: do not cache
     idempotency_cache[payment_id] = {
         "timestamp": time.time(),
-        "fingerprint": reserved["fingerprint"],  # exact reserved fingerprint
+        "fingerprint": fingerprint,
         "response": {},  # your response data
     }
 
+async def retain_unknown_on_settle_failure(ctx) -> None:
+    payment_id = extract_payment_identifier(ctx.payment_payload)
+    if not payment_id:
+        return
+    mark_outcome_unknown(
+        pending_reservations,
+        payment_id=payment_id,
+        fingerprint=request_fingerprint(
+            method="GET", url="/weather", body=b"", payload=ctx.payment_payload
+        ),
+        now=time.time(),
+        ttl_seconds=reservation_ttl_seconds(),
+        token=_hook_reservation_token(ctx),
+    )
+
+async def release_pending_reservation(ctx) -> None:
+    payment_id = extract_payment_identifier(ctx.payment_payload)
+    if not payment_id:
+        return
+    release_if_pending(
+        pending_reservations,
+        payment_id=payment_id,
+        fingerprint=request_fingerprint(
+            method="GET", url="/weather", body=b"", payload=ctx.payment_payload
+        ),
+        now=time.time(),
+        ttl_seconds=reservation_ttl_seconds(),
+        token=_hook_reservation_token(ctx),
+    )
+
 server = x402ResourceServer(facilitator)
 server.register("eip155:84532", ExactEvmServerScheme())
+server.on_before_settle(before_settle)
 server.on_after_settle(after_settle)
+server.on_settle_failure(retain_unknown_on_settle_failure)
+server.on_verify_failure(release_pending_reservation)
+server.on_verified_payment_canceled(release_pending_reservation)
 ```
+
+A thrown/timeout/network settlement outcome is indeterminate: transition to the bounded `outcome_unknown` tombstone and do not release. Only a definitive pre-settlement failure may release. Python `on_settle_failure` conflates unsuccessful results and thrown errors, so retaining is safer. `MAX_PENDING_RESERVATIONS` is 1024.
 
 ### Step 3: Check Cache Before Payment
 
@@ -448,8 +695,16 @@ Register payment middleware first, then the idempotency middleware, so the cache
 
 ```python
 import base64
+import binascii
 import json
 from fastapi import Request, Response
+from pydantic import ValidationError
+from request_binding import (
+    MAX_PENDING_RESERVATIONS,
+    RETRY_AFTER_SECONDS,
+    bind_payment_id,
+    request_fingerprint,
+)
 from x402.schemas import PaymentPayload
 
 app.add_middleware(PaymentMiddlewareASGI, routes=routes, server=server)
@@ -457,55 +712,79 @@ app.add_middleware(PaymentMiddlewareASGI, routes=routes, server=server)
 @app.middleware("http")
 async def idempotency_middleware(request: Request, call_next):
     payment_header = request.headers.get("PAYMENT-SIGNATURE") or request.headers.get("X-Payment")
-    if payment_header:
-        try:
-            payment_data = json.loads(base64.b64decode(payment_header))
-            payment_payload = PaymentPayload.model_validate(payment_data)
-            payment_id = extract_payment_identifier(payment_payload)
+    if not payment_header:
+        return await call_next(request)
+    try:
+        payment_data = json.loads(base64.b64decode(payment_header).decode("utf-8"))
+        payment_payload = PaymentPayload.model_validate(payment_data)
+    except (binascii.Error, UnicodeDecodeError, json.JSONDecodeError, ValidationError):
+        return await call_next(request)  # Only malformed header decoding may continue.
 
-            if payment_id:
-                fingerprint = request_fingerprint(
-                    method=request.method,
-                    url=str(request.url),
-                    body=await request.body(),
-                    payload=payment_payload,
-                )
-                cached = idempotency_cache.get(payment_id)
-                if cached and time.time() - cached["timestamp"] < CACHE_TTL_SECONDS:
-                    if cached["fingerprint"] != fingerprint:
-                        return Response(
-                            content=json.dumps({
-                                "error": "payment identifier already used with different request",
-                                "paymentId": payment_id,
-                            }),
-                            media_type="application/json",
-                            status_code=409,
-                        )
-                    return Response(
-                        content=json.dumps(cached["response"]),
-                        media_type="application/json",
-                    )
-                reserved = pending_reservations.get(payment_id)
-                if reserved and time.time() - reserved["timestamp"] < RESERVATION_TTL_SECONDS:
-                    error = (
-                        "payment identifier is already being processed for this request"
-                        if reserved["fingerprint"] == fingerprint
-                        else "payment identifier already used with different request"
-                    )
-                    return Response(
-                        content=json.dumps({"error": error, "paymentId": payment_id}),
-                        media_type="application/json",
-                        status_code=409,
-                    )
-                pending_reservations[payment_id] = {
-                    "fingerprint": fingerprint,
-                    "timestamp": time.time(),
-                }
-        except Exception:
-            pass  # Invalid payment header, continue to normal flow
+    payment_id = extract_payment_identifier(payment_payload)
+    if not payment_id:
+        return await call_next(request)
+    if request.method != "GET" or request.url.path != "/weather":
+        return await call_next(request)
+    try:
+        fingerprint = request_fingerprint(
+            method=request.method,
+            url=str(request.url),
+            body=await request.body(),
+            payload=payment_payload,
+        )
+        decision = bind_payment_id(
+            idempotency_cache,
+            pending_reservations,
+            payment_id=payment_id,
+            fingerprint=fingerprint,
+            now=time.time(),
+            cache_ttl_seconds=CACHE_TTL_SECONDS,
+            reservation_ttl_seconds=RESERVATION_TTL_SECONDS,
+            max_pending=MAX_PENDING_RESERVATIONS,
+        )
+        cached = idempotency_cache[payment_id] if decision.kind == "hit" else None
+        reserved = pending_reservations[payment_id] if decision.kind == "miss" else None
+    except Exception:
+        return Response(
+            content=json.dumps({
+                "error": "payment identifier storage unavailable",
+                "retryable": True,
+            }),
+            media_type="application/json",
+            status_code=503,
+            headers={"Retry-After": str(RETRY_AFTER_SECONDS)},
+        )
 
+    if decision.kind == "conflict":
+        return Response(
+            content=json.dumps({
+                "error": "payment identifier already used with different request",
+                "paymentId": payment_id,
+            }),
+            media_type="application/json",
+            status_code=409,
+        )
+    if decision.kind in ("in_flight", "capacity"):
+        return Response(
+            content=json.dumps({
+                "error": decision.kind,
+                "paymentId": payment_id,
+                "retryable": True,
+            }),
+            media_type="application/json",
+            status_code=503,
+            headers={"Retry-After": str(RETRY_AFTER_SECONDS)},
+        )
+    if decision.kind == "hit":
+        return Response(
+            content=json.dumps(cached["response"]),
+            media_type="application/json",
+        )
+    request.state.x402_reservation_token = reserved.token
     return await call_next(request)
 ```
+
+Do not assign `pending_reservations[payment_id] = ...` directly. `bind_payment_id` / `try_reserve` own the 1024-entry bound. See `examples/python/servers/payment-identifier/main.py` for the full middleware.
 
 </Tab>
 <Tab title="Go">
@@ -543,6 +822,8 @@ routes := x402http.RoutesConfig{
 
 ### Step 2: Extract Payment ID
 
+The Go quickstart below is **not request-bound**. Do not copy it as a security pattern. Follow [Request Binding](#request-binding) and the TypeScript/Python examples: a cache hit requires the HTTP request fingerprint **and** the settled payment credential. ID-only reuse is a conflict.
+
 Use the `ExtractPaymentIdentifier()` utility to get the payment ID from the payload:
 
 ```go
@@ -558,23 +839,26 @@ if err != nil {
     return
 }
 
-// Check for duplicate
-if existingResponse, found := processedPayments[paymentID]; found {
-    // Return cached response
-    c.JSON(200, existingResponse)
+// Not request-bound: do not return a cached 200 from payment ID alone.
+if _, found := processedPayments[paymentID]; found {
+    c.JSON(409, gin.H{
+        "error":     "payment identifier already used; bind to request fingerprint before reuse",
+        "paymentId": paymentID,
+    })
     return
 }
 ```
 
 ### Step 3: Cache Responses
 
-Store responses after successful payment processing:
+Store responses after successful payment processing. Binding the cache by payment ID alone is not sufficient; see [Request Binding](#request-binding).
 
 ```go
 // In-memory cache (use Redis in production)
 var processedPayments = make(map[string]interface{})
 
-// After processing payment
+// After processing payment. A production Go server must also store the
+// request+credential fingerprint from the Request Binding rules.
 processedPayments[paymentID] = responseData
 ```
 
@@ -583,34 +867,49 @@ processedPayments[paymentID] = responseData
 
 ### Request Binding
 
-Servers should bind each payment ID to a normalized fingerprint of the HTTP request before returning a cached result. Hashing the payment payload or `PAYMENT-SIGNATURE` / `X-Payment` header is not sufficient: those values do not change when the same signed payload is sent as a different method, path, query, or body.
+Servers should bind each payment ID to a normalized fingerprint of the HTTP request **and** the settled payment credential before returning a cached result. A payload-only hash is not request binding: the same signed payload can be replayed against a different method, path, query, or body. A request-only hash is also insufficient: a stolen payment ID plus a fabricated `PAYMENT-SIGNATURE` / `X-Payment` credential must not retrieve the cached paid response.
 
-The fingerprint should cover the parts of the request that make the paid operation unique:
+The fingerprint should cover the parts of the paid operation that make it unique:
 
 - `scheme`, `network`, `asset`, `amount`, `payTo`
-- HTTP method and canonical resource path (query keys sorted, duplicate-key order preserved, no fragment)
+- Canonical `maxTimeoutSeconds` / `max_timeout_seconds` and recursively canonical `accepted.extra`
+- HTTP method and canonical resource path (RFC 3986 query encoding, keys stably sorted by decoded key, duplicate-key order preserved, no fragment)
 - Raw request body SHA-256 (the Express example is GET-only and hashes empty bytes; it does not parse POST bodies)
+- SHA-256 of the scheme-specific credential (`payload.payload`, including signature / authorization)
 - Application-level operation or order identifier (when available)
+
+Reserve a payment identifier only for the exact protected paid route(s). Unpaid paths including `/health` and unmatched routes must not create a reservation, even when they carry a syntactically valid payment header.
 
 Store the first observed fingerprint with the payment ID. Later requests with the same ID and the same fingerprint can return the cached response. Later requests with the same ID but a different fingerprint should return `409 Conflict`, not a cached response, a second execution, or `grantAccess: true`.
 
-Before payment middleware, keep an expiring in-flight reservation (fingerprint + timestamp) distinct from the settled cache. A live reservation must never grant access, never start a second settlement, and never be overwritten. Same fingerprint while reserved is an in-flight `409`; a different fingerprint is the request-conflict `409`. If verification fails, drop the reservation after a short TTL (30 seconds in the official examples, not the one-hour cache TTL). `onAfterSettle` must consume only that live reservation and cache its exact fingerprint; if the reservation is missing or expired, do not cache.
+Before payment middleware, keep an expiring in-flight reservation (fingerprint + timestamp + token + state) distinct from the settled cache. A live reservation must never grant access, never start a second settlement, and never be overwritten. Same fingerprint while reserved is retryable HTTP `503`; a different fingerprint is HTTP `409`. At 1024 live entries after expired cleanup, fail closed with retryable `503` and do not enter verify/settle. Consume, release, mark-unknown, and any mutation require the exact reservation token; missing token is never fingerprint-only ownership.
 
-When the same backend handles multiple paid resources, scope the storage key by tenant, merchant, route, or facilitator account to avoid cross-resource collisions.
+Register `onBeforeSettle` to mark settlement started, refresh the server-owned phase clock, and abort before the facilitator when the exact token no longer owns the reservation. Never ignore a failed ownership transition. Pre-settlement rejection (verify failure, no matching requirement, extension rejection, verified-payment cancel) must release **only that tokenized pending** reservation. Once settlement has begun, a thrown timeout/network/facilitator error is outcome-unknown: retain a tokenized tombstone until the server-owned 300s TTL expires so a fresh credential cannot settle under that ID. Release a settling reservation only for a returned definitive unsuccessful settle result where the SDK distinguishes it. Python `on_settle_failure` conflates unsuccessful results and thrown errors, so retaining is safer there. A settle failure is not immediately safe to retry.
+
+Reservation lifetime is server policy, never client `accepted.maxTimeoutSeconds`. That field is still fingerprinted. An exact still-current token may enter settlement or finalize after its prior phase deadline only when cleanup has not replaced it. `onAfterSettle` must consume only that matching current reservation and cache its exact fingerprint; missing, replaced, mismatched, or unknown ownership must not cache.
+
+When the same backend handles multiple paid resources, scope the storage key by tenant, merchant, route, or facilitator account to avoid cross-resource collisions. These official examples remain educational. The 1024-entry bounded map is still susceptible to availability pressure from unauthenticated but syntactically valid payloads; it is not a production idempotency library.
 
 ### Idempotency Behavior
 
-| Scenario                                                     | Server Response                             |
-| ------------------------------------------------------------ | ------------------------------------------- |
-| New payment ID                                               | Reserve, process payment, cache on settle   |
-| Same payment ID, same request fingerprint (within cache TTL) | Return cached response, skip payment        |
-| Same payment ID, same fingerprint, live reservation          | 409 in-flight conflict, do not settle again |
-| Same payment ID, different request fingerprint               | Return 409 Conflict; do not overwrite       |
-| Same payment ID (after cache TTL)                            | Process payment normally, update cache      |
-| Reservation expired (failed verification)                    | Drop reservation; ID can proceed again      |
-| Settle with missing/expired reservation                      | Do not cache                                |
-| No payment ID                                                | Process payment normally (no caching)       |
-| `required: true`, no payment ID provided                     | Return 400 Bad Request                      |
+| Scenario                                                                      | Server Response                                                                |
+| ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| New payment ID                                                                | Reserve, process payment, cache on settle                                      |
+| Same payment ID, same request+credential fingerprint (within cache TTL)       | Return cached response, skip payment                                           |
+| Same payment ID, same fingerprint, live reservation                           | 503 retryable in-flight; do not settle again                                   |
+| Same payment ID, different request or credential fingerprint                  | Return 409 Conflict; do not overwrite                                          |
+| Pending map at 1024 live entries                                              | 503 retryable capacity; do not overwrite; do not verify/settle                 |
+| Same payment ID (after cache TTL)                                             | Process payment normally, update cache                                         |
+| Pre-settlement reject (verify, no matching requirement, extension, cancel)    | Release matching pending tokenized reservation                                 |
+| Thrown settle timeout/network/facilitator error                               | Outcome-unknown tombstone until 300s server TTL; not safe to retry immediately |
+| Definitive unsuccessful settle result (TypeScript `result.success === false`) | Release matching reservation                                                   |
+| Reservation expired (stale-work recovery)                                     | Drop reservation; ID can proceed again                                         |
+| Stale failure/settle after a replacement reservation                          | Do not delete or consume the replacement (token required)                      |
+| Before-settle with missing/replaced/mismatched/unknown reservation            | Abort before facilitator settlement                                            |
+| Exact current-token settle callback after its prior phase deadline            | Cache only if cleanup has not replaced it                                      |
+| Valid payment header on `/health` or an unmatched path                        | No reservation; paid route is not blocked                                      |
+| No payment ID                                                                 | Process payment normally (no caching)                                          |
+| `required: true`, no payment ID provided                                      | Return 400 Bad Request                                                         |
 
 ### Configuration Options
 
@@ -621,15 +920,16 @@ Adjust `CACHE_TTL_MS` (TypeScript/Go) or `CACHE_TTL_SECONDS` (Python) based on y
 - Short TTL (5-15 min): For time-sensitive resources
 - Long TTL (1-24 hours): For static or infrequently changing resources
 
-Keep a separate in-flight reservation TTL (`RESERVATION_TTL_MS` / `RESERVATION_TTL_SECONDS`). The official examples use 30 seconds, not the one-hour settled cache TTL, so a failed verification cannot leak memory or block the payment ID.
+Keep a separate in-flight reservation TTL (`RESERVATION_TTL_MS` / `RESERVATION_TTL_SECONDS`) as a stale-work and outcome-unknown expiry bound. The official examples use one server-owned 300 second TTL and ignore client `maxTimeoutSeconds` for map lifetime. Entering settlement and entering outcome-unknown each refresh that server-owned phase clock. An exact current token may finalize after its deadline only when cleanup has not replaced it; a stale token cannot consume a replacement. The pending map is bounded at 1024 entries via `tryReserve` / `try_reserve`; do not insert into the map directly. Failed verification must release the matching pending reservation via lifecycle hooks. A thrown/timeout/network settle outcome must become `outcome_unknown` and must not release. HTTP `409` is a fingerprint conflict; HTTP `503` is retryable in-flight or capacity. This remains an educational example: unauthenticated but syntactically valid payloads can still fill the bounded map.
 
 ### Production Considerations
 
 1. **Use Redis or similar** instead of in-memory cache for distributed systems
-2. **Handle cache failures gracefully** - if cache is unavailable, process payment normally
-3. **Bind payment IDs to request fingerprints** - store the fingerprint (scheme, network, asset, amount, payTo, HTTP method, canonical path, raw body SHA-256, and application operation ID) alongside the payment ID and return `409 Conflict` if the same ID is replayed with a different fingerprint. Do not fingerprint only the payment payload. The official Express example is GET-only and hashes an empty body; do not assume it captures POST bodies.
-4. **Reserve in-flight IDs** so two concurrent misses cannot bind the first settlement to the second request. Expire reservations on a short TTL.
-5. **Monitor cache hit rates** to tune TTL and detect abuse
+2. **Fail closed when idempotency storage is unavailable** - return retryable HTTP 503 and do not verify or settle. Bypassing idempotency requires a separate merchant policy that does not claim duplicate-settlement protection.
+3. **Bind payment IDs to request and credential fingerprints** - store the fingerprint (scheme, network, asset, amount, payTo, maxTimeoutSeconds, canonical extra, HTTP method, RFC 3986 canonical path, raw body SHA-256, credential SHA-256, and application operation ID) alongside the payment ID and return `409 Conflict` if the same ID is replayed with a different fingerprint. Do not fingerprint only the payment payload, and do not fingerprint only the HTTP request. The official Express example is GET-only and hashes an empty body; do not assume it captures POST bodies.
+4. **Reserve in-flight IDs only on protected paid routes** so two concurrent misses cannot bind the first settlement to the second request. Require the exact reservation token for consume/release/mark-unknown. Release pending reservations only on definitive pre-settlement rejection or a returned definitive unsuccessful settle result. Thrown/timeout/network settle errors keep an `outcome_unknown` tombstone for the server-owned 300s TTL and must not release. Bound the in-memory map through `tryReserve` / `try_reserve` and fail closed at capacity. Unauthenticated but syntactically valid payloads can still fill those 1024 entries.
+5. **Replay the exact encoded payment header** on retry only when the later 402 is for the configured exact request URL and the same selected accepted payment terms. Configure one helper per URL. Do not infer capture from a shared pending URL. A non-target 402 before capture fails closed. Never replay cross-origin, cross-path, across query drift, or against different accepted terms. Do not log or persist the raw header.
+6. **Monitor cache hit rates** to tune TTL and detect abuse. These official examples remain educational single-process GET-only samples, not a production idempotency library.
 
 ## API Reference
 
@@ -956,14 +1256,10 @@ Full working examples are available in the x402 repository:
 
 ## FAQ
 
-**Q: What happens if I reuse a payment ID for a different request?**
-A: If the request fingerprint differs from the original (different scheme, network, asset, amount, route, etc.), the server should return `409 Conflict`. Don't reuse payment IDs across different logical requests.
+**Q: What happens if I reuse a payment ID for a different request?** A: If the request fingerprint differs from the original (different scheme, network, asset, amount, route, etc.), the server should return `409 Conflict`. Don't reuse payment IDs across different logical requests.
 
-**Q: How long are payment IDs cached?**
-A: This is configurable by the server. Typical TTLs range from 5 minutes to 24 hours depending on the use case.
+**Q: How long are payment IDs cached?** A: This is configurable by the server. Typical TTLs range from 5 minutes to 24 hours depending on the use case.
 
-**Q: Can I use custom payment ID formats?**
-A: Payment IDs must be 16-128 characters, alphanumeric with hyphens and underscores allowed. Use `isValidPaymentId()` to validate custom IDs.
+**Q: Can I use custom payment ID formats?** A: Payment IDs must be 16-128 characters, alphanumeric with hyphens and underscores allowed. Use `isValidPaymentId()` to validate custom IDs.
 
-**Q: What if the server doesn't support payment-identifier?**
-A: The extension is optional. If the server doesn't advertise support, clients can still make payments normally without idempotency.
+**Q: What if the server doesn't support payment-identifier?** A: The extension is optional. If the server doesn't advertise support, clients can still make payments normally without idempotency.

--- a/examples/python/clients/payment-identifier/README.md
+++ b/examples/python/clients/payment-identifier/README.md
@@ -7,7 +7,7 @@ Example client demonstrating how to use the `payment-identifier` extension to en
 1. Client generates a unique payment ID using `generate_payment_id()`
 2. Client includes the payment ID in the `PaymentPayload` using `append_payment_identifier_to_extensions()`
 3. Server caches responses keyed by payment ID
-4. Retry requests with the same payment ID return cached responses without re-processing payment
+4. The client captures the first encoded `PAYMENT-SIGNATURE` header and replays it only for one configured exact request URL and selected accepted payment terms. The target URL is immutable helper configuration. It does not infer capture from a shared pending URL, and it does not replay cross-origin, cross-path, or against different accepted terms.
 
 ```python
 from x402 import x402Client
@@ -15,7 +15,9 @@ from x402.extensions.payment_identifier import (
     append_payment_identifier_to_extensions,
     generate_payment_id,
 )
+from x402.http import x402HTTPClient
 from x402.http.clients import x402HttpxClient
+from main import configure_exact_header_replay  # hashes terms, not the header
 
 client = x402Client()
 # ... register schemes ...
@@ -31,13 +33,23 @@ async def before_payment_creation(context):
 
 client.on_before_payment_creation(before_payment_creation)
 
-async with x402HttpxClient(client) as http:
-    # First request - payment is processed
+http_client = x402HTTPClient(client)
+# url is immutable configuration. PaymentCreatedContext has no request URL,
+# so a shared pending_url cannot correlate concurrent 402s. This helper is
+# sequential single-URL scope and fails closed if a non-target 402 arrives
+# before capture.
+configure_exact_header_replay(client, http_client, url)
+
+async with x402HttpxClient(http_client) as http:
+    # First request - payment is processed and the exact encoded header is captured
     response1 = await http.get(url)
 
-    # Retry with same payment ID - cached response returned (no payment)
+    # Retry the same URL and selected terms. Do not create a new signature.
+    # Do not replay against another origin, path, or accepted-terms set.
     response2 = await http.get(url)
 ```
+
+`configure_exact_header_replay` is the helper in `main.py`. It binds the in-memory header to the configured exact request URL and `accepted_terms_fingerprint` of selected terms (scheme, network, asset, amount, payTo, maxTimeoutSeconds, extra). Do not reuse one helper across origins or paths. The raw header stays in memory only; do not log or persist it.
 
 ## Prerequisites
 
@@ -96,7 +108,7 @@ Second Request (SAME payment ID: pay_7d5d747be160e280504c099d984bcfe0)
 ====================================================
 Making request to: http://localhost:4022/weather
 
-Expected: Server returns cached response without payment processing
+Expected: replay exact payment header; cached response, no new signature
 
 Response (45ms): {"report": {"weather": "sunny", "temperature": 70, "cached": true}}
 
@@ -114,13 +126,14 @@ Summary
 ## Use Cases
 
 - **Network failures**: Safely retry failed requests without duplicate payments
-- **Client crashes**: Resume requests after restart using persisted payment IDs
+- **Bounded same-process retries**: Reuse the captured exact header without creating a second payment credential
 - **Load balancing**: Same request can hit different servers with shared cache
 - **Testing**: Replay requests during development without spending funds
 
 ## Best Practices
 
 1. **Generate payment IDs at the logical request level**, not per retry
-2. **Persist payment IDs** for long-running operations so they survive restarts
+2. **Keep the payment ID and captured exact header together only in the bounded in-memory retry helper.** This example does not support restart recovery. Persisting a raw payment credential requires a separate encrypted-storage design and threat review; persisting the ID alone creates a fresh credential and conflicts with credential-bound server state.
 3. **Use descriptive prefixes** (e.g., `order_`, `sub_`) to identify payment types
 4. **Don't reuse payment IDs** across different logical requests
+5. **Replay the exact encoded payment header only for the configured exact request URL and selected accepted terms.** Configure one helper per URL. Do not infer capture from a shared pending URL. Do not reuse it cross-origin, cross-path, or against a 402 that no longer offers those terms. A non-target 402 before capture fails closed. Do not log or persist the raw header.

--- a/examples/python/clients/payment-identifier/main.py
+++ b/examples/python/clients/payment-identifier/main.py
@@ -5,21 +5,28 @@ when making payments. This allows safe retries without duplicate payments.
 
 This example:
 1. Makes a request with a unique payment ID
-2. Makes a second request with the SAME payment ID
-3. The second request returns from cache without payment processing
+2. Captures the first exact encoded payment header
+3. Replays that header on a later 402 only for the configured exact request URL
+   and selected accepted terms. The helper is sequential single-URL scope.
+4. The second request returns from cache without payment processing
 
 Required environment variables:
 - EVM_PRIVATE_KEY: The private key of the EVM signer
 """
 
+from __future__ import annotations
+
 import asyncio
+import hashlib
+import json
 import os
 import sys
 import time
+from collections.abc import Awaitable, Callable, Mapping
+from typing import Any
 
 from dotenv import load_dotenv
 from eth_account import Account
-
 from x402 import x402Client
 from x402.extensions.payment_identifier import (
     append_payment_identifier_to_extensions,
@@ -29,9 +36,120 @@ from x402.http import x402HTTPClient
 from x402.http.clients import x402HttpxClient
 from x402.mechanisms.evm import EthAccountSigner
 from x402.mechanisms.evm.exact.register import register_exact_evm_client
-from x402.schemas import PaymentCreationContext
+from x402.schemas import (
+    PaymentCreatedContext,
+    PaymentCreationContext,
+    PaymentRequiredContext,
+    PaymentRequiredHeadersResult,
+)
 
 load_dotenv()
+
+
+def _requirements_mapping(value: Any) -> Mapping[str, Any]:
+    if value is None:
+        return {}
+    if isinstance(value, Mapping):
+        return value
+    dump = getattr(value, "model_dump", None)
+    if callable(dump):
+        dumped = dump(by_alias=True)
+        if isinstance(dumped, Mapping):
+            return dumped
+    return {}
+
+
+def accepted_terms_fingerprint(requirements: Any) -> str:
+    """Deterministic fingerprint of selected accepted payment terms.
+
+    Covers scheme, network, asset, amount, payTo, maxTimeoutSeconds, and
+    recursively canonical extra. Used only as a replay-context key.
+    """
+    terms = _requirements_mapping(requirements)
+    extra = terms.get("extra")
+    timeout = terms.get("maxTimeoutSeconds", terms.get("max_timeout_seconds"))
+    material = {
+        "amount": str(terms.get("amount") or ""),
+        "asset": str(terms.get("asset") or ""),
+        "extra": json.dumps(
+            extra if extra is not None else {},
+            separators=(",", ":"),
+            sort_keys=True,
+            ensure_ascii=False,
+        ),
+        "maxTimeoutSeconds": "" if timeout is None else str(timeout),
+        "network": str(terms.get("network") or ""),
+        "payTo": str(terms.get("payTo") or terms.get("pay_to") or ""),
+        "scheme": str(terms.get("scheme") or ""),
+    }
+    canonical = json.dumps(
+        material, separators=(",", ":"), sort_keys=True, ensure_ascii=False
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _accepts_include_terms(payment_required: Any, terms: str) -> bool:
+    accepts = getattr(payment_required, "accepts", None) or []
+    return any(accepted_terms_fingerprint(item) == terms for item in accepts)
+
+
+def configure_exact_header_replay(
+    client: x402Client, http_client: x402HTTPClient, target_url: str
+) -> tuple[
+    dict[str, object],
+    Callable[[PaymentCreatedContext], Awaitable[None]],
+]:
+    """Capture the first encoded payment header for one exact target URL.
+
+    ``target_url`` is immutable configuration. PaymentCreatedContext has no
+    request URL, so a shared mutable pending_url cannot correlate concurrent
+    402s. This helper is an educational sequential-retry client for that one
+    URL. A 402 for any other origin, path, or query before capture poisons
+    capture (fail closed): the credential is not stored and is not replayed.
+    Replay still requires an exact URL string match and matching selected
+    accepted terms. Never replays cross-origin, cross-path, or against
+    different accepted terms. Does not print or persist the header.
+    """
+    captured: dict[str, object] = {"url": target_url}
+    saw_target_required = False
+    saw_foreign_required = False
+
+    async def after_payment_creation(context: PaymentCreatedContext) -> None:
+        if (
+            captured.get("headers")
+            or not target_url
+            or not saw_target_required
+            or saw_foreign_required
+        ):
+            return
+        captured["headers"] = dict(
+            http_client.encode_payment_signature_header(context.payment_payload)
+        )
+        captured["terms"] = accepted_terms_fingerprint(context.selected_requirements)
+
+    async def on_payment_required(
+        context: PaymentRequiredContext,
+    ) -> PaymentRequiredHeadersResult | None:
+        nonlocal saw_target_required, saw_foreign_required
+        headers = captured.get("headers")
+        if context.request_url != target_url:
+            if not isinstance(headers, dict) or not headers:
+                saw_foreign_required = True
+            return None
+        if isinstance(headers, dict) and headers:
+            terms = captured.get("terms")
+            if not isinstance(terms, str) or not _accepts_include_terms(
+                context.payment_required, terms
+            ):
+                return None
+            return PaymentRequiredHeadersResult(headers=headers)
+        if target_url:
+            saw_target_required = True
+        return None
+
+    client.on_after_payment_creation(after_payment_creation)
+    http_client.on_payment_required(on_payment_required)
+    return captured, after_payment_creation
 
 
 async def main() -> None:
@@ -65,8 +183,8 @@ async def main() -> None:
 
     client.on_before_payment_creation(before_payment_creation)
 
-    # Create HTTP client helper for payment response extraction
     http_client = x402HTTPClient(client)
+    configure_exact_header_replay(client, http_client, url)
 
     # First request - will process payment
     print("\n" + "=" * 52)
@@ -74,7 +192,7 @@ async def main() -> None:
     print("=" * 52)
     print(f"Making request to: {url}\n")
 
-    async with x402HttpxClient(client) as http:
+    async with x402HttpxClient(http_client) as http:
         start_time1 = time.time()
         response1 = await http.get(url)
         await response1.aread()
@@ -87,16 +205,18 @@ async def main() -> None:
             settle_response = http_client.get_payment_settle_response(
                 lambda name: response1.headers.get(name)
             )
-            print(f"\nPayment response: {settle_response.model_dump_json(indent=2)}")
+            print(f"\nPayment settled on {settle_response.network}")
         except ValueError:
             pass
 
-        # Second request - same payment ID, should return from cache
+        # Second request - same payment ID, replay the exact encoded header
         print("\n" + "=" * 52)
         print(f"Second Request (SAME payment ID: {payment_id})")
         print("=" * 52)
         print(f"Making request to: {url}\n")
-        print("Expected: Server returns cached response without payment processing\n")
+        print(
+            "Expected: replay exact payment header; cached response, no new signature\n"
+        )
 
         start_time2 = time.time()
         response2 = await http.get(url)
@@ -109,7 +229,7 @@ async def main() -> None:
             settle_response = http_client.get_payment_settle_response(
                 lambda name: response2.headers.get(name)
             )
-            print(f"\nPayment response: {settle_response.model_dump_json(indent=2)}")
+            print(f"\nPayment settled on {settle_response.network}")
         except ValueError:
             print("\nNo payment processed - response served from cache!")
 

--- a/examples/python/clients/payment-identifier/test_header_replay.py
+++ b/examples/python/clients/payment-identifier/test_header_replay.py
@@ -1,0 +1,224 @@
+"""Exact encoded payment-header replay for the payment-identifier client.
+
+Replay is bound to the exact request URL and selected accepted terms.
+No live server, wallet print, or raw header dump.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import unittest
+
+from x402 import x402Client
+from x402.http import x402HTTPClient
+from x402.schemas import (
+    PaymentCreatedContext,
+    PaymentPayload,
+    PaymentRequired,
+    PaymentRequirements,
+)
+
+from main import configure_exact_header_replay
+
+REQUIREMENTS = PaymentRequirements(
+    scheme="exact",
+    network="eip155:84532",
+    asset="0x0000000000000000000000000000000000000001",
+    amount="1000",
+    pay_to="0x0000000000000000000000000000000000000002",
+    max_timeout_seconds=300,
+)
+OTHER_REQUIREMENTS = PaymentRequirements(
+    scheme="exact",
+    network="eip155:84532",
+    asset="0x0000000000000000000000000000000000000001",
+    amount="9999",
+    pay_to="0x0000000000000000000000000000000000000002",
+    max_timeout_seconds=300,
+)
+PAYMENT_REQUIRED = PaymentRequired(accepts=[REQUIREMENTS])
+OTHER_PAYMENT_REQUIRED = PaymentRequired(accepts=[OTHER_REQUIREMENTS])
+PAYLOAD = PaymentPayload(
+    x402_version=2,
+    payload={"signature": "0xsig"},
+    accepted=REQUIREMENTS,
+)
+PAYLOAD_A = PaymentPayload(
+    x402_version=2,
+    payload={"signature": "0xsig-A"},
+    accepted=REQUIREMENTS,
+)
+PAYLOAD_B = PaymentPayload(
+    x402_version=2,
+    payload={"signature": "0xsig-B"},
+    accepted=REQUIREMENTS,
+)
+
+WEATHER = "http://localhost:4022/weather"
+WEATHER_QUERY = "http://localhost:4022/weather?x=1"
+FORECAST = "http://localhost:4022/forecast"
+EVIL_ORIGIN = "http://evil.example/weather"
+
+
+def _digest(headers: dict[str, str] | None) -> str:
+    if not headers:
+        return ""
+    value = next(iter(headers.values()))
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+class ExactHeaderReplay(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        self.client = x402Client()
+        self.http_client = x402HTTPClient(self.client)
+        self.captured, self.after_payment_creation = configure_exact_header_replay(
+            self.client, self.http_client, WEATHER
+        )
+
+    async def _capture(self) -> None:
+        before = await self.http_client.handle_payment_required(
+            PAYMENT_REQUIRED, WEATHER
+        )
+        self.assertIsNone(before)
+        await self.after_payment_creation(
+            PaymentCreatedContext(
+                payment_required=PAYMENT_REQUIRED,
+                selected_requirements=REQUIREMENTS,
+                payment_payload=PAYLOAD,
+            )
+        )
+
+    async def test_second_402_replays_the_first_encoded_header(self) -> None:
+        await self._capture()
+        self.assertIn("headers", self.captured)
+        first = self.captured["headers"]
+        self.assertIsInstance(first, dict)
+        replayed = await self.http_client.handle_payment_required(
+            PAYMENT_REQUIRED, WEATHER
+        )
+        self.assertIsNotNone(replayed)
+        first_headers = first
+        replayed_headers = replayed or {}
+        self.assertEqual(list(first_headers), list(replayed_headers))
+        self.assertEqual(_digest(first_headers), _digest(replayed_headers))
+        first_value = next(iter(first_headers.values()))
+        self.assertGreater(len(first_value), 16)
+
+    async def test_replay_rejects_a_different_url(self) -> None:
+        await self._capture()
+        replayed = await self.http_client.handle_payment_required(
+            PAYMENT_REQUIRED, WEATHER_QUERY
+        )
+        self.assertIsNone(replayed)
+
+    async def test_replay_rejects_a_different_origin(self) -> None:
+        await self._capture()
+        replayed = await self.http_client.handle_payment_required(
+            PAYMENT_REQUIRED, EVIL_ORIGIN
+        )
+        self.assertIsNone(replayed)
+
+    async def test_replay_rejects_a_different_path(self) -> None:
+        await self._capture()
+        replayed = await self.http_client.handle_payment_required(
+            PAYMENT_REQUIRED, FORECAST
+        )
+        self.assertIsNone(replayed)
+
+    async def test_replay_rejects_different_accepted_terms(self) -> None:
+        await self._capture()
+        replayed = await self.http_client.handle_payment_required(
+            OTHER_PAYMENT_REQUIRED, WEATHER
+        )
+        self.assertIsNone(replayed)
+        same = await self.http_client.handle_payment_required(PAYMENT_REQUIRED, WEATHER)
+        self.assertIsNotNone(same)
+        self.assertEqual(_digest(self.captured["headers"]), _digest(same))
+
+    async def test_interleaved_foreign_402_does_not_bind_capture_to_b(self) -> None:
+        before_a = await self.http_client.handle_payment_required(
+            PAYMENT_REQUIRED, WEATHER
+        )
+        before_b = await self.http_client.handle_payment_required(
+            PAYMENT_REQUIRED, EVIL_ORIGIN
+        )
+        self.assertIsNone(before_a)
+        self.assertIsNone(before_b)
+        await self.after_payment_creation(
+            PaymentCreatedContext(
+                payment_required=PAYMENT_REQUIRED,
+                selected_requirements=REQUIREMENTS,
+                payment_payload=PAYLOAD_A,
+            )
+        )
+        replayed_b = await self.http_client.handle_payment_required(
+            PAYMENT_REQUIRED, EVIL_ORIGIN
+        )
+        replayed_a = await self.http_client.handle_payment_required(
+            PAYMENT_REQUIRED, WEATHER
+        )
+        self.assertIsNone(replayed_b)
+        self.assertIsNone(replayed_a)
+        self.assertEqual(self.captured.get("url"), WEATHER)
+        self.assertFalse(self.captured.get("headers"))
+
+    async def test_reverse_interleave_does_not_bind_b_credential_to_a(self) -> None:
+        before_b = await self.http_client.handle_payment_required(
+            PAYMENT_REQUIRED, FORECAST
+        )
+        before_a = await self.http_client.handle_payment_required(
+            PAYMENT_REQUIRED, WEATHER
+        )
+        self.assertIsNone(before_b)
+        self.assertIsNone(before_a)
+        await self.after_payment_creation(
+            PaymentCreatedContext(
+                payment_required=PAYMENT_REQUIRED,
+                selected_requirements=REQUIREMENTS,
+                payment_payload=PAYLOAD_B,
+            )
+        )
+        replayed_a = await self.http_client.handle_payment_required(
+            PAYMENT_REQUIRED, WEATHER
+        )
+        replayed_b = await self.http_client.handle_payment_required(
+            PAYMENT_REQUIRED, FORECAST
+        )
+        self.assertIsNone(replayed_a)
+        self.assertIsNone(replayed_b)
+        self.assertEqual(self.captured.get("url"), WEATHER)
+        self.assertFalse(self.captured.get("headers"))
+
+    async def test_sequential_capture_survives_a_later_foreign_402(self) -> None:
+        await self._capture()
+        foreign = await self.http_client.handle_payment_required(
+            PAYMENT_REQUIRED, EVIL_ORIGIN
+        )
+        self.assertIsNone(foreign)
+        same = await self.http_client.handle_payment_required(PAYMENT_REQUIRED, WEATHER)
+        self.assertIsNotNone(same)
+        self.assertEqual(_digest(self.captured["headers"]), _digest(same))
+        self.assertEqual(self.captured.get("url"), WEATHER)
+
+    async def test_empty_target_url_fails_closed(self) -> None:
+        client = x402Client()
+        http_client = x402HTTPClient(client)
+        captured, after_payment_creation = configure_exact_header_replay(
+            client, http_client, ""
+        )
+        before = await http_client.handle_payment_required(PAYMENT_REQUIRED, WEATHER)
+        self.assertIsNone(before)
+        await after_payment_creation(
+            PaymentCreatedContext(
+                payment_required=PAYMENT_REQUIRED,
+                selected_requirements=REQUIREMENTS,
+                payment_payload=PAYLOAD,
+            )
+        )
+        replayed = await http_client.handle_payment_required(PAYMENT_REQUIRED, WEATHER)
+        self.assertIsNone(replayed)
+        self.assertFalse(captured.get("headers"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/python/servers/payment-identifier/README.md
+++ b/examples/python/servers/payment-identifier/README.md
@@ -6,13 +6,24 @@ Example server demonstrating how to implement the `payment-identifier` extension
 
 1. Server advertises `payment-identifier` extension support in PaymentRequired responses
 2. Server extracts payment ID from incoming PaymentPayload using `extract_payment_identifier()`
-3. Before payment middleware, the server looks up the settled cache, then holds an expiring in-flight reservation (fingerprint + timestamp, 30s TTL, distinct from the 1-hour cache)
-4. After settlement, `on_after_settle` consumes only that live reservation and caches its exact fingerprint
-5. Same payment ID and same fingerprint return the cached response without payment processing
-6. Same payment ID with a different method, path, query, or body returns HTTP 409 and does not grant access
-7. A second in-flight request never overwrites a live reservation; same fingerprint is an in-flight 409, a different fingerprint is the request-conflict 409
+3. Before payment middleware, the server looks up the settled cache, then holds an expiring in-flight reservation (fingerprint + timestamp + token + state). TTL is a server-owned 300s, not client `maxTimeoutSeconds`. The pending map is bounded at 1024 entries. Only `GET /weather` is reserved.
+4. After settlement, `on_after_settle` consumes only the matching reservation and caches its exact fingerprint
+5. Same payment ID and same request+credential fingerprint return the cached response without payment processing
+6. Same payment ID with a different method, path, query, body, extra, timeout, or payment credential returns HTTP 409 and does not grant access
+7. A second in-flight request never overwrites a live reservation; in-flight and capacity are HTTP 503 retryable
+8. `on_before_settle` aborts before the facilitator if the exact token no longer owns the reservation. Pre-settlement rejection releases the matching pending reservation. A thrown, timed-out, or network settlement outcome is indeterminate: mark a tokenized `outcome_unknown` tombstone and do not release. Python `on_settle_failure` retains because it conflates unsuccessful results and thrown errors. Only a definitive pre-settlement failure may release. A settle failure is not immediately safe to retry. This educational example's 1024-entry map is still susceptible to availability pressure from unauthenticated but syntactically valid payloads.
 
 ```python
+from request_binding import (
+    consume_reservation,
+    mark_settlement_started,
+    mark_outcome_unknown,
+    release_if_pending,
+    request_fingerprint,
+    reservation_token_from_transport,
+    reservation_ttl_seconds,
+)
+from x402.schemas import AbortResult
 from x402.extensions.payment_identifier import (
     PAYMENT_IDENTIFIER,
     declare_payment_identifier_extension,
@@ -32,19 +43,80 @@ routes = {
     ),
 }
 
-# Consume the live reservation after settlement; do not cache if missing or expired
+def _hook_reservation_token(ctx):
+    return reservation_token_from_transport(getattr(ctx, "transport_context", None))
+
+def _hook_fingerprint(ctx):
+    return request_fingerprint(
+        method="GET", url="/weather", body=b"", payload=ctx.payment_payload
+    )
+
+async def before_settle(ctx):
+    payment_id = extract_payment_identifier(ctx.payment_payload)
+    if not payment_id:
+        return None
+    started = mark_settlement_started(
+        pending_reservations,
+        payment_id=payment_id,
+        fingerprint=_hook_fingerprint(ctx),
+        now=time.time(),
+        ttl_seconds=reservation_ttl_seconds(),
+        token=_hook_reservation_token(ctx),
+    )
+    if not started:
+        return AbortResult(reason="payment_identifier_reservation_lost")
+    return None
+
+# Consume only the exact owned reservation after settlement.
 async def after_settle(ctx):
     payment_id = extract_payment_identifier(ctx.payment_payload)
-    fingerprint = (
-        consume_reservation(pending_reservations, payment_id=payment_id, now=time.time(), ttl_seconds=30)
-        if payment_id
-        else None
+    if not payment_id:
+        return
+    fingerprint = consume_reservation(
+        pending_reservations,
+        payment_id=payment_id,
+        fingerprint=_hook_fingerprint(ctx),
+        now=time.time(),
+        ttl_seconds=reservation_ttl_seconds(),
+        token=_hook_reservation_token(ctx),
     )
-    if payment_id and fingerprint:
+    if fingerprint:
         idempotency_cache[payment_id] = cached_response
 
+async def retain_unknown_on_settle_failure(ctx):
+    payment_id = extract_payment_identifier(ctx.payment_payload)
+    if not payment_id:
+        return
+    mark_outcome_unknown(
+        pending_reservations,
+        payment_id=payment_id,
+        fingerprint=_hook_fingerprint(ctx),
+        now=time.time(),
+        ttl_seconds=reservation_ttl_seconds(),
+        token=_hook_reservation_token(ctx),
+    )
+
+async def release_pending_reservation(ctx):
+    payment_id = extract_payment_identifier(ctx.payment_payload)
+    if not payment_id:
+        return
+    release_if_pending(
+        pending_reservations,
+        payment_id=payment_id,
+        fingerprint=_hook_fingerprint(ctx),
+        now=time.time(),
+        ttl_seconds=reservation_ttl_seconds(),
+        token=_hook_reservation_token(ctx),
+    )
+
+server.on_before_settle(before_settle)
 server.on_after_settle(after_settle)
+server.on_verify_failure(release_pending_reservation)
+server.on_settle_failure(retain_unknown_on_settle_failure)
+server.on_verified_payment_canceled(release_pending_reservation)
 ```
+
+Copy the audited helpers from `request_binding.py` rather than inlining `dict.pop`. `try_reserve` / `bind_payment_id` enforce the 1024-entry bound. Missing token is never ownership.
 
 ## Prerequisites
 
@@ -84,16 +156,18 @@ Payment-Identifier Example Server
 
 Idempotency Configuration:
    - Cache TTL: 1 hour
-   - In-flight reservation TTL: 30 seconds
+   - In-flight reservation TTL: 300s server-owned (not client maxTimeoutSeconds)
+   - Pending map bound: 1024 entries, fail closed at capacity
    - Payment ID: optional (required: false)
 
 How it works:
    1. Client sends payment with a unique payment ID
-   2. Server caches the response bound to that ID and the HTTP request
-   3. Same ID and same request fingerprint returns the cached response
-   4. Same ID with a different method, path, query, or body returns 409
+   2. Server caches the response bound to that ID, the HTTP request, and the payment credential
+   3. Same ID and same request+credential fingerprint returns the cached response
+   4. Same ID with a different method, path, query, body, or credential returns 409
    5. A live in-flight reservation is never overwritten
-   6. No duplicate payment processing occurs on a cache hit
+   6. Reservations are created only for GET /weather
+   7. No duplicate payment processing occurs on a cache hit
 ```
 
 Request-binding unit tests (no wallet, chain, facilitator, or payment):
@@ -148,6 +222,6 @@ Clients must provide a payment ID. Requests without one will be rejected.
 
 1. **Use a distributed cache** (Redis, Memcached) instead of in-memory dict
 2. **Configure appropriate TTL** based on your use case
-3. **Bind payment IDs to the HTTP request** (method, canonical path+query, raw body, accepted terms) and return 409 on drift
-4. **Reserve in-flight payment IDs** with a short TTL (30s here) so concurrent requests cannot overwrite the first fingerprint; expire failed verification so the map cannot grow without bound
-5. **Monitor cache hit rates** to optimize performance
+3. **Bind payment IDs to the HTTP request and settled credential** (method, canonical path+query, raw body, accepted terms, `payload.payload`) and return 409 on drift. Do not hash only the payload or only the HTTP request.
+4. **Reserve in-flight payment IDs only on protected paid routes** so concurrent requests cannot overwrite the first fingerprint. Require the exact token for consume/release/mark-unknown. Release pending reservations only on definitive pre-settlement rejection. A thrown/timeout/network settle outcome is indeterminate: keep a tombstone for 300s and do not release. Python `on_settle_failure` retains because it cannot distinguish unsuccessful results from thrown errors.
+5. **Replay the exact encoded payment header** on retry, and only for the same request URL and selected accepted terms. Bound the in-memory map at 1024 via `try_reserve`. This GET-only single-process educational example is not a production idempotency library. Unauthenticated but syntactically valid payloads can still fill the bounded map.

--- a/examples/python/servers/payment-identifier/README.md
+++ b/examples/python/servers/payment-identifier/README.md
@@ -6,8 +6,11 @@ Example server demonstrating how to implement the `payment-identifier` extension
 
 1. Server advertises `payment-identifier` extension support in PaymentRequired responses
 2. Server extracts payment ID from incoming PaymentPayload using `extract_payment_identifier()`
-3. After settlement, server caches the response keyed by payment ID
-4. Duplicate requests with the same payment ID return cached response without payment processing
+3. Before payment middleware, the server looks up the settled cache, then holds an expiring in-flight reservation (fingerprint + timestamp, 30s TTL, distinct from the 1-hour cache)
+4. After settlement, `on_after_settle` consumes only that live reservation and caches its exact fingerprint
+5. Same payment ID and same fingerprint return the cached response without payment processing
+6. Same payment ID with a different method, path, query, or body returns HTTP 409 and does not grant access
+7. A second in-flight request never overwrites a live reservation; same fingerprint is an in-flight 409, a different fingerprint is the request-conflict 409
 
 ```python
 from x402.extensions.payment_identifier import (
@@ -29,10 +32,15 @@ routes = {
     ),
 }
 
-# Cache response after settlement
+# Consume the live reservation after settlement; do not cache if missing or expired
 async def after_settle(ctx):
     payment_id = extract_payment_identifier(ctx.payment_payload)
-    if payment_id:
+    fingerprint = (
+        consume_reservation(pending_reservations, payment_id=payment_id, now=time.time(), ttl_seconds=30)
+        if payment_id
+        else None
+    )
+    if payment_id and fingerprint:
         idempotency_cache[payment_id] = cached_response
 
 server.on_after_settle(after_settle)
@@ -76,13 +84,22 @@ Payment-Identifier Example Server
 
 Idempotency Configuration:
    - Cache TTL: 1 hour
+   - In-flight reservation TTL: 30 seconds
    - Payment ID: optional (required: false)
 
 How it works:
    1. Client sends payment with a unique payment ID
-   2. Server caches the response keyed by payment ID
-   3. If same payment ID is seen within 1 hour, cached response is returned
-   4. No duplicate payment processing occurs
+   2. Server caches the response bound to that ID and the HTTP request
+   3. Same ID and same request fingerprint returns the cached response
+   4. Same ID with a different method, path, query, or body returns 409
+   5. A live in-flight reservation is never overwritten
+   6. No duplicate payment processing occurs on a cache hit
+```
+
+Request-binding unit tests (no wallet, chain, facilitator, or payment):
+
+```bash
+python3 -m unittest test_request_binding.py
 ```
 
 When requests come in:
@@ -131,5 +148,6 @@ Clients must provide a payment ID. Requests without one will be rejected.
 
 1. **Use a distributed cache** (Redis, Memcached) instead of in-memory dict
 2. **Configure appropriate TTL** based on your use case
-3. **Consider cache key structure** to include route/method for multi-endpoint servers
-4. **Monitor cache hit rates** to optimize performance
+3. **Bind payment IDs to the HTTP request** (method, canonical path+query, raw body, accepted terms) and return 409 on drift
+4. **Reserve in-flight payment IDs** with a short TTL (30s here) so concurrent requests cannot overwrite the first fingerprint; expire failed verification so the map cannot grow without bound
+5. **Monitor cache hit rates** to optimize performance

--- a/examples/python/servers/payment-identifier/main.py
+++ b/examples/python/servers/payment-identifier/main.py
@@ -5,12 +5,16 @@ extension for idempotent payment processing.
 
 This server:
 1. Advertises payment-identifier extension support in PaymentRequired responses
-2. Caches responses keyed by payment ID plus an HTTP request fingerprint
+2. Caches responses keyed by payment ID plus an HTTP request and credential fingerprint
 3. Returns cached responses only when the fingerprint matches
 4. Returns HTTP 409 without granting access when the same payment ID is reused
-   with a different method, path, query, body, or accepted terms
+   with a different method, path, query, body, accepted terms, extra, timeout, or credential
 5. Holds an expiring in-flight reservation so concurrent requests cannot
    overwrite the first fingerprint or start a second settlement
+6. Reserves only the protected paid route (GET /weather), never /health or
+   unmatched paths
+7. Releases a pending reservation on pre-settlement rejection. Thrown settle
+   errors keep a tokenized tombstone until the server-owned TTL expires.
 
 Required environment variables:
 - EVM_ADDRESS: The EVM address to receive payments
@@ -27,16 +31,6 @@ from typing import Any
 from dotenv import load_dotenv
 from fastapi import FastAPI, Request, Response
 from pydantic import BaseModel, ValidationError
-from request_binding import (
-    CONFLICT_MESSAGE,
-    IN_FLIGHT_MESSAGE,
-    RESERVATION_TTL_SECONDS,
-    Reservation,
-    bind_payment_id,
-    cleanup_expired_reservations,
-    consume_reservation,
-    request_fingerprint,
-)
 from x402.extensions.payment_identifier import (
     PAYMENT_IDENTIFIER,
     declare_payment_identifier_extension,
@@ -46,8 +40,28 @@ from x402.http import FacilitatorConfig, HTTPFacilitatorClient, PaymentOption
 from x402.http.middleware.fastapi import PaymentMiddlewareASGI
 from x402.http.types import RouteConfig
 from x402.mechanisms.evm.exact import ExactEvmServerScheme
-from x402.schemas import Network, PaymentPayload, SettleContext
+from x402.schemas import AbortResult, Network, PaymentPayload, SettleContext
 from x402.server import x402ResourceServer
+
+from request_binding import (
+    CAPACITY_MESSAGE,
+    CONFLICT_MESSAGE,
+    IN_FLIGHT_MESSAGE,
+    RESERVATION_TTL_SECONDS,
+    RETRY_AFTER_SECONDS,
+    RETRYABLE_STATUS_CODE,
+    Reservation,
+    bind_payment_id,
+    cleanup_expired_reservations,
+    consume_reservation,
+    is_protected_route,
+    mark_outcome_unknown,
+    mark_settlement_started,
+    release_if_pending,
+    request_fingerprint,
+    reservation_token_from_transport,
+    reservation_ttl_seconds,
+)
 
 load_dotenv()
 
@@ -98,7 +112,7 @@ def cleanup_expired_entries() -> None:
     cleanup_expired_reservations(
         pending_reservations,
         now=now,
-        ttl_seconds=RESERVATION_TTL_SECONDS,
+        ttl_seconds=reservation_ttl_seconds(),
     )
 
 
@@ -111,17 +125,49 @@ server = x402ResourceServer(facilitator)
 server.register(EVM_NETWORK, ExactEvmServerScheme())
 
 
+def _hook_http_identity(ctx: Any) -> tuple[str, str]:
+    transport = getattr(ctx, "transport_context", None)
+    request = getattr(transport, "request", None)
+    adapter = getattr(request, "adapter", None) if request is not None else None
+    method = getattr(request, "method", "") or ""
+    url = getattr(request, "path", "") or ""
+    if adapter is not None:
+        method = adapter.get_method() or method
+        url = adapter.get_url() or url
+    return method, url
+
+
+def _hook_reservation_token(ctx: Any) -> str | None:
+    return reservation_token_from_transport(getattr(ctx, "transport_context", None))
+
+
+def _hook_fingerprint(ctx: Any) -> str:
+    method, url = _hook_http_identity(ctx)
+    return request_fingerprint(
+        method=method,
+        url=url,
+        body=b"",
+        payload=ctx.payment_payload,
+    )
+
+
+def _hook_payment_id(ctx: Any) -> str | None:
+    return extract_payment_identifier(ctx.payment_payload)
+
+
 # Hook after settlement to cache the response with the request fingerprint
 async def after_settle(ctx: SettleContext) -> None:
-    """Cache the response after successful payment settlement."""
-    payment_id = extract_payment_identifier(ctx.payment_payload)
+    """Cache only when this request's matching reservation is consumed."""
+    payment_id = _hook_payment_id(ctx)
     if not payment_id:
         return
     fingerprint = consume_reservation(
         pending_reservations,
         payment_id=payment_id,
+        fingerprint=_hook_fingerprint(ctx),
         now=time.time(),
-        ttl_seconds=RESERVATION_TTL_SECONDS,
+        ttl_seconds=reservation_ttl_seconds(),
+        token=_hook_reservation_token(ctx),
     )
     if not fingerprint:
         return
@@ -139,7 +185,59 @@ async def after_settle(ctx: SettleContext) -> None:
     )
 
 
+async def before_settle(ctx: Any) -> AbortResult | None:
+    """Track the transition into settlement for this tokenized reservation."""
+    payment_id = _hook_payment_id(ctx)
+    if not payment_id:
+        return
+    started = mark_settlement_started(
+        pending_reservations,
+        payment_id=payment_id,
+        fingerprint=_hook_fingerprint(ctx),
+        now=time.time(),
+        ttl_seconds=reservation_ttl_seconds(),
+        token=_hook_reservation_token(ctx),
+    )
+    if not started:
+        return AbortResult(reason="payment_identifier_reservation_lost")
+    return None
+
+
+async def retain_unknown_on_settle_failure(ctx: Any) -> None:
+    """Retain a tombstone: Python settle-failure conflates result and throw."""
+    payment_id = _hook_payment_id(ctx)
+    if not payment_id:
+        return
+    mark_outcome_unknown(
+        pending_reservations,
+        payment_id=payment_id,
+        fingerprint=_hook_fingerprint(ctx),
+        now=time.time(),
+        ttl_seconds=reservation_ttl_seconds(),
+        token=_hook_reservation_token(ctx),
+    )
+
+
+async def release_pending_reservation(ctx: Any) -> None:
+    """Drop only this request's pending reservation on pre-settlement failure."""
+    payment_id = _hook_payment_id(ctx)
+    if not payment_id:
+        return
+    release_if_pending(
+        pending_reservations,
+        payment_id=payment_id,
+        fingerprint=_hook_fingerprint(ctx),
+        now=time.time(),
+        ttl_seconds=reservation_ttl_seconds(),
+        token=_hook_reservation_token(ctx),
+    )
+
+
+server.on_before_settle(before_settle)
 server.on_after_settle(after_settle)
+server.on_verify_failure(release_pending_reservation)
+server.on_settle_failure(retain_unknown_on_settle_failure)
+server.on_verified_payment_canceled(release_pending_reservation)
 
 
 # Route configuration with payment-identifier extension advertised
@@ -171,90 +269,156 @@ app.add_middleware(PaymentMiddlewareASGI, routes=routes, server=server)
 @app.middleware("http")
 async def idempotency_middleware(request: Request, call_next: Any) -> Response:
     """Bind payment IDs to the HTTP request before payment processing."""
-    cleanup_expired_entries()
+
+    def storage_unavailable() -> Response:
+        return Response(
+            content=json.dumps(
+                {
+                    "error": "payment identifier storage unavailable",
+                    "retryable": True,
+                }
+            ),
+            media_type="application/json",
+            status_code=RETRYABLE_STATUS_CODE,
+            headers={"Retry-After": str(RETRY_AFTER_SECONDS)},
+        )
 
     payment_header = request.headers.get("PAYMENT-SIGNATURE") or request.headers.get(
         "X-Payment"
     )
-    if payment_header:
-        try:
-            payment_data = json.loads(base64.b64decode(payment_header).decode("utf-8"))
-            payment_payload = PaymentPayload.model_validate(payment_data)
-            payment_id = extract_payment_identifier(payment_payload)
+    reserved_token: str | None = None
+    reserved_payment_id: str | None = None
+    reserved_fingerprint: str | None = None
+    if not payment_header:
+        return await call_next(request)
 
-            if payment_id:
-                print(f"[Idempotency] Checking payment ID: {payment_id}")
-                fingerprint = request_fingerprint(
-                    method=request.method,
-                    url=str(request.url),
-                    body=await request.body(),
-                    payload=payment_data,
-                )
-                decision = bind_payment_id(
-                    idempotency_cache,
-                    pending_reservations,
-                    payment_id=payment_id,
-                    fingerprint=fingerprint,
-                    now=time.time(),
-                    cache_ttl_seconds=CACHE_TTL_SECONDS,
-                    reservation_ttl_seconds=RESERVATION_TTL_SECONDS,
-                )
+    try:
+        payment_data = json.loads(base64.b64decode(payment_header).decode("utf-8"))
+        payment_payload = PaymentPayload.model_validate(payment_data)
+    except (
+        binascii.Error,
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+        ValidationError,
+    ):
+        # Only malformed header decoding may continue normal payment handling.
+        return await call_next(request)
 
-                if decision.kind == "conflict":
-                    print("[Idempotency] CONFLICT - same ID, different request")
-                    return Response(
-                        content=json.dumps(
-                            {
-                                "error": CONFLICT_MESSAGE,
-                                "paymentId": payment_id,
-                            }
-                        ),
-                        media_type="application/json",
-                        status_code=409,
-                    )
+    payment_id = extract_payment_identifier(payment_payload)
+    if not payment_id:
+        return await call_next(request)
+    if not is_protected_route(request.method, str(request.url), routes):
+        return await call_next(request)
 
-                if decision.kind == "in_flight":
-                    print("[Idempotency] IN FLIGHT - same ID, request already reserved")
-                    return Response(
-                        content=json.dumps(
-                            {
-                                "error": IN_FLIGHT_MESSAGE,
-                                "paymentId": payment_id,
-                            }
-                        ),
-                        media_type="application/json",
-                        status_code=409,
-                    )
+    try:
+        cleanup_expired_entries()
+        print(f"[Idempotency] Checking payment ID: {payment_id}")
+        fingerprint = request_fingerprint(
+            method=request.method,
+            url=str(request.url),
+            body=await request.body(),
+            payload=payment_data,
+        )
+        decision = bind_payment_id(
+            idempotency_cache,
+            pending_reservations,
+            payment_id=payment_id,
+            fingerprint=fingerprint,
+            now=time.time(),
+            cache_ttl_seconds=CACHE_TTL_SECONDS,
+            reservation_ttl_seconds=reservation_ttl_seconds(),
+        )
 
-                if decision.kind == "hit":
-                    cached = idempotency_cache[payment_id]
-                    age = time.time() - cached.timestamp
-                    print(
-                        f"[Idempotency] Cache HIT - returning cached response (age: {int(age)}s)"
-                    )
-                    cached_response = {
-                        "report": {
-                            **cached.response["report"],
-                            "cached": True,
-                        }
-                    }
-                    return Response(
-                        content=json.dumps(cached_response),
-                        media_type="application/json",
-                        status_code=200,
-                    )
+        if decision.kind == "hit":
+            cached = idempotency_cache[payment_id]
+        else:
+            cached = None
+        if decision.kind == "miss":
+            reserved = pending_reservations[payment_id]
+            if not reserved.token:
+                raise RuntimeError("reservation missing token after bind")
+        else:
+            reserved = None
+    except Exception:  # noqa: BLE001 - storage boundary must fail closed
+        return storage_unavailable()
 
-                print("[Idempotency] Cache MISS - reserved, proceeding with payment")
-        except (
-            binascii.Error,
-            UnicodeDecodeError,
-            json.JSONDecodeError,
-            ValidationError,
-        ):
-            # Invalid payment header format continues through normal payment handling.
-            return await call_next(request)
+    if decision.kind == "conflict":
+        print("[Idempotency] CONFLICT - same ID, different request")
+        return Response(
+            content=json.dumps(
+                {
+                    "error": CONFLICT_MESSAGE,
+                    "paymentId": payment_id,
+                }
+            ),
+            media_type="application/json",
+            status_code=409,
+        )
 
-    return await call_next(request)
+    if decision.kind == "in_flight":
+        print("[Idempotency] IN FLIGHT - retryable, request already reserved")
+        return Response(
+            content=json.dumps(
+                {
+                    "error": IN_FLIGHT_MESSAGE,
+                    "paymentId": payment_id,
+                    "retryable": True,
+                }
+            ),
+            media_type="application/json",
+            status_code=RETRYABLE_STATUS_CODE,
+            headers={"Retry-After": str(RETRY_AFTER_SECONDS)},
+        )
+
+    if decision.kind == "capacity":
+        print("[Idempotency] CAPACITY - retryable, reservation map is full")
+        return Response(
+            content=json.dumps(
+                {
+                    "error": CAPACITY_MESSAGE,
+                    "paymentId": payment_id,
+                    "retryable": True,
+                }
+            ),
+            media_type="application/json",
+            status_code=RETRYABLE_STATUS_CODE,
+            headers={"Retry-After": str(RETRY_AFTER_SECONDS)},
+        )
+
+    if decision.kind == "hit" and cached is not None:
+        age = time.time() - cached.timestamp
+        print(f"[Idempotency] Cache HIT - returning cached response (age: {int(age)}s)")
+        cached_response = {
+            "report": {
+                **cached.response["report"],
+                "cached": True,
+            }
+        }
+        return Response(
+            content=json.dumps(cached_response),
+            media_type="application/json",
+            status_code=200,
+        )
+
+    if reserved is None:
+        return storage_unavailable()
+    request.state.x402_reservation_token = reserved.token
+    reserved_token = reserved.token
+    reserved_payment_id = payment_id
+    reserved_fingerprint = fingerprint
+    print("[Idempotency] Cache MISS - reserved, proceeding with payment")
+
+    response = await call_next(request)
+    if reserved_payment_id and reserved_token and reserved_fingerprint:
+        release_if_pending(
+            pending_reservations,
+            payment_id=reserved_payment_id,
+            fingerprint=reserved_fingerprint,
+            now=time.time(),
+            ttl_seconds=reservation_ttl_seconds(),
+            token=reserved_token,
+        )
+    return response
 
 
 # Routes
@@ -282,14 +446,35 @@ if __name__ == "__main__":
     print("   Listening at http://localhost:4022")
     print("\nIdempotency Configuration:")
     print("   - Cache TTL: 1 hour")
-    print("   - In-flight reservation TTL: 30 seconds")
+    print(
+        "   - In-flight reservation TTL: "
+        f"{int(RESERVATION_TTL_SECONDS)}s server-owned (not client maxTimeoutSeconds)"
+    )
+    print("   - Pending map bound: 1024 entries, fail closed at capacity")
     print("   - Payment ID: optional (required: false)")
+    print("   - Scope: GET-only, single-process in-memory example")
     print("\nHow it works:")
     print("   1. Client sends payment with a unique payment ID")
-    print("   2. Server caches the response bound to that ID and the HTTP request")
-    print("   3. Same ID and same request fingerprint returns the cached response")
-    print("   4. Same ID with a different method, path, query, or body returns 409")
-    print("   5. A live in-flight reservation is never overwritten")
-    print("   6. No duplicate payment processing occurs on a cache hit\n")
+    print(
+        "   2. Server caches the response bound to that ID, HTTP request, and credential"
+    )
+    print(
+        "   3. Same ID and same request+credential fingerprint returns the cached response"
+    )
+    print(
+        "   4. Same ID with a different method, path, query, body, extra, timeout, or credential returns 409"
+    )
+    print(
+        "   5. In-flight and capacity responses are HTTP 503 retryable, not 409 conflict"
+    )
+    print("   6. Reservations are created only for GET /weather")
+    print(
+        "   7. Pre-settlement rejection releases the matching reservation; thrown settle errors keep a tokenized tombstone until TTL"
+    )
+    print("   8. A settle failure is not immediately safe to retry")
+    print(
+        "   9. Replay the exact encoded payment header; do not create a new signature"
+    )
+    print("  10. No duplicate payment processing occurs on a cache hit\n")
 
     uvicorn.run(app, host="0.0.0.0", port=4022)

--- a/examples/python/servers/payment-identifier/main.py
+++ b/examples/python/servers/payment-identifier/main.py
@@ -5,14 +5,19 @@ extension for idempotent payment processing.
 
 This server:
 1. Advertises payment-identifier extension support in PaymentRequired responses
-2. Caches responses keyed by payment ID after settlement
-3. Returns cached responses for duplicate payment IDs without re-processing
+2. Caches responses keyed by payment ID plus an HTTP request fingerprint
+3. Returns cached responses only when the fingerprint matches
+4. Returns HTTP 409 without granting access when the same payment ID is reused
+   with a different method, path, query, body, or accepted terms
+5. Holds an expiring in-flight reservation so concurrent requests cannot
+   overwrite the first fingerprint or start a second settlement
 
 Required environment variables:
 - EVM_ADDRESS: The EVM address to receive payments
 """
 
 import base64
+import binascii
 import json
 import os
 import time
@@ -21,8 +26,17 @@ from typing import Any
 
 from dotenv import load_dotenv
 from fastapi import FastAPI, Request, Response
-from pydantic import BaseModel
-
+from pydantic import BaseModel, ValidationError
+from request_binding import (
+    CONFLICT_MESSAGE,
+    IN_FLIGHT_MESSAGE,
+    RESERVATION_TTL_SECONDS,
+    Reservation,
+    bind_payment_id,
+    cleanup_expired_reservations,
+    consume_reservation,
+    request_fingerprint,
+)
 from x402.extensions.payment_identifier import (
     PAYMENT_IDENTIFIER,
     declare_payment_identifier_extension,
@@ -62,15 +76,17 @@ class WeatherResponse(BaseModel):
 @dataclass
 class CachedResponse:
     timestamp: float
+    fingerprint: str
     response: dict[str, Any]
 
 
 idempotency_cache: dict[str, CachedResponse] = {}
+pending_reservations: dict[str, Reservation] = {}
 CACHE_TTL_SECONDS = 60 * 60  # 1 hour
 
 
 def cleanup_expired_entries() -> None:
-    """Clean up expired entries from the cache."""
+    """Clean up expired cache and in-flight reservation entries."""
     now = time.time()
     expired_keys = [
         key
@@ -79,6 +95,11 @@ def cleanup_expired_entries() -> None:
     ]
     for key in expired_keys:
         del idempotency_cache[key]
+    cleanup_expired_reservations(
+        pending_reservations,
+        now=now,
+        ttl_seconds=RESERVATION_TTL_SECONDS,
+    )
 
 
 # App
@@ -90,22 +111,32 @@ server = x402ResourceServer(facilitator)
 server.register(EVM_NETWORK, ExactEvmServerScheme())
 
 
-# Hook after settlement to cache the response
+# Hook after settlement to cache the response with the request fingerprint
 async def after_settle(ctx: SettleContext) -> None:
     """Cache the response after successful payment settlement."""
     payment_id = extract_payment_identifier(ctx.payment_payload)
-    if payment_id:
-        print(f"[Idempotency] Caching response for payment ID: {payment_id}")
-        idempotency_cache[payment_id] = CachedResponse(
-            timestamp=time.time(),
-            response={
-                "report": {
-                    "weather": "sunny",
-                    "temperature": 70,
-                    "cached": False,
-                }
-            },
-        )
+    if not payment_id:
+        return
+    fingerprint = consume_reservation(
+        pending_reservations,
+        payment_id=payment_id,
+        now=time.time(),
+        ttl_seconds=RESERVATION_TTL_SECONDS,
+    )
+    if not fingerprint:
+        return
+    print(f"[Idempotency] Caching response for payment ID: {payment_id}")
+    idempotency_cache[payment_id] = CachedResponse(
+        timestamp=time.time(),
+        fingerprint=fingerprint,
+        response={
+            "report": {
+                "weather": "sunny",
+                "temperature": 70,
+                "cached": False,
+            }
+        },
+    )
 
 
 server.on_after_settle(after_settle)
@@ -132,58 +163,98 @@ routes = {
 }
 
 
-# Custom middleware to check idempotency cache before payment processing
+# Payment middleware is inner. The later HTTP middleware is outermost so it can
+# 409 or serve a cache hit before payment verification.
+app.add_middleware(PaymentMiddlewareASGI, routes=routes, server=server)
+
+
 @app.middleware("http")
 async def idempotency_middleware(request: Request, call_next: Any) -> Response:
-    """Check idempotency cache before payment processing."""
-    # Clean up expired entries periodically
+    """Bind payment IDs to the HTTP request before payment processing."""
     cleanup_expired_entries()
 
-    # Only check for payment header on protected routes
-    payment_header = request.headers.get("X-Payment")
-    if payment_header and request.url.path == "/weather":
+    payment_header = request.headers.get("PAYMENT-SIGNATURE") or request.headers.get(
+        "X-Payment"
+    )
+    if payment_header:
         try:
-            # Decode payment header to extract payment ID
             payment_data = json.loads(base64.b64decode(payment_header).decode("utf-8"))
             payment_payload = PaymentPayload.model_validate(payment_data)
             payment_id = extract_payment_identifier(payment_payload)
 
             if payment_id:
                 print(f"[Idempotency] Checking payment ID: {payment_id}")
-                cached = idempotency_cache.get(payment_id)
+                fingerprint = request_fingerprint(
+                    method=request.method,
+                    url=str(request.url),
+                    body=await request.body(),
+                    payload=payment_data,
+                )
+                decision = bind_payment_id(
+                    idempotency_cache,
+                    pending_reservations,
+                    payment_id=payment_id,
+                    fingerprint=fingerprint,
+                    now=time.time(),
+                    cache_ttl_seconds=CACHE_TTL_SECONDS,
+                    reservation_ttl_seconds=RESERVATION_TTL_SECONDS,
+                )
 
-                if cached:
-                    age = time.time() - cached.timestamp
-                    if age < CACHE_TTL_SECONDS:
-                        print(
-                            f"[Idempotency] Cache HIT - returning cached response (age: {int(age)}s)"
-                        )
-                        # Return cached response with cached flag set to true
-                        cached_response = {
-                            "report": {
-                                **cached.response["report"],
-                                "cached": True,
+                if decision.kind == "conflict":
+                    print("[Idempotency] CONFLICT - same ID, different request")
+                    return Response(
+                        content=json.dumps(
+                            {
+                                "error": CONFLICT_MESSAGE,
+                                "paymentId": payment_id,
                             }
+                        ),
+                        media_type="application/json",
+                        status_code=409,
+                    )
+
+                if decision.kind == "in_flight":
+                    print("[Idempotency] IN FLIGHT - same ID, request already reserved")
+                    return Response(
+                        content=json.dumps(
+                            {
+                                "error": IN_FLIGHT_MESSAGE,
+                                "paymentId": payment_id,
+                            }
+                        ),
+                        media_type="application/json",
+                        status_code=409,
+                    )
+
+                if decision.kind == "hit":
+                    cached = idempotency_cache[payment_id]
+                    age = time.time() - cached.timestamp
+                    print(
+                        f"[Idempotency] Cache HIT - returning cached response (age: {int(age)}s)"
+                    )
+                    cached_response = {
+                        "report": {
+                            **cached.response["report"],
+                            "cached": True,
                         }
-                        return Response(
-                            content=json.dumps(cached_response),
-                            media_type="application/json",
-                            status_code=200,
-                        )
-                    else:
-                        print("[Idempotency] Cache EXPIRED - proceeding with payment")
-                        del idempotency_cache[payment_id]
-                else:
-                    print("[Idempotency] Cache MISS - proceeding with payment")
-        except Exception:
-            # Invalid payment header format, continue to normal flow
-            pass
+                    }
+                    return Response(
+                        content=json.dumps(cached_response),
+                        media_type="application/json",
+                        status_code=200,
+                    )
+
+                print("[Idempotency] Cache MISS - reserved, proceeding with payment")
+        except (
+            binascii.Error,
+            UnicodeDecodeError,
+            json.JSONDecodeError,
+            ValidationError,
+        ):
+            # Invalid payment header format continues through normal payment handling.
+            return await call_next(request)
 
     return await call_next(request)
-
-
-# Add payment middleware after idempotency middleware
-app.add_middleware(PaymentMiddlewareASGI, routes=routes, server=server)
 
 
 # Routes
@@ -211,11 +282,14 @@ if __name__ == "__main__":
     print("   Listening at http://localhost:4022")
     print("\nIdempotency Configuration:")
     print("   - Cache TTL: 1 hour")
+    print("   - In-flight reservation TTL: 30 seconds")
     print("   - Payment ID: optional (required: false)")
     print("\nHow it works:")
     print("   1. Client sends payment with a unique payment ID")
-    print("   2. Server caches the response keyed by payment ID")
-    print("   3. If same payment ID is seen within 1 hour, cached response is returned")
-    print("   4. No duplicate payment processing occurs\n")
+    print("   2. Server caches the response bound to that ID and the HTTP request")
+    print("   3. Same ID and same request fingerprint returns the cached response")
+    print("   4. Same ID with a different method, path, query, or body returns 409")
+    print("   5. A live in-flight reservation is never overwritten")
+    print("   6. No duplicate payment processing occurs on a cache hit\n")
 
     uvicorn.run(app, host="0.0.0.0", port=4022)

--- a/examples/python/servers/payment-identifier/request_binding.py
+++ b/examples/python/servers/payment-identifier/request_binding.py
@@ -1,0 +1,232 @@
+"""Bind a payment identifier to the HTTP request, not the payment payload.
+
+Fingerprint covers HTTP method, canonical path+query, raw body SHA-256, and
+accepted terms (scheme, network, asset, amount, payTo). Same payment ID with a
+different fingerprint is a conflict: HTTP 409, grant_access False.
+
+In-flight work is an expiring reservation (fingerprint + timestamp), not a
+bare fingerprint. A live reservation is never overwritten. Settled cache TTL
+is one hour; reservation TTL is 30 seconds so failed verification cannot leak
+or block the ID forever.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, MutableMapping
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import parse_qsl, urlencode, urlsplit
+
+HIT = "hit"
+CONFLICT = "conflict"
+IN_FLIGHT = "in_flight"
+MISS = "miss"
+EXPIRED = "expired"
+
+CONFLICT_MESSAGE = "payment identifier already used with different request"
+IN_FLIGHT_MESSAGE = "payment identifier is already being processed for this request"
+
+# Distinct from the one-hour settled cache TTL used by the example server.
+RESERVATION_TTL_SECONDS = 30.0
+
+
+def canonical_request_url(url: str) -> str:
+    parts = urlsplit(url)
+    # Sort by key only. Python's sort is stable, matching URLSearchParams.sort():
+    # distinct keys are ordered, duplicate-key relative order is preserved.
+    pairs = sorted(
+        parse_qsl(parts.query, keep_blank_values=True), key=lambda item: item[0]
+    )
+    query = urlencode(pairs)
+    path = parts.path or "/"
+    return f"{path}?{query}" if query else path
+
+
+def body_sha256(body: bytes | bytearray | memoryview | str | None) -> str:
+    if body is None:
+        data = b""
+    elif isinstance(body, str):
+        data = body.encode("utf-8")
+    else:
+        data = bytes(body)
+    return hashlib.sha256(data).hexdigest()
+
+
+def _as_mapping(value: Any) -> Mapping[str, Any]:
+    if value is None:
+        return {}
+    if isinstance(value, Mapping):
+        return value
+    if hasattr(value, "model_dump"):
+        dumped = value.model_dump(by_alias=True)
+        if isinstance(dumped, Mapping):
+            return dumped
+    return {}
+
+
+def payment_terms(payload: Any) -> dict[str, str]:
+    accepted = _as_mapping(_as_mapping(payload).get("accepted"))
+    pay_to = accepted.get("payTo", accepted.get("pay_to", ""))
+    return {
+        "scheme": str(accepted.get("scheme") or ""),
+        "network": str(accepted.get("network") or ""),
+        "asset": str(accepted.get("asset") or ""),
+        "amount": str(accepted.get("amount") or ""),
+        "payTo": str(pay_to or ""),
+    }
+
+
+def request_fingerprint(
+    *,
+    method: str,
+    url: str,
+    body: bytes | bytearray | memoryview | str | None,
+    payload: Any,
+) -> str:
+    material = {
+        "bodySha256": body_sha256(body),
+        "method": (method or "").upper(),
+        "url": canonical_request_url(url),
+        **payment_terms(payload),
+    }
+    canonical = json.dumps(material, separators=(",", ":"), sort_keys=True)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True)
+class CacheDecision:
+    kind: str
+    status_code: int | None
+    grant_access: bool
+
+
+@dataclass(frozen=True)
+class Reservation:
+    fingerprint: str
+    timestamp: float
+
+
+def lookup(
+    cache: Mapping[str, Any],
+    *,
+    payment_id: str,
+    fingerprint: str,
+    now: float,
+    ttl_seconds: float,
+) -> CacheDecision:
+    cached = cache.get(payment_id)
+    if cached is None:
+        return CacheDecision(MISS, None, False)
+    if isinstance(cached, Mapping):
+        timestamp = float(cached["timestamp"])
+        cached_fp = cached.get("fingerprint")
+    else:
+        timestamp = float(cached.timestamp)
+        cached_fp = getattr(cached, "fingerprint", None)
+    if now - timestamp >= ttl_seconds:
+        return CacheDecision(EXPIRED, None, False)
+    if not cached_fp or cached_fp != fingerprint:
+        return CacheDecision(CONFLICT, 409, False)
+    return CacheDecision(HIT, 200, True)
+
+
+def _reservation_parts(value: Any) -> tuple[float, str | None]:
+    if isinstance(value, Mapping):
+        return float(value["timestamp"]), value.get("fingerprint")
+    return float(value.timestamp), getattr(value, "fingerprint", None)
+
+
+def cleanup_expired_reservations(
+    reservations: MutableMapping[str, Any],
+    *,
+    now: float,
+    ttl_seconds: float,
+) -> int:
+    """Drop expired reservations in one pass over the current map."""
+    expired = [
+        key
+        for key, value in reservations.items()
+        if now - _reservation_parts(value)[0] >= ttl_seconds
+    ]
+    for key in expired:
+        del reservations[key]
+    return len(expired)
+
+
+def try_reserve(
+    reservations: MutableMapping[str, Any],
+    *,
+    payment_id: str,
+    fingerprint: str,
+    now: float,
+    ttl_seconds: float,
+) -> CacheDecision:
+    """Create a reservation or refuse without granting access.
+
+    A live reservation is never overwritten. Same fingerprint is in-flight
+    conflict; a different fingerprint is request conflict. Expired entries
+    are removed, then a new reservation is stored.
+    """
+    existing = reservations.get(payment_id)
+    if existing is not None:
+        timestamp, reserved_fp = _reservation_parts(existing)
+        if now - timestamp < ttl_seconds:
+            if reserved_fp and reserved_fp == fingerprint:
+                return CacheDecision(IN_FLIGHT, 409, False)
+            return CacheDecision(CONFLICT, 409, False)
+        del reservations[payment_id]
+    reservations[payment_id] = Reservation(fingerprint=fingerprint, timestamp=now)
+    return CacheDecision(MISS, None, False)
+
+
+def consume_reservation(
+    reservations: MutableMapping[str, Any],
+    *,
+    payment_id: str,
+    now: float,
+    ttl_seconds: float,
+) -> str | None:
+    """Pop a live reservation and return its fingerprint.
+
+    Missing or expired reservations return None and must not be cached.
+    """
+    existing = reservations.pop(payment_id, None)
+    if existing is None:
+        return None
+    timestamp, fingerprint = _reservation_parts(existing)
+    if now - timestamp >= ttl_seconds or not fingerprint:
+        return None
+    return str(fingerprint)
+
+
+def bind_payment_id(
+    cache: MutableMapping[str, Any],
+    reservations: MutableMapping[str, Any],
+    *,
+    payment_id: str,
+    fingerprint: str,
+    now: float,
+    cache_ttl_seconds: float,
+    reservation_ttl_seconds: float,
+) -> CacheDecision:
+    """Settled cache first, then in-flight reservation. Never grants on reserve."""
+    decision = lookup(
+        cache,
+        payment_id=payment_id,
+        fingerprint=fingerprint,
+        now=now,
+        ttl_seconds=cache_ttl_seconds,
+    )
+    if decision.kind in (HIT, CONFLICT):
+        return decision
+    if decision.kind == EXPIRED:
+        cache.pop(payment_id, None)
+    return try_reserve(
+        reservations,
+        payment_id=payment_id,
+        fingerprint=fingerprint,
+        now=now,
+        ttl_seconds=reservation_ttl_seconds,
+    )

--- a/examples/python/servers/payment-identifier/request_binding.py
+++ b/examples/python/servers/payment-identifier/request_binding.py
@@ -1,47 +1,109 @@
-"""Bind a payment identifier to the HTTP request, not the payment payload.
+"""Bind a payment identifier to the HTTP request and settled credential.
 
-Fingerprint covers HTTP method, canonical path+query, raw body SHA-256, and
-accepted terms (scheme, network, asset, amount, payTo). Same payment ID with a
-different fingerprint is a conflict: HTTP 409, grant_access False.
+Fingerprint covers HTTP method, canonical path+query, raw body SHA-256,
+accepted terms (scheme, network, asset, amount, payTo, maxTimeoutSeconds,
+recursively canonical extra), and SHA-256 of the scheme-specific credential
+(`payload.payload`). Same payment ID with a different fingerprint is a
+conflict: HTTP 409, grant_access False.
 
-In-flight work is an expiring reservation (fingerprint + timestamp), not a
-bare fingerprint. A live reservation is never overwritten. Settled cache TTL
-is one hour; reservation TTL is 30 seconds so failed verification cannot leak
-or block the ID forever.
+A payload-only hash and a request-only hash are both insufficient: a stolen
+payment ID plus a fabricated credential must not replay a cached paid response.
+
+Reserve only for protected paid routes. Unpaid paths, including /health and
+unmatched routes, must not create reservations.
+
+In-flight work is an expiring reservation (fingerprint + timestamp + token +
+state). Reservation lifetime and capacity are server policy: TTL is always
+RESERVATION_TTL_SECONDS (300s). Client accepted.maxTimeoutSeconds is
+fingerprinted, never used as map TTL. The pending map is bounded to
+MAX_PENDING_RESERVATIONS after expired cleanup.
+
+Consume, release, mark-unknown, and any other mutation require the exact
+supplied token. Missing token is never fingerprint-only ownership.
+
+Query encoding is RFC 3986: unreserved characters stay literal, spaces are
+%20, pairs are stably sorted by decoded key.
+
+This example is GET-only, single-process, and does not capture POST bodies.
 """
 
 from __future__ import annotations
 
 import hashlib
 import json
+import secrets
 from collections.abc import Mapping, MutableMapping
 from dataclasses import dataclass
 from typing import Any
-from urllib.parse import parse_qsl, urlencode, urlsplit
+from urllib.parse import parse_qsl, quote, urlsplit
 
 HIT = "hit"
 CONFLICT = "conflict"
 IN_FLIGHT = "in_flight"
+CAPACITY = "capacity"
 MISS = "miss"
 EXPIRED = "expired"
 
+PENDING = "pending"
+SETTLING = "settling"
+UNKNOWN = "unknown"
+
 CONFLICT_MESSAGE = "payment identifier already used with different request"
 IN_FLIGHT_MESSAGE = "payment identifier is already being processed for this request"
+CAPACITY_MESSAGE = "payment identifier reservation map is at capacity"
 
-# Distinct from the one-hour settled cache TTL used by the example server.
-RESERVATION_TTL_SECONDS = 30.0
+CONFLICT_STATUS_CODE = 409
+RETRYABLE_STATUS_CODE = 503
+RETRY_AFTER_SECONDS = 1
+
+# Server-owned in-flight TTL. Client maxTimeoutSeconds does not choose map TTL.
+RESERVATION_TTL_SECONDS = 300.0
+FALLBACK_RESERVATION_TTL_SECONDS = RESERVATION_TTL_SECONDS
+MAX_PENDING_RESERVATIONS = 1024
+
+# RFC 3986 unreserved: ALPHA / DIGIT / "-" / "." / "_" / "~"
+_RFC3986_UNRESERVED = "-._~"
+
+
+def canonical_json(value: Any) -> str:
+    """Canonical JSON with recursively sorted object keys."""
+    return json.dumps(value, separators=(",", ":"), sort_keys=True, ensure_ascii=False)
+
+
+def rfc3986_encode(value: str) -> str:
+    """Percent-encode one query component per RFC 3986.
+
+    Unreserved characters stay literal. Space becomes ``%20``. ``~`` is not
+    encoded.
+    """
+    return quote(value, safe=_RFC3986_UNRESERVED, encoding="utf-8")
 
 
 def canonical_request_url(url: str) -> str:
+    """Canonical path and query using RFC 3986 encoding.
+
+    Pairs are decoded, stably sorted by decoded key (duplicate-key order
+    preserved), and re-encoded. Spaces become ``%20``.
+    """
     parts = urlsplit(url)
-    # Sort by key only. Python's sort is stable, matching URLSearchParams.sort():
-    # distinct keys are ordered, duplicate-key relative order is preserved.
-    pairs = sorted(
-        parse_qsl(parts.query, keep_blank_values=True), key=lambda item: item[0]
+    pairs = list(parse_qsl(parts.query, keep_blank_values=True, encoding="utf-8"))
+    pairs.sort(key=lambda item: item[0])
+    query = "&".join(
+        f"{rfc3986_encode(key)}={rfc3986_encode(value)}" for key, value in pairs
     )
-    query = urlencode(pairs)
     path = parts.path or "/"
     return f"{path}?{query}" if query else path
+
+
+def request_path(url: str) -> str:
+    """Path only, no query and no URL-dot-dot collapse."""
+    return urlsplit(url).path or "/"
+
+
+def is_protected_route(method: str, url: str, routes: Mapping[str, Any]) -> bool:
+    """True when method+path is an exact paid route table key (e.g. 'GET /weather')."""
+    key = f"{(method or '').upper()} {request_path(url)}"
+    return key in routes
 
 
 def body_sha256(body: bytes | bytearray | memoryview | str | None) -> str:
@@ -66,6 +128,21 @@ def _as_mapping(value: Any) -> Mapping[str, Any]:
     return {}
 
 
+def canonical_max_timeout_seconds(accepted: Any) -> str:
+    terms = _as_mapping(accepted)
+    raw = terms.get("maxTimeoutSeconds", terms.get("max_timeout_seconds"))
+    if raw is None:
+        return ""
+    return str(raw)
+
+
+def canonical_accepted_extra(accepted: Any) -> str:
+    extra = _as_mapping(accepted).get("extra")
+    if extra is None:
+        return "{}"
+    return canonical_json(extra)
+
+
 def payment_terms(payload: Any) -> dict[str, str]:
     accepted = _as_mapping(_as_mapping(payload).get("accepted"))
     pay_to = accepted.get("payTo", accepted.get("pay_to", ""))
@@ -75,7 +152,24 @@ def payment_terms(payload: Any) -> dict[str, str]:
         "asset": str(accepted.get("asset") or ""),
         "amount": str(accepted.get("amount") or ""),
         "payTo": str(pay_to or ""),
+        "maxTimeoutSeconds": canonical_max_timeout_seconds(accepted),
+        "extra": canonical_accepted_extra(accepted),
     }
+
+
+def credential_sha256(payload: Any) -> str:
+    """SHA-256 of canonical JSON for payload.payload (signature / authorization)."""
+    credential = _as_mapping(payload).get("payload")
+    if credential is None:
+        canonical = ""
+    else:
+        canonical = canonical_json(credential)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def reservation_ttl_seconds(*_args: Any, **_kwargs: Any) -> float:
+    """Server-owned reservation TTL. Ignores client maxTimeoutSeconds."""
+    return RESERVATION_TTL_SECONDS
 
 
 def request_fingerprint(
@@ -87,11 +181,14 @@ def request_fingerprint(
 ) -> str:
     material = {
         "bodySha256": body_sha256(body),
+        "credentialSha256": credential_sha256(payload),
         "method": (method or "").upper(),
         "url": canonical_request_url(url),
         **payment_terms(payload),
     }
-    canonical = json.dumps(material, separators=(",", ":"), sort_keys=True)
+    canonical = json.dumps(
+        material, separators=(",", ":"), sort_keys=True, ensure_ascii=False
+    )
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
@@ -102,10 +199,13 @@ class CacheDecision:
     grant_access: bool
 
 
-@dataclass(frozen=True)
+@dataclass
 class Reservation:
     fingerprint: str
     timestamp: float
+    token: str = ""
+    ttl_seconds: float = RESERVATION_TTL_SECONDS
+    state: str = PENDING
 
 
 def lookup(
@@ -128,28 +228,72 @@ def lookup(
     if now - timestamp >= ttl_seconds:
         return CacheDecision(EXPIRED, None, False)
     if not cached_fp or cached_fp != fingerprint:
-        return CacheDecision(CONFLICT, 409, False)
+        return CacheDecision(CONFLICT, CONFLICT_STATUS_CODE, False)
     return CacheDecision(HIT, 200, True)
 
 
-def _reservation_parts(value: Any) -> tuple[float, str | None]:
+def _reservation_parts(
+    value: Any,
+) -> tuple[float, str | None, str, float, str]:
     if isinstance(value, Mapping):
-        return float(value["timestamp"]), value.get("fingerprint")
-    return float(value.timestamp), getattr(value, "fingerprint", None)
+        ttl = value.get("ttl_seconds", value.get("ttlSeconds", RESERVATION_TTL_SECONDS))
+        return (
+            float(value["timestamp"]),
+            value.get("fingerprint"),
+            str(value.get("token") or ""),
+            float(ttl if ttl is not None else RESERVATION_TTL_SECONDS),
+            str(value.get("state") or PENDING),
+        )
+    ttl = getattr(
+        value,
+        "ttl_seconds",
+        getattr(value, "ttlSeconds", RESERVATION_TTL_SECONDS),
+    )
+    return (
+        float(value.timestamp),
+        getattr(value, "fingerprint", None),
+        str(getattr(value, "token", "") or ""),
+        float(ttl if ttl is not None else RESERVATION_TTL_SECONDS),
+        str(getattr(value, "state", PENDING) or PENDING),
+    )
+
+
+def _live_limit(stored_ttl: float, ttl_seconds: float) -> float:
+    return stored_ttl if stored_ttl > 0 else ttl_seconds
+
+
+def _is_live(
+    timestamp: float, stored_ttl: float, now: float, ttl_seconds: float
+) -> bool:
+    return now - timestamp < _live_limit(stored_ttl, ttl_seconds)
+
+
+def _owns_reservation(
+    reserved_fp: str | None,
+    reserved_token: str,
+    *,
+    fingerprint: str,
+    token: str | None,
+) -> bool:
+    if not token or not reserved_token:
+        return False
+    if not reserved_fp or reserved_fp != fingerprint:
+        return False
+    return reserved_token == token
 
 
 def cleanup_expired_reservations(
     reservations: MutableMapping[str, Any],
     *,
     now: float,
-    ttl_seconds: float,
+    ttl_seconds: float = RESERVATION_TTL_SECONDS,
 ) -> int:
     """Drop expired reservations in one pass over the current map."""
-    expired = [
-        key
-        for key, value in reservations.items()
-        if now - _reservation_parts(value)[0] >= ttl_seconds
-    ]
+    expired = []
+    for key, value in reservations.items():
+        timestamp, _fp, _token, stored_ttl, _state = _reservation_parts(value)
+        if not _is_live(timestamp, stored_ttl, now, ttl_seconds):
+            expired.append(key)
     for key in expired:
         del reservations[key]
     return len(expired)
@@ -161,23 +305,37 @@ def try_reserve(
     payment_id: str,
     fingerprint: str,
     now: float,
-    ttl_seconds: float,
+    ttl_seconds: float = RESERVATION_TTL_SECONDS,
+    token: str | None = None,
+    max_pending: int = MAX_PENDING_RESERVATIONS,
 ) -> CacheDecision:
     """Create a reservation or refuse without granting access.
 
-    A live reservation is never overwritten. Same fingerprint is in-flight
-    conflict; a different fingerprint is request conflict. Expired entries
-    are removed, then a new reservation is stored.
+    A live reservation is never overwritten. Same fingerprint is retryable
+    in-flight; a different fingerprint is request conflict. After expired
+    cleanup, a full map fails closed with capacity and does not enter
+    verify/settle.
     """
+    cleanup_expired_reservations(reservations, now=now, ttl_seconds=ttl_seconds)
     existing = reservations.get(payment_id)
     if existing is not None:
-        timestamp, reserved_fp = _reservation_parts(existing)
-        if now - timestamp < ttl_seconds:
+        timestamp, reserved_fp, _reserved_token, stored_ttl, _state = (
+            _reservation_parts(existing)
+        )
+        if _is_live(timestamp, stored_ttl, now, ttl_seconds):
             if reserved_fp and reserved_fp == fingerprint:
-                return CacheDecision(IN_FLIGHT, 409, False)
-            return CacheDecision(CONFLICT, 409, False)
+                return CacheDecision(IN_FLIGHT, RETRYABLE_STATUS_CODE, False)
+            return CacheDecision(CONFLICT, CONFLICT_STATUS_CODE, False)
         del reservations[payment_id]
-    reservations[payment_id] = Reservation(fingerprint=fingerprint, timestamp=now)
+    if len(reservations) >= max_pending:
+        return CacheDecision(CAPACITY, RETRYABLE_STATUS_CODE, False)
+    reservations[payment_id] = Reservation(
+        fingerprint=fingerprint,
+        timestamp=now,
+        token=token or secrets.token_hex(16),
+        ttl_seconds=ttl_seconds,
+        state=PENDING,
+    )
     return CacheDecision(MISS, None, False)
 
 
@@ -185,20 +343,173 @@ def consume_reservation(
     reservations: MutableMapping[str, Any],
     *,
     payment_id: str,
+    fingerprint: str,
     now: float,
-    ttl_seconds: float,
+    ttl_seconds: float = RESERVATION_TTL_SECONDS,
+    token: str | None = None,
 ) -> str | None:
-    """Pop a live reservation and return its fingerprint.
+    """Pop the matching current reservation and return its fingerprint.
 
-    Missing or expired reservations return None and must not be cached.
+    Outcome-unknown tombstones are retained. Missing token is never ownership.
     """
-    existing = reservations.pop(payment_id, None)
+    existing = reservations.get(payment_id)
     if existing is None:
         return None
-    timestamp, fingerprint = _reservation_parts(existing)
-    if now - timestamp >= ttl_seconds or not fingerprint:
+    _timestamp, reserved_fp, reserved_token, _stored_ttl, state = _reservation_parts(
+        existing
+    )
+    if not _owns_reservation(
+        reserved_fp, reserved_token, fingerprint=fingerprint, token=token
+    ):
         return None
-    return str(fingerprint)
+    if state == UNKNOWN:
+        return None
+    if not reserved_fp:
+        return None
+    # An exact current token may finish after its phase deadline if cleanup has
+    # not replaced it. A replacement has a different token and fails ownership.
+    del reservations[payment_id]
+    return str(reserved_fp)
+
+
+def release_reservation(
+    reservations: MutableMapping[str, Any],
+    *,
+    payment_id: str,
+    fingerprint: str,
+    now: float,
+    ttl_seconds: float = RESERVATION_TTL_SECONDS,
+    token: str | None = None,
+) -> bool:
+    """Drop a matching pending or settling reservation. Unknown tombstones stay."""
+    existing = reservations.get(payment_id)
+    if existing is None:
+        return False
+    timestamp, reserved_fp, reserved_token, stored_ttl, state = _reservation_parts(
+        existing
+    )
+    if not _owns_reservation(
+        reserved_fp, reserved_token, fingerprint=fingerprint, token=token
+    ):
+        return False
+    if state == UNKNOWN:
+        return False
+    if not _is_live(timestamp, stored_ttl, now, ttl_seconds):
+        return False
+    del reservations[payment_id]
+    return True
+
+
+def release_if_pending(
+    reservations: MutableMapping[str, Any],
+    *,
+    payment_id: str,
+    fingerprint: str,
+    now: float,
+    ttl_seconds: float = RESERVATION_TTL_SECONDS,
+    token: str | None = None,
+) -> bool:
+    """Release only a pending pre-settlement reservation owned by this token."""
+    existing = reservations.get(payment_id)
+    if existing is None:
+        return False
+    _timestamp, _fp, _tok, _ttl, state = _reservation_parts(existing)
+    if state != PENDING:
+        return False
+    return release_reservation(
+        reservations,
+        payment_id=payment_id,
+        fingerprint=fingerprint,
+        now=now,
+        ttl_seconds=ttl_seconds,
+        token=token,
+    )
+
+
+def mark_settlement_started(
+    reservations: MutableMapping[str, Any],
+    *,
+    payment_id: str,
+    fingerprint: str,
+    now: float,
+    ttl_seconds: float = RESERVATION_TTL_SECONDS,
+    token: str | None = None,
+) -> bool:
+    """Mark a matching exact-token reservation as having entered settlement."""
+    del ttl_seconds  # Retained for call-site symmetry; exact token owns transition.
+    existing = reservations.get(payment_id)
+    if existing is None:
+        return False
+    _timestamp, reserved_fp, reserved_token, _stored_ttl, state = _reservation_parts(
+        existing
+    )
+    if not _owns_reservation(
+        reserved_fp, reserved_token, fingerprint=fingerprint, token=token
+    ):
+        return False
+    if state == UNKNOWN:
+        return False
+    if isinstance(existing, Reservation):
+        existing.state = SETTLING
+        existing.timestamp = now
+        return True
+    if isinstance(existing, MutableMapping):
+        existing["state"] = SETTLING
+        existing["timestamp"] = now
+        return True
+    return False
+
+
+def mark_outcome_unknown(
+    reservations: MutableMapping[str, Any],
+    *,
+    payment_id: str,
+    fingerprint: str,
+    now: float,
+    ttl_seconds: float = RESERVATION_TTL_SECONDS,
+    token: str | None = None,
+) -> bool:
+    """Retain a tokenized outcome-unknown tombstone until the server TTL expires."""
+    del ttl_seconds  # Retained for call-site symmetry; exact token owns transition.
+    existing = reservations.get(payment_id)
+    if existing is None:
+        return False
+    _timestamp, reserved_fp, reserved_token, _stored_ttl, state = _reservation_parts(
+        existing
+    )
+    if not _owns_reservation(
+        reserved_fp, reserved_token, fingerprint=fingerprint, token=token
+    ):
+        return False
+    if state == UNKNOWN:
+        return False
+    if isinstance(existing, Reservation):
+        existing.state = UNKNOWN
+        existing.timestamp = now
+        return True
+    if isinstance(existing, MutableMapping):
+        existing["state"] = UNKNOWN
+        existing["timestamp"] = now
+        return True
+    return False
+
+
+def reservation_token_from_transport(transport_context: Any) -> str | None:
+    """Read the middleware token from a FastAPI SDK transport context.
+
+    FastAPIAdapter stores the Starlette request on ``adapter._request``.
+    Missing adapter or token is not fingerprint-only ownership.
+    """
+    request = getattr(transport_context, "request", None)
+    adapter = getattr(request, "adapter", None) if request is not None else None
+    raw = getattr(adapter, "_request", None)
+    if raw is None:
+        return None
+    state = getattr(raw, "state", None)
+    token = (
+        getattr(state, "x402_reservation_token", None) if state is not None else None
+    )
+    return str(token) if token else None
 
 
 def bind_payment_id(
@@ -209,7 +520,8 @@ def bind_payment_id(
     fingerprint: str,
     now: float,
     cache_ttl_seconds: float,
-    reservation_ttl_seconds: float,
+    reservation_ttl_seconds: float = RESERVATION_TTL_SECONDS,
+    max_pending: int = MAX_PENDING_RESERVATIONS,
 ) -> CacheDecision:
     """Settled cache first, then in-flight reservation. Never grants on reserve."""
     decision = lookup(
@@ -229,4 +541,5 @@ def bind_payment_id(
         fingerprint=fingerprint,
         now=now,
         ttl_seconds=reservation_ttl_seconds,
+        max_pending=max_pending,
     )

--- a/examples/python/servers/payment-identifier/test_lifecycle.py
+++ b/examples/python/servers/payment-identifier/test_lifecycle.py
@@ -1,0 +1,382 @@
+"""Harnessed FastAPI request lifecycle for payment-identifier reservations.
+
+Uses the SDK FastAPIAdapter so the middleware token must reach hook context.
+No wallet, chain, or facilitator.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import unittest
+
+from fastapi import FastAPI, Request, Response
+from fastapi.testclient import TestClient
+from x402.http.middleware.fastapi import FastAPIAdapter
+from x402.http.types import HTTPRequestContext, HTTPTransportContext
+
+from request_binding import (
+    PENDING,
+    RESERVATION_TTL_SECONDS,
+    UNKNOWN,
+    Reservation,
+    bind_payment_id,
+    consume_reservation,
+    is_protected_route,
+    mark_outcome_unknown,
+    mark_settlement_started,
+    release_if_pending,
+    request_fingerprint,
+    reservation_token_from_transport,
+)
+
+PAYMENT_ID = "pay_aaaaaaaaaaaaaaaa"
+PAID_ROUTES = {"GET /weather": object()}
+PAYLOAD = {
+    "x402Version": 2,
+    "accepted": {
+        "scheme": "exact",
+        "network": "eip155:84532",
+        "asset": "0x0000000000000000000000000000000000000001",
+        "amount": "1000",
+        "payTo": "0x0000000000000000000000000000000000000002",
+        "maxTimeoutSeconds": 300,
+    },
+    "payload": {"signature": "0xsig"},
+    "extensions": {
+        "payment-identifier": {"info": {"id": PAYMENT_ID, "required": False}},
+    },
+}
+
+
+def encode_header(payload: dict) -> str:
+    return base64.b64encode(json.dumps(payload).encode("utf-8")).decode("ascii")
+
+
+def build_app() -> tuple[FastAPI, dict, dict, dict]:
+    cache: dict = {}
+    reservations: dict = {}
+    seen: dict = {}
+    app = FastAPI()
+
+    @app.middleware("http")
+    async def payment_stub(request: Request, call_next):  # type: ignore[no-untyped-def]
+        adapter = FastAPIAdapter(request)
+        transport = HTTPTransportContext(
+            request=HTTPRequestContext(
+                adapter=adapter,
+                path=request.url.path,
+                method=request.method,
+            )
+        )
+        token = reservation_token_from_transport(transport)
+        seen["token"] = token
+        scenario = request.headers.get("x-test-scenario", "no-match")
+        fingerprint = request_fingerprint(
+            method=request.method,
+            url=str(request.url),
+            body=b"",
+            payload=PAYLOAD,
+        )
+        if request.url.path != "/weather":
+            return await call_next(request)
+        if scenario == "verify-fail":
+            seen["phase"] = "verify-fail"
+            if token:
+                release_if_pending(
+                    reservations,
+                    payment_id=PAYMENT_ID,
+                    fingerprint=fingerprint,
+                    now=1.0,
+                    ttl_seconds=RESERVATION_TTL_SECONDS,
+                    token=token,
+                )
+            return Response(status_code=402, content=b'{"error":"verify"}')
+        if scenario == "settle-throw":
+            seen["phase"] = "before-settle"
+            if token:
+                mark_settlement_started(
+                    reservations,
+                    payment_id=PAYMENT_ID,
+                    fingerprint=fingerprint,
+                    now=1.0,
+                    ttl_seconds=RESERVATION_TTL_SECONDS,
+                    token=token,
+                )
+                mark_outcome_unknown(
+                    reservations,
+                    payment_id=PAYMENT_ID,
+                    fingerprint=fingerprint,
+                    now=1.0,
+                    ttl_seconds=RESERVATION_TTL_SECONDS,
+                    token=token,
+                )
+            return Response(status_code=402, content=b'{"error":"settle-unknown"}')
+        if scenario in ("settle-ok", "reservation-lost"):
+            seen["phase"] = "after-settle"
+            if token:
+                started = mark_settlement_started(
+                    reservations,
+                    payment_id=PAYMENT_ID,
+                    fingerprint=fingerprint,
+                    now=1.0,
+                    ttl_seconds=RESERVATION_TTL_SECONDS,
+                    token=token,
+                )
+                if not started:
+                    seen["aborted"] = True
+                    return Response(
+                        status_code=409,
+                        content=b'{"error":"payment_identifier_reservation_lost"}',
+                    )
+                seen["settled"] = True
+                consumed = consume_reservation(
+                    reservations,
+                    payment_id=PAYMENT_ID,
+                    fingerprint=fingerprint,
+                    now=1.0,
+                    ttl_seconds=RESERVATION_TTL_SECONDS,
+                    token=token,
+                )
+                if consumed:
+                    cache[PAYMENT_ID] = {
+                        "timestamp": 1.0,
+                        "fingerprint": consumed,
+                        "response": {"report": {"weather": "sunny", "cached": False}},
+                    }
+            return Response(
+                status_code=200,
+                content=b'{"report":{"weather":"sunny","cached":false}}',
+            )
+        seen["phase"] = "no-match"
+        return Response(status_code=402, content=b'{"error":"no matching requirement"}')
+
+    @app.middleware("http")
+    async def idempotency(request: Request, call_next):  # type: ignore[no-untyped-def]
+        header = request.headers.get("payment-signature") or request.headers.get(
+            "x-payment"
+        )
+        reserved_token = None
+        reserved_fp = None
+        if header and is_protected_route(request.method, str(request.url), PAID_ROUTES):
+            fingerprint = request_fingerprint(
+                method=request.method,
+                url=str(request.url),
+                body=b"",
+                payload=PAYLOAD,
+            )
+            try:
+                if request.headers.get("x-test-scenario") == "storage-fail":
+                    raise RuntimeError("injected storage failure")
+                decision = bind_payment_id(
+                    cache,
+                    reservations,
+                    payment_id=PAYMENT_ID,
+                    fingerprint=fingerprint,
+                    now=0.0,
+                    cache_ttl_seconds=3600.0,
+                    reservation_ttl_seconds=RESERVATION_TTL_SECONDS,
+                )
+            except Exception:  # noqa: BLE001 - injected storage boundary
+                seen["storage_failed"] = True
+                return Response(
+                    status_code=503,
+                    content=json.dumps(
+                        {
+                            "error": "payment identifier storage unavailable",
+                            "retryable": True,
+                        }
+                    ),
+                    media_type="application/json",
+                    headers={"Retry-After": "1"},
+                )
+            if decision.kind == "hit":
+                return Response(
+                    status_code=200,
+                    content=json.dumps(
+                        {
+                            "report": {
+                                **cache[PAYMENT_ID]["response"]["report"],
+                                "cached": True,
+                            }
+                        }
+                    ),
+                    media_type="application/json",
+                )
+            if decision.kind in ("conflict", "in_flight", "capacity"):
+                return Response(
+                    status_code=decision.status_code or 409,
+                    content=json.dumps({"kind": decision.kind}),
+                    media_type="application/json",
+                )
+            reserved = reservations.get(PAYMENT_ID)
+            if reserved is not None and reserved.fingerprint == fingerprint:
+                request.state.x402_reservation_token = reserved.token
+                reserved_token = reserved.token
+                reserved_fp = fingerprint
+                if request.headers.get("x-test-scenario") == "reservation-lost":
+                    reservations[PAYMENT_ID] = Reservation(
+                        fingerprint=reserved.fingerprint,
+                        timestamp=reserved.timestamp,
+                        token="replacement-token",
+                        ttl_seconds=reserved.ttl_seconds,
+                        state=PENDING,
+                    )
+        response = await call_next(request)
+        if reserved_token and reserved_fp:
+            release_if_pending(
+                reservations,
+                payment_id=PAYMENT_ID,
+                fingerprint=reserved_fp,
+                now=2.0,
+                ttl_seconds=RESERVATION_TTL_SECONDS,
+                token=reserved_token,
+            )
+        return response
+
+    @app.get("/health")
+    async def health() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.get("/weather")
+    async def weather() -> dict[str, str]:
+        return {"weather": "sunny"}
+
+    return app, cache, reservations, seen
+
+
+class FastAPILifecycle(unittest.TestCase):
+    def setUp(self) -> None:
+        self.app, self.cache, self.reservations, self.seen = build_app()
+        self.client = TestClient(self.app)
+        self.headers = {"payment-signature": encode_header(PAYLOAD)}
+
+    def test_unprotected_health_does_not_reserve(self) -> None:
+        response = self.client.get("/health", headers=self.headers)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self.reservations, {})
+        weather = self.client.get(
+            "/weather",
+            headers={**self.headers, "x-test-scenario": "settle-ok"},
+        )
+        self.assertEqual(weather.status_code, 200)
+        self.assertIn(PAYMENT_ID, self.cache)
+
+    def test_pre_settlement_rejection_releases_pending(self) -> None:
+        response = self.client.get(
+            "/weather",
+            headers={**self.headers, "x-test-scenario": "no-match"},
+        )
+        self.assertEqual(response.status_code, 402)
+        self.assertEqual(self.seen["phase"], "no-match")
+        self.assertTrue(self.seen["token"])
+        self.assertNotIn(PAYMENT_ID, self.reservations)
+
+    def test_token_reaches_before_settle_and_unknown_retention(self) -> None:
+        response = self.client.get(
+            "/weather",
+            headers={**self.headers, "x-test-scenario": "settle-throw"},
+        )
+        self.assertEqual(response.status_code, 402)
+        self.assertTrue(self.seen["token"])
+        self.assertEqual(self.reservations[PAYMENT_ID].state, UNKNOWN)
+        self.assertEqual(self.reservations[PAYMENT_ID].token, self.seen["token"])
+        retry = self.client.get(
+            "/weather",
+            headers={**self.headers, "x-test-scenario": "settle-ok"},
+        )
+        self.assertEqual(retry.status_code, 503)
+        self.assertNotIn(PAYMENT_ID, self.cache)
+
+    def test_successful_consume_caches(self) -> None:
+        response = self.client.get(
+            "/weather",
+            headers={**self.headers, "x-test-scenario": "settle-ok"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(self.seen["token"])
+        self.assertIn(PAYMENT_ID, self.cache)
+        self.assertNotIn(PAYMENT_ID, self.reservations)
+        hit = self.client.get(
+            "/weather",
+            headers={**self.headers, "x-test-scenario": "settle-ok"},
+        )
+        self.assertEqual(hit.status_code, 200)
+        self.assertTrue(hit.json()["report"]["cached"])
+
+    def test_verify_failure_is_pre_settlement_cleanup(self) -> None:
+        response = self.client.get(
+            "/weather",
+            headers={**self.headers, "x-test-scenario": "verify-fail"},
+        )
+        self.assertEqual(response.status_code, 402)
+        self.assertTrue(self.seen["token"])
+        self.assertNotIn(PAYMENT_ID, self.reservations)
+        self.assertEqual(self.reservations.get(PAYMENT_ID, PENDING), PENDING)
+
+    def test_stale_token_callback_does_not_mutate_replacement(self) -> None:
+        response = self.client.get(
+            "/weather",
+            headers={**self.headers, "x-test-scenario": "settle-throw"},
+        )
+        self.assertEqual(response.status_code, 402)
+        original = self.reservations[PAYMENT_ID]
+        stale_token = original.token
+        self.reservations[PAYMENT_ID] = Reservation(
+            fingerprint=original.fingerprint,
+            timestamp=original.timestamp,
+            token="token-replacement",
+            ttl_seconds=original.ttl_seconds,
+            state=PENDING,
+        )
+        self.assertIsNone(
+            consume_reservation(
+                self.reservations,
+                payment_id=PAYMENT_ID,
+                fingerprint=original.fingerprint,
+                now=1.0,
+                ttl_seconds=RESERVATION_TTL_SECONDS,
+                token=stale_token,
+            )
+        )
+        self.assertFalse(
+            release_if_pending(
+                self.reservations,
+                payment_id=PAYMENT_ID,
+                fingerprint=original.fingerprint,
+                now=1.0,
+                ttl_seconds=RESERVATION_TTL_SECONDS,
+                token=stale_token,
+            )
+        )
+        self.assertEqual(self.reservations[PAYMENT_ID].token, "token-replacement")
+        self.assertEqual(self.reservations[PAYMENT_ID].state, PENDING)
+
+    def test_lost_reservation_aborts_before_settlement(self) -> None:
+        response = self.client.get(
+            "/weather",
+            headers={**self.headers, "x-test-scenario": "reservation-lost"},
+        )
+        self.assertEqual(response.status_code, 409)
+        self.assertTrue(self.seen["aborted"])
+        self.assertFalse(self.seen.get("settled", False))
+        self.assertNotIn(PAYMENT_ID, self.cache)
+        self.assertEqual(self.reservations[PAYMENT_ID].token, "replacement-token")
+
+    def test_storage_failure_fails_closed_before_payment(self) -> None:
+        response = self.client.get(
+            "/weather",
+            headers={**self.headers, "x-test-scenario": "storage-fail"},
+        )
+        self.assertEqual(response.status_code, 503)
+        self.assertTrue(response.json()["retryable"])
+        self.assertEqual(response.headers["retry-after"], "1")
+        self.assertTrue(self.seen["storage_failed"])
+        self.assertNotIn("phase", self.seen)
+        self.assertFalse(self.seen.get("settled", False))
+        self.assertEqual(self.cache, {})
+        self.assertEqual(self.reservations, {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/python/servers/payment-identifier/test_request_binding.py
+++ b/examples/python/servers/payment-identifier/test_request_binding.py
@@ -1,0 +1,300 @@
+"""Credential-free tests for request-bound payment-identifier lookup.
+
+No wallet, chain, facilitator, or live payment.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from request_binding import (
+    RESERVATION_TTL_SECONDS,
+    Reservation,
+    bind_payment_id,
+    cleanup_expired_reservations,
+    consume_reservation,
+    lookup,
+    request_fingerprint,
+    try_reserve,
+)
+
+PAYMENT_ID = "pay_aaaaaaaaaaaaaaaa"
+TTL = 3600.0
+NOW = 1_000.0
+
+PAYLOAD = {
+    "x402Version": 2,
+    "accepted": {
+        "scheme": "exact",
+        "network": "eip155:84532",
+        "asset": "0x0000000000000000000000000000000000000001",
+        "amount": "1000",
+        "payTo": "0x0000000000000000000000000000000000000002",
+    },
+    "payload": {"signature": "0xsig"},
+    "extensions": {
+        "payment-identifier": {"info": {"id": PAYMENT_ID, "required": False}},
+    },
+}
+
+WEATHER = "http://localhost:4022/weather"
+FORECAST = "http://localhost:4022/forecast"
+
+
+def fp(*, method="GET", url=WEATHER, body=b"", payload=PAYLOAD) -> str:
+    return request_fingerprint(method=method, url=url, body=body, payload=payload)
+
+
+def cache_for(fingerprint: str) -> dict:
+    return {
+        PAYMENT_ID: {
+            "timestamp": NOW,
+            "fingerprint": fingerprint,
+            "response": {"report": {"weather": "sunny"}},
+        }
+    }
+
+
+def bind(cache, reservations, fingerprint, now=NOW + 1):
+    return bind_payment_id(
+        cache,
+        reservations,
+        payment_id=PAYMENT_ID,
+        fingerprint=fingerprint,
+        now=now,
+        cache_ttl_seconds=TTL,
+        reservation_ttl_seconds=RESERVATION_TTL_SECONDS,
+    )
+
+
+class RequestBoundLookup(unittest.TestCase):
+    def test_identical_retry_is_hit(self) -> None:
+        decision = lookup(
+            cache_for(fp()),
+            payment_id=PAYMENT_ID,
+            fingerprint=fp(),
+            now=NOW + 1,
+            ttl_seconds=TTL,
+        )
+        self.assertEqual(decision.kind, "hit")
+        self.assertEqual(decision.status_code, 200)
+        self.assertTrue(decision.grant_access)
+
+    def test_method_drift_is_409_without_access(self) -> None:
+        decision = lookup(
+            cache_for(fp(method="GET")),
+            payment_id=PAYMENT_ID,
+            fingerprint=fp(method="POST"),
+            now=NOW + 1,
+            ttl_seconds=TTL,
+        )
+        self.assertEqual(decision.status_code, 409)
+        self.assertFalse(decision.grant_access)
+
+    def test_path_drift_is_409_without_access(self) -> None:
+        decision = lookup(
+            cache_for(fp(url=WEATHER)),
+            payment_id=PAYMENT_ID,
+            fingerprint=fp(url=FORECAST),
+            now=NOW + 1,
+            ttl_seconds=TTL,
+        )
+        self.assertEqual(decision.status_code, 409)
+        self.assertFalse(decision.grant_access)
+
+    def test_body_drift_is_409_without_access(self) -> None:
+        decision = lookup(
+            cache_for(fp(body=b"")),
+            payment_id=PAYMENT_ID,
+            fingerprint=fp(body=b'{"city":"nyc"}'),
+            now=NOW + 1,
+            ttl_seconds=TTL,
+        )
+        self.assertEqual(decision.status_code, 409)
+        self.assertFalse(decision.grant_access)
+
+    def test_query_drift_is_409_without_access(self) -> None:
+        decision = lookup(
+            cache_for(fp(url=WEATHER)),
+            payment_id=PAYMENT_ID,
+            fingerprint=fp(url=WEATHER + "?city=nyc"),
+            now=NOW + 1,
+            ttl_seconds=TTL,
+        )
+        self.assertEqual(decision.status_code, 409)
+        self.assertFalse(decision.grant_access)
+
+    def test_terms_drift_is_409_without_access(self) -> None:
+        other = {**PAYLOAD, "accepted": {**PAYLOAD["accepted"], "amount": "999999"}}
+        decision = lookup(
+            cache_for(fp()),
+            payment_id=PAYMENT_ID,
+            fingerprint=fp(payload=other),
+            now=NOW + 1,
+            ttl_seconds=TTL,
+        )
+        self.assertEqual(decision.status_code, 409)
+        self.assertFalse(decision.grant_access)
+
+    def test_missing_fingerprint_is_conflict(self) -> None:
+        cache = {PAYMENT_ID: {"timestamp": NOW, "response": {}}}
+        decision = lookup(
+            cache,
+            payment_id=PAYMENT_ID,
+            fingerprint=fp(),
+            now=NOW + 1,
+            ttl_seconds=TTL,
+        )
+        self.assertEqual(decision.status_code, 409)
+        self.assertFalse(decision.grant_access)
+
+    def test_unknown_id_is_miss(self) -> None:
+        decision = lookup(
+            {}, payment_id=PAYMENT_ID, fingerprint=fp(), now=NOW, ttl_seconds=TTL
+        )
+        self.assertEqual(decision.kind, "miss")
+        self.assertFalse(decision.grant_access)
+
+    def test_query_param_order_is_stable(self) -> None:
+        self.assertEqual(fp(url=WEATHER + "?b=2&a=1"), fp(url=WEATHER + "?a=1&b=2"))
+
+    def test_duplicate_query_key_order_is_preserved(self) -> None:
+        self.assertNotEqual(fp(url=WEATHER + "?a=1&a=2"), fp(url=WEATHER + "?a=2&a=1"))
+
+
+class InFlightReservation(unittest.TestCase):
+    def test_same_id_same_request_is_in_flight(self) -> None:
+        cache: dict = {}
+        reservations: dict = {}
+        first = bind(cache, reservations, fp())
+        second = bind(cache, reservations, fp())
+        self.assertEqual(first.kind, "miss")
+        self.assertEqual(second.kind, "in_flight")
+        self.assertEqual(second.status_code, 409)
+        self.assertFalse(second.grant_access)
+        self.assertEqual(reservations[PAYMENT_ID].fingerprint, fp())
+
+    def test_same_id_different_request_is_conflict(self) -> None:
+        cache: dict = {}
+        reservations: dict = {}
+        first = bind(cache, reservations, fp(url=WEATHER))
+        second = bind(cache, reservations, fp(url=FORECAST))
+        self.assertEqual(first.kind, "miss")
+        self.assertEqual(second.kind, "conflict")
+        self.assertEqual(second.status_code, 409)
+        self.assertFalse(second.grant_access)
+
+    def test_live_reservation_is_not_overwritten(self) -> None:
+        reservations: dict = {}
+        first_fp = fp(url=WEATHER)
+        second_fp = fp(url=FORECAST)
+        try_reserve(
+            reservations,
+            payment_id=PAYMENT_ID,
+            fingerprint=first_fp,
+            now=NOW,
+            ttl_seconds=RESERVATION_TTL_SECONDS,
+        )
+        try_reserve(
+            reservations,
+            payment_id=PAYMENT_ID,
+            fingerprint=second_fp,
+            now=NOW + 1,
+            ttl_seconds=RESERVATION_TTL_SECONDS,
+        )
+        self.assertEqual(reservations[PAYMENT_ID].fingerprint, first_fp)
+        self.assertEqual(
+            consume_reservation(
+                reservations,
+                payment_id=PAYMENT_ID,
+                now=NOW + 2,
+                ttl_seconds=RESERVATION_TTL_SECONDS,
+            ),
+            first_fp,
+        )
+
+    def test_failed_payment_reservation_expires(self) -> None:
+        reservations: dict = {}
+        first = try_reserve(
+            reservations,
+            payment_id=PAYMENT_ID,
+            fingerprint=fp(),
+            now=NOW,
+            ttl_seconds=RESERVATION_TTL_SECONDS,
+        )
+        self.assertEqual(first.kind, "miss")
+        blocked = try_reserve(
+            reservations,
+            payment_id=PAYMENT_ID,
+            fingerprint=fp(),
+            now=NOW + 1,
+            ttl_seconds=RESERVATION_TTL_SECONDS,
+        )
+        self.assertEqual(blocked.kind, "in_flight")
+        removed = cleanup_expired_reservations(
+            reservations,
+            now=NOW + RESERVATION_TTL_SECONDS,
+            ttl_seconds=RESERVATION_TTL_SECONDS,
+        )
+        self.assertEqual(removed, 1)
+        self.assertNotIn(PAYMENT_ID, reservations)
+        retry = try_reserve(
+            reservations,
+            payment_id=PAYMENT_ID,
+            fingerprint=fp(),
+            now=NOW + RESERVATION_TTL_SECONDS,
+            ttl_seconds=RESERVATION_TTL_SECONDS,
+        )
+        self.assertEqual(retry.kind, "miss")
+        self.assertFalse(retry.grant_access)
+
+    def test_missing_reservation_at_settle_does_not_cache(self) -> None:
+        fingerprint = consume_reservation(
+            {},
+            payment_id=PAYMENT_ID,
+            now=NOW,
+            ttl_seconds=RESERVATION_TTL_SECONDS,
+        )
+        self.assertIsNone(fingerprint)
+
+    def test_expired_reservation_at_settle_does_not_cache(self) -> None:
+        reservations = {
+            PAYMENT_ID: Reservation(fingerprint=fp(), timestamp=NOW),
+        }
+        fingerprint = consume_reservation(
+            reservations,
+            payment_id=PAYMENT_ID,
+            now=NOW + RESERVATION_TTL_SECONDS,
+            ttl_seconds=RESERVATION_TTL_SECONDS,
+        )
+        self.assertIsNone(fingerprint)
+        self.assertNotIn(PAYMENT_ID, reservations)
+
+    def test_settled_retry_is_hit(self) -> None:
+        cache: dict = {}
+        reservations: dict = {}
+        first = bind(cache, reservations, fp())
+        self.assertEqual(first.kind, "miss")
+        stored = consume_reservation(
+            reservations,
+            payment_id=PAYMENT_ID,
+            now=NOW + 2,
+            ttl_seconds=RESERVATION_TTL_SECONDS,
+        )
+        self.assertEqual(stored, fp())
+        cache[PAYMENT_ID] = {
+            "timestamp": NOW + 2,
+            "fingerprint": stored,
+            "response": {"report": {"weather": "sunny"}},
+        }
+        leftover = Reservation(fingerprint=fp(url=FORECAST), timestamp=NOW + 2)
+        reservations[PAYMENT_ID] = leftover
+        retry = bind(cache, reservations, fp(), now=NOW + 3)
+        self.assertEqual(retry.kind, "hit")
+        self.assertEqual(retry.status_code, 200)
+        self.assertTrue(retry.grant_access)
+        self.assertEqual(reservations[PAYMENT_ID], leftover)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/python/servers/payment-identifier/test_request_binding.py
+++ b/examples/python/servers/payment-identifier/test_request_binding.py
@@ -5,22 +5,56 @@ No wallet, chain, facilitator, or live payment.
 
 from __future__ import annotations
 
+import json
 import unittest
+from pathlib import Path
 
 from request_binding import (
+    CAPACITY,
+    CONFLICT,
+    CONFLICT_STATUS_CODE,
+    FALLBACK_RESERVATION_TTL_SECONDS,
+    HIT,
+    IN_FLIGHT,
+    MAX_PENDING_RESERVATIONS,
+    PENDING,
     RESERVATION_TTL_SECONDS,
+    RETRYABLE_STATUS_CODE,
+    UNKNOWN,
     Reservation,
     bind_payment_id,
+    canonical_accepted_extra,
+    canonical_max_timeout_seconds,
+    canonical_request_url,
     cleanup_expired_reservations,
     consume_reservation,
+    is_protected_route,
     lookup,
+    mark_outcome_unknown,
+    mark_settlement_started,
+    release_if_pending,
+    release_reservation,
     request_fingerprint,
+    reservation_ttl_seconds,
     try_reserve,
 )
 
 PAYMENT_ID = "pay_aaaaaaaaaaaaaaaa"
 TTL = 3600.0
 NOW = 1_000.0
+CANONICAL_SAME_REQUEST_FINGERPRINT = (
+    "3be3051236cf413f1cb88528fa8d9a7f22de774366f31fa7f319b972e943cc3f"
+)
+CANONICAL_EXTRA_FINGERPRINT = (
+    "0565bb0ee3d8210ff27002b3c8e0748a570362835e1ef44186e1d4c967f2cf8c"
+)
+QUERY_FIXTURES = json.loads(
+    (
+        Path(__file__).resolve().parents[3]
+        / "shared"
+        / "payment-identifier-query-fixtures.json"
+    ).read_text(encoding="utf-8")
+)
 
 PAYLOAD = {
     "x402Version": 2,
@@ -55,6 +89,18 @@ def cache_for(fingerprint: str) -> dict:
     }
 
 
+def stored(fingerprint: str, **overrides: object) -> Reservation:
+    values = {
+        "fingerprint": fingerprint,
+        "timestamp": NOW,
+        "token": "token-a",
+        "ttl_seconds": RESERVATION_TTL_SECONDS,
+        "state": PENDING,
+    }
+    values.update(overrides)
+    return Reservation(**values)  # type: ignore[arg-type]
+
+
 def bind(cache, reservations, fingerprint, now=NOW + 1):
     return bind_payment_id(
         cache,
@@ -76,7 +122,7 @@ class RequestBoundLookup(unittest.TestCase):
             now=NOW + 1,
             ttl_seconds=TTL,
         )
-        self.assertEqual(decision.kind, "hit")
+        self.assertEqual(decision.kind, HIT)
         self.assertEqual(decision.status_code, 200)
         self.assertTrue(decision.grant_access)
 
@@ -136,6 +182,19 @@ class RequestBoundLookup(unittest.TestCase):
         self.assertEqual(decision.status_code, 409)
         self.assertFalse(decision.grant_access)
 
+    def test_credential_drift_is_409_without_access(self) -> None:
+        other = {**PAYLOAD, "payload": {"signature": "0xforged"}}
+        decision = lookup(
+            cache_for(fp()),
+            payment_id=PAYMENT_ID,
+            fingerprint=fp(payload=other),
+            now=NOW + 1,
+            ttl_seconds=TTL,
+        )
+        self.assertEqual(decision.status_code, 409)
+        self.assertFalse(decision.grant_access)
+        self.assertNotEqual(fp(), fp(payload=other))
+
     def test_missing_fingerprint_is_conflict(self) -> None:
         cache = {PAYMENT_ID: {"timestamp": NOW, "response": {}}}
         decision = lookup(
@@ -169,8 +228,8 @@ class InFlightReservation(unittest.TestCase):
         first = bind(cache, reservations, fp())
         second = bind(cache, reservations, fp())
         self.assertEqual(first.kind, "miss")
-        self.assertEqual(second.kind, "in_flight")
-        self.assertEqual(second.status_code, 409)
+        self.assertEqual(second.kind, IN_FLIGHT)
+        self.assertEqual(second.status_code, RETRYABLE_STATUS_CODE)
         self.assertFalse(second.grant_access)
         self.assertEqual(reservations[PAYMENT_ID].fingerprint, fp())
 
@@ -180,8 +239,8 @@ class InFlightReservation(unittest.TestCase):
         first = bind(cache, reservations, fp(url=WEATHER))
         second = bind(cache, reservations, fp(url=FORECAST))
         self.assertEqual(first.kind, "miss")
-        self.assertEqual(second.kind, "conflict")
-        self.assertEqual(second.status_code, 409)
+        self.assertEqual(second.kind, CONFLICT)
+        self.assertEqual(second.status_code, CONFLICT_STATUS_CODE)
         self.assertFalse(second.grant_access)
 
     def test_live_reservation_is_not_overwritten(self) -> None:
@@ -195,6 +254,7 @@ class InFlightReservation(unittest.TestCase):
             now=NOW,
             ttl_seconds=RESERVATION_TTL_SECONDS,
         )
+        token = reservations[PAYMENT_ID].token
         try_reserve(
             reservations,
             payment_id=PAYMENT_ID,
@@ -207,8 +267,10 @@ class InFlightReservation(unittest.TestCase):
             consume_reservation(
                 reservations,
                 payment_id=PAYMENT_ID,
+                fingerprint=first_fp,
                 now=NOW + 2,
                 ttl_seconds=RESERVATION_TTL_SECONDS,
+                token=token,
             ),
             first_fp,
         )
@@ -230,7 +292,7 @@ class InFlightReservation(unittest.TestCase):
             now=NOW + 1,
             ttl_seconds=RESERVATION_TTL_SECONDS,
         )
-        self.assertEqual(blocked.kind, "in_flight")
+        self.assertEqual(blocked.kind, IN_FLIGHT)
         removed = cleanup_expired_reservations(
             reservations,
             now=NOW + RESERVATION_TTL_SECONDS,
@@ -252,22 +314,24 @@ class InFlightReservation(unittest.TestCase):
         fingerprint = consume_reservation(
             {},
             payment_id=PAYMENT_ID,
+            fingerprint=fp(),
             now=NOW,
             ttl_seconds=RESERVATION_TTL_SECONDS,
+            token="token-a",
         )
         self.assertIsNone(fingerprint)
 
-    def test_expired_reservation_at_settle_does_not_cache(self) -> None:
-        reservations = {
-            PAYMENT_ID: Reservation(fingerprint=fp(), timestamp=NOW),
-        }
+    def test_expired_current_reservation_can_cache_if_not_replaced(self) -> None:
+        reservations = {PAYMENT_ID: stored(fp())}
         fingerprint = consume_reservation(
             reservations,
             payment_id=PAYMENT_ID,
+            fingerprint=fp(),
             now=NOW + RESERVATION_TTL_SECONDS,
             ttl_seconds=RESERVATION_TTL_SECONDS,
+            token="token-a",
         )
-        self.assertIsNone(fingerprint)
+        self.assertEqual(fingerprint, fp())
         self.assertNotIn(PAYMENT_ID, reservations)
 
     def test_settled_retry_is_hit(self) -> None:
@@ -275,25 +339,546 @@ class InFlightReservation(unittest.TestCase):
         reservations: dict = {}
         first = bind(cache, reservations, fp())
         self.assertEqual(first.kind, "miss")
-        stored = consume_reservation(
+        token = reservations[PAYMENT_ID].token
+        stored_fp = consume_reservation(
             reservations,
             payment_id=PAYMENT_ID,
+            fingerprint=fp(),
             now=NOW + 2,
             ttl_seconds=RESERVATION_TTL_SECONDS,
+            token=token,
         )
-        self.assertEqual(stored, fp())
+        self.assertEqual(stored_fp, fp())
         cache[PAYMENT_ID] = {
             "timestamp": NOW + 2,
-            "fingerprint": stored,
+            "fingerprint": stored_fp,
             "response": {"report": {"weather": "sunny"}},
         }
-        leftover = Reservation(fingerprint=fp(url=FORECAST), timestamp=NOW + 2)
+        leftover = stored(fp(url=FORECAST), timestamp=NOW + 2, token="token-b")
         reservations[PAYMENT_ID] = leftover
         retry = bind(cache, reservations, fp(), now=NOW + 3)
-        self.assertEqual(retry.kind, "hit")
+        self.assertEqual(retry.kind, HIT)
         self.assertEqual(retry.status_code, 200)
         self.assertTrue(retry.grant_access)
         self.assertEqual(reservations[PAYMENT_ID], leftover)
+
+
+PAID_ROUTES = {"GET /weather": object()}
+
+
+class ProtectedRoute(unittest.TestCase):
+    def test_weather_is_protected(self) -> None:
+        self.assertTrue(is_protected_route("GET", WEATHER, PAID_ROUTES))
+        self.assertTrue(is_protected_route("GET", "/weather?city=nyc", PAID_ROUTES))
+
+    def test_health_is_not_protected(self) -> None:
+        self.assertFalse(
+            is_protected_route("GET", "http://localhost:4022/health", PAID_ROUTES)
+        )
+
+    def test_unmatched_path_is_not_protected(self) -> None:
+        self.assertFalse(is_protected_route("GET", "/not-a-paid-route", PAID_ROUTES))
+
+    def test_unprotected_header_cannot_block_paid_route(self) -> None:
+        cache: dict = {}
+        reservations: dict = {}
+        health_fp = fp(url="http://localhost:4022/health")
+        self.assertFalse(
+            is_protected_route("GET", "http://localhost:4022/health", PAID_ROUTES)
+        )
+        self.assertNotIn(PAYMENT_ID, reservations)
+        weather = bind(cache, reservations, fp())
+        self.assertEqual(weather.kind, "miss")
+        self.assertEqual(reservations[PAYMENT_ID].fingerprint, fp())
+        self.assertNotEqual(health_fp, fp())
+
+
+class ReservationRelease(unittest.TestCase):
+    def test_verify_failure_releases_matching_reservation(self) -> None:
+        reservations: dict = {}
+        try_reserve(
+            reservations,
+            payment_id=PAYMENT_ID,
+            fingerprint=fp(),
+            now=NOW,
+            ttl_seconds=RESERVATION_TTL_SECONDS,
+        )
+        token = reservations[PAYMENT_ID].token
+        released = release_reservation(
+            reservations,
+            payment_id=PAYMENT_ID,
+            fingerprint=fp(),
+            now=NOW + 1,
+            ttl_seconds=RESERVATION_TTL_SECONDS,
+            token=token,
+        )
+        self.assertTrue(released)
+        self.assertNotIn(PAYMENT_ID, reservations)
+        retry = try_reserve(
+            reservations,
+            payment_id=PAYMENT_ID,
+            fingerprint=fp(),
+            now=NOW + 2,
+            ttl_seconds=RESERVATION_TTL_SECONDS,
+        )
+        self.assertEqual(retry.kind, "miss")
+
+    def test_stale_failure_does_not_drop_replacement(self) -> None:
+        replacement = stored(fp(url=FORECAST), timestamp=NOW + 1, token="token-b")
+        reservations = {PAYMENT_ID: replacement}
+        dropped = release_reservation(
+            reservations,
+            payment_id=PAYMENT_ID,
+            fingerprint=fp(),
+            now=NOW + 2,
+            ttl_seconds=RESERVATION_TTL_SECONDS,
+            token="token-a",
+        )
+        self.assertFalse(dropped)
+        self.assertEqual(reservations[PAYMENT_ID], replacement)
+
+    def test_stale_settle_does_not_consume_replacement(self) -> None:
+        first_fp = fp()
+        replacement_fp = fp(url=FORECAST)
+        reservations = {
+            PAYMENT_ID: stored(replacement_fp, timestamp=NOW + 1, token="token-b")
+        }
+        stolen = consume_reservation(
+            reservations,
+            payment_id=PAYMENT_ID,
+            fingerprint=first_fp,
+            now=NOW + 2,
+            ttl_seconds=RESERVATION_TTL_SECONDS,
+            token="token-a",
+        )
+        self.assertIsNone(stolen)
+        self.assertEqual(reservations[PAYMENT_ID].fingerprint, replacement_fp)
+
+    def test_settle_after_expiry_does_not_cache_replacement(self) -> None:
+        replacement = stored(
+            fp(url=FORECAST),
+            timestamp=NOW + RESERVATION_TTL_SECONDS,
+            token="token-b",
+        )
+        reservations = {PAYMENT_ID: replacement}
+        cached = consume_reservation(
+            reservations,
+            payment_id=PAYMENT_ID,
+            fingerprint=fp(),
+            now=NOW + RESERVATION_TTL_SECONDS + 1,
+            ttl_seconds=RESERVATION_TTL_SECONDS,
+            token="token-a",
+        )
+        self.assertIsNone(cached)
+        self.assertEqual(reservations[PAYMENT_ID], replacement)
+
+    def test_same_fingerprint_replacement_requires_token(self) -> None:
+        reservations = {
+            PAYMENT_ID: stored(
+                fp(), timestamp=NOW + RESERVATION_TTL_SECONDS, token="token-b"
+            )
+        }
+        stolen = consume_reservation(
+            reservations,
+            payment_id=PAYMENT_ID,
+            fingerprint=fp(),
+            now=NOW + RESERVATION_TTL_SECONDS + 1,
+            ttl_seconds=RESERVATION_TTL_SECONDS,
+            token="token-a",
+        )
+        self.assertIsNone(stolen)
+        self.assertIn(PAYMENT_ID, reservations)
+
+    def test_missing_token_is_not_fingerprint_ownership(self) -> None:
+        reservations = {PAYMENT_ID: stored(fp(), token="token-b")}
+        self.assertFalse(
+            release_reservation(
+                reservations,
+                payment_id=PAYMENT_ID,
+                fingerprint=fp(),
+                now=NOW + 1,
+                ttl_seconds=RESERVATION_TTL_SECONDS,
+            )
+        )
+        self.assertIsNone(
+            consume_reservation(
+                reservations,
+                payment_id=PAYMENT_ID,
+                fingerprint=fp(),
+                now=NOW + 1,
+                ttl_seconds=RESERVATION_TTL_SECONDS,
+            )
+        )
+        self.assertFalse(
+            mark_outcome_unknown(
+                reservations,
+                payment_id=PAYMENT_ID,
+                fingerprint=fp(),
+                now=NOW + 1,
+                ttl_seconds=RESERVATION_TTL_SECONDS,
+                token="token-a",
+            )
+        )
+        self.assertFalse(
+            mark_settlement_started(
+                reservations,
+                payment_id=PAYMENT_ID,
+                fingerprint=fp(),
+                now=NOW + 1,
+                ttl_seconds=RESERVATION_TTL_SECONDS,
+                token="token-a",
+            )
+        )
+        self.assertEqual(reservations[PAYMENT_ID].token, "token-b")
+        self.assertEqual(reservations[PAYMENT_ID].timestamp, NOW)
+
+
+class ReservationTtl(unittest.TestCase):
+    def test_exact_current_token_enters_settlement_after_prior_deadline(self) -> None:
+        reservations: dict = {}
+        try_reserve(
+            reservations,
+            payment_id=PAYMENT_ID,
+            fingerprint=fp(),
+            now=NOW,
+            ttl_seconds=RESERVATION_TTL_SECONDS,
+        )
+        token = reservations[PAYMENT_ID].token
+        settlement_started = NOW + RESERVATION_TTL_SECONDS + 1
+        self.assertTrue(
+            mark_settlement_started(
+                reservations,
+                payment_id=PAYMENT_ID,
+                fingerprint=fp(),
+                now=settlement_started,
+                ttl_seconds=RESERVATION_TTL_SECONDS,
+                token=token,
+            )
+        )
+        self.assertEqual(reservations[PAYMENT_ID].timestamp, settlement_started)
+        self.assertEqual(
+            consume_reservation(
+                reservations,
+                payment_id=PAYMENT_ID,
+                fingerprint=fp(),
+                now=settlement_started + RESERVATION_TTL_SECONDS + 1,
+                ttl_seconds=RESERVATION_TTL_SECONDS,
+                token=token,
+            ),
+            fp(),
+        )
+        self.assertNotIn(PAYMENT_ID, reservations)
+
+    def test_unknown_transition_refreshes_full_window_after_original_deadline(
+        self,
+    ) -> None:
+        reservations: dict = {}
+        try_reserve(
+            reservations,
+            payment_id=PAYMENT_ID,
+            fingerprint=fp(),
+            now=NOW,
+            ttl_seconds=RESERVATION_TTL_SECONDS,
+        )
+        token = reservations[PAYMENT_ID].token
+        settlement_started = NOW + RESERVATION_TTL_SECONDS - 1
+        outcome_unknown = settlement_started + RESERVATION_TTL_SECONDS + 1
+        self.assertTrue(
+            mark_settlement_started(
+                reservations,
+                payment_id=PAYMENT_ID,
+                fingerprint=fp(),
+                now=settlement_started,
+                ttl_seconds=RESERVATION_TTL_SECONDS,
+                token=token,
+            )
+        )
+        self.assertTrue(
+            mark_outcome_unknown(
+                reservations,
+                payment_id=PAYMENT_ID,
+                fingerprint=fp(),
+                now=outcome_unknown,
+                ttl_seconds=RESERVATION_TTL_SECONDS,
+                token=token,
+            )
+        )
+        self.assertEqual(reservations[PAYMENT_ID].timestamp, outcome_unknown)
+        other = fp(payload={**PAYLOAD, "payload": {"signature": "0xforged"}})
+        self.assertEqual(
+            try_reserve(
+                reservations,
+                payment_id=PAYMENT_ID,
+                fingerprint=other,
+                now=outcome_unknown + RESERVATION_TTL_SECONDS - 1,
+                ttl_seconds=RESERVATION_TTL_SECONDS,
+            ).kind,
+            CONFLICT,
+        )
+
+    def test_tiny_client_timeout_does_not_set_map_ttl(self) -> None:
+        payload = {
+            **PAYLOAD,
+            "accepted": {**PAYLOAD["accepted"], "maxTimeoutSeconds": 1},
+        }
+        reservations: dict = {}
+        try_reserve(
+            reservations,
+            payment_id=PAYMENT_ID,
+            fingerprint=fp(payload=payload),
+            now=NOW,
+            ttl_seconds=reservation_ttl_seconds(payload),
+        )
+        blocked = try_reserve(
+            reservations,
+            payment_id=PAYMENT_ID,
+            fingerprint=fp(payload=payload),
+            now=NOW + 2,
+            ttl_seconds=reservation_ttl_seconds(payload),
+        )
+        self.assertEqual(blocked.kind, IN_FLIGHT)
+        self.assertEqual(reservation_ttl_seconds(payload), RESERVATION_TTL_SECONDS)
+        self.assertEqual(FALLBACK_RESERVATION_TTL_SECONDS, 300.0)
+
+    def test_huge_client_timeout_does_not_extend_map_ttl(self) -> None:
+        payload = {
+            **PAYLOAD,
+            "accepted": {**PAYLOAD["accepted"], "maxTimeoutSeconds": 1_000_000},
+        }
+        reservations: dict = {}
+        try_reserve(
+            reservations,
+            payment_id=PAYMENT_ID,
+            fingerprint=fp(payload=payload),
+            now=NOW,
+            ttl_seconds=reservation_ttl_seconds(payload),
+        )
+        removed = cleanup_expired_reservations(
+            reservations,
+            now=NOW + RESERVATION_TTL_SECONDS,
+            ttl_seconds=reservation_ttl_seconds(payload),
+        )
+        self.assertEqual(removed, 1)
+        self.assertNotIn(PAYMENT_ID, reservations)
+
+    def test_expires_only_after_server_owned_ttl(self) -> None:
+        reservations: dict = {}
+        try_reserve(
+            reservations,
+            payment_id=PAYMENT_ID,
+            fingerprint=fp(),
+            now=NOW,
+            ttl_seconds=RESERVATION_TTL_SECONDS,
+        )
+        self.assertEqual(
+            cleanup_expired_reservations(
+                reservations,
+                now=NOW + RESERVATION_TTL_SECONDS - 1,
+                ttl_seconds=RESERVATION_TTL_SECONDS,
+            ),
+            0,
+        )
+        self.assertEqual(
+            cleanup_expired_reservations(
+                reservations,
+                now=NOW + RESERVATION_TTL_SECONDS,
+                ttl_seconds=RESERVATION_TTL_SECONDS,
+            ),
+            1,
+        )
+
+
+class ReservationCapacity(unittest.TestCase):
+    def test_capacity_fails_closed_without_overwrite(self) -> None:
+        reservations: dict = {}
+        for index in range(MAX_PENDING_RESERVATIONS):
+            decision = try_reserve(
+                reservations,
+                payment_id=f"pay_{index:04d}",
+                fingerprint=fp(),
+                now=NOW,
+                ttl_seconds=RESERVATION_TTL_SECONDS,
+            )
+            self.assertEqual(decision.kind, "miss")
+        overflow = try_reserve(
+            reservations,
+            payment_id=PAYMENT_ID,
+            fingerprint=fp(),
+            now=NOW,
+            ttl_seconds=RESERVATION_TTL_SECONDS,
+        )
+        self.assertEqual(overflow.kind, CAPACITY)
+        self.assertEqual(overflow.status_code, RETRYABLE_STATUS_CODE)
+        self.assertFalse(overflow.grant_access)
+        self.assertEqual(len(reservations), MAX_PENDING_RESERVATIONS)
+        self.assertNotIn(PAYMENT_ID, reservations)
+
+    def test_capacity_recovers_after_expiry_cleanup(self) -> None:
+        reservations: dict = {}
+        for index in range(MAX_PENDING_RESERVATIONS):
+            try_reserve(
+                reservations,
+                payment_id=f"pay_{index:04d}",
+                fingerprint=fp(),
+                now=NOW,
+                ttl_seconds=RESERVATION_TTL_SECONDS,
+            )
+        retry = try_reserve(
+            reservations,
+            payment_id=PAYMENT_ID,
+            fingerprint=fp(),
+            now=NOW + RESERVATION_TTL_SECONDS,
+            ttl_seconds=RESERVATION_TTL_SECONDS,
+        )
+        self.assertEqual(retry.kind, "miss")
+        self.assertIn(PAYMENT_ID, reservations)
+
+
+class SettlementLifecycle(unittest.TestCase):
+    def test_pre_settlement_release_clears_pending(self) -> None:
+        reservations: dict = {}
+        try_reserve(
+            reservations,
+            payment_id=PAYMENT_ID,
+            fingerprint=fp(),
+            now=NOW,
+            ttl_seconds=RESERVATION_TTL_SECONDS,
+        )
+        token = reservations[PAYMENT_ID].token
+        self.assertTrue(
+            release_if_pending(
+                reservations,
+                payment_id=PAYMENT_ID,
+                fingerprint=fp(),
+                now=NOW + 1,
+                ttl_seconds=RESERVATION_TTL_SECONDS,
+                token=token,
+            )
+        )
+        self.assertNotIn(PAYMENT_ID, reservations)
+
+    def test_outcome_unknown_retains_tombstone(self) -> None:
+        reservations: dict = {}
+        try_reserve(
+            reservations,
+            payment_id=PAYMENT_ID,
+            fingerprint=fp(),
+            now=NOW,
+            ttl_seconds=RESERVATION_TTL_SECONDS,
+        )
+        token = reservations[PAYMENT_ID].token
+        self.assertTrue(
+            mark_settlement_started(
+                reservations,
+                payment_id=PAYMENT_ID,
+                fingerprint=fp(),
+                now=NOW + 1,
+                ttl_seconds=RESERVATION_TTL_SECONDS,
+                token=token,
+            )
+        )
+        self.assertTrue(
+            mark_outcome_unknown(
+                reservations,
+                payment_id=PAYMENT_ID,
+                fingerprint=fp(),
+                now=NOW + 2,
+                ttl_seconds=RESERVATION_TTL_SECONDS,
+                token=token,
+            )
+        )
+        self.assertEqual(reservations[PAYMENT_ID].state, UNKNOWN)
+        self.assertFalse(
+            release_if_pending(
+                reservations,
+                payment_id=PAYMENT_ID,
+                fingerprint=fp(),
+                now=NOW + 3,
+                ttl_seconds=RESERVATION_TTL_SECONDS,
+                token=token,
+            )
+        )
+        self.assertIsNone(
+            consume_reservation(
+                reservations,
+                payment_id=PAYMENT_ID,
+                fingerprint=fp(),
+                now=NOW + 3,
+                ttl_seconds=RESERVATION_TTL_SECONDS,
+                token=token,
+            )
+        )
+        other = fp(payload={**PAYLOAD, "payload": {"signature": "0xforged"}})
+        fresh = try_reserve(
+            reservations,
+            payment_id=PAYMENT_ID,
+            fingerprint=other,
+            now=NOW + 4,
+            ttl_seconds=RESERVATION_TTL_SECONDS,
+        )
+        self.assertEqual(fresh.kind, CONFLICT)
+        same = try_reserve(
+            reservations,
+            payment_id=PAYMENT_ID,
+            fingerprint=fp(),
+            now=NOW + 5,
+            ttl_seconds=RESERVATION_TTL_SECONDS,
+        )
+        self.assertEqual(same.kind, IN_FLIGHT)
+
+
+class AcceptedTermsFingerprint(unittest.TestCase):
+    def test_max_timeout_seconds_is_fingerprinted(self) -> None:
+        other = {
+            **PAYLOAD,
+            "accepted": {**PAYLOAD["accepted"], "maxTimeoutSeconds": 60},
+        }
+        self.assertNotEqual(fp(), fp(payload=other))
+        self.assertEqual(canonical_max_timeout_seconds(PAYLOAD["accepted"]), "")
+        self.assertEqual(canonical_max_timeout_seconds(other["accepted"]), "60")
+
+    def test_extra_is_recursively_canonical(self) -> None:
+        extra_a = {
+            **PAYLOAD,
+            "accepted": {**PAYLOAD["accepted"], "extra": {"z": 1, "a": {"b": 2}}},
+        }
+        extra_b = {
+            **PAYLOAD,
+            "accepted": {**PAYLOAD["accepted"], "extra": {"a": {"b": 2}, "z": 1}},
+        }
+        extra_c = {
+            **PAYLOAD,
+            "accepted": {**PAYLOAD["accepted"], "extra": {"z": 1, "a": {"b": 3}}},
+        }
+        self.assertEqual(fp(payload=extra_a), fp(payload=extra_b))
+        self.assertNotEqual(fp(payload=extra_a), fp(payload=extra_c))
+        self.assertEqual(
+            canonical_accepted_extra(extra_a["accepted"]),
+            '{"a":{"b":2},"z":1}',
+        )
+
+
+class CanonicalQueryEncoding(unittest.TestCase):
+    def test_shared_adversarial_fixtures(self) -> None:
+        for fixture in QUERY_FIXTURES:
+            with self.subTest(fixture["name"]):
+                self.assertEqual(
+                    canonical_request_url(fixture["url"]), fixture["canonical"]
+                )
+
+
+class CrossLanguageFixture(unittest.TestCase):
+    def test_canonical_same_request_fingerprint(self) -> None:
+        digest = fp(url=WEATHER + "?b=2&a=1")
+        self.assertEqual(fp(url=WEATHER + "?a=1&b=2"), digest)
+        self.assertEqual(digest, CANONICAL_SAME_REQUEST_FINGERPRINT)
+
+    def test_canonical_extra_fingerprint(self) -> None:
+        extra = {
+            **PAYLOAD,
+            "accepted": {**PAYLOAD["accepted"], "extra": {"z": 1, "a": {"b": 2}}},
+        }
+        self.assertEqual(fp(payload=extra), CANONICAL_EXTRA_FINGERPRINT)
 
 
 if __name__ == "__main__":

--- a/examples/shared/payment-identifier-query-fixtures.json
+++ b/examples/shared/payment-identifier-query-fixtures.json
@@ -1,0 +1,52 @@
+[
+  {
+    "name": "tilde-unreserved",
+    "url": "http://localhost:4022/weather?a=~",
+    "canonical": "/weather?a=~"
+  },
+  {
+    "name": "space-percent-20",
+    "url": "http://localhost:4022/weather?q=a%20b",
+    "canonical": "/weather?q=a%20b"
+  },
+  {
+    "name": "plus-decoded-as-space",
+    "url": "http://localhost:4022/weather?q=a+b",
+    "canonical": "/weather?q=a%20b"
+  },
+  {
+    "name": "unicode-checkmark",
+    "url": "http://localhost:4022/weather?q=%E2%9C%93",
+    "canonical": "/weather?q=%E2%9C%93"
+  },
+  {
+    "name": "empty-value",
+    "url": "http://localhost:4022/weather?a=",
+    "canonical": "/weather?a="
+  },
+  {
+    "name": "repeated-keys-stable",
+    "url": "http://localhost:4022/weather?a=1&a=2",
+    "canonical": "/weather?a=1&a=2"
+  },
+  {
+    "name": "repeated-keys-reversed",
+    "url": "http://localhost:4022/weather?a=2&a=1",
+    "canonical": "/weather?a=2&a=1"
+  },
+  {
+    "name": "sort-by-decoded-key",
+    "url": "http://localhost:4022/weather?b=1&a=2",
+    "canonical": "/weather?a=2&b=1"
+  },
+  {
+    "name": "percent-encoded-key-sorts-decoded",
+    "url": "http://localhost:4022/weather?b=1&%61=2",
+    "canonical": "/weather?a=2&b=1"
+  },
+  {
+    "name": "exclamation-not-unreserved",
+    "url": "http://localhost:4022/weather?x=!",
+    "canonical": "/weather?x=%21"
+  }
+]

--- a/examples/typescript/clients/payment-identifier/README.md
+++ b/examples/typescript/clients/payment-identifier/README.md
@@ -7,11 +7,15 @@ Example client demonstrating how to use the `payment-identifier` extension to en
 1. Client generates a unique payment ID using `generatePaymentId()`
 2. Client includes the payment ID in the `PaymentPayload` using `appendPaymentIdentifierToExtensions()`
 3. Server caches responses keyed by payment ID
-4. Retry requests with the same payment ID return cached responses without re-processing payment
+4. The client captures the first encoded `PAYMENT-SIGNATURE` header and replays it only for one configured exact request URL and selected accepted payment terms. The target URL is immutable helper configuration. It does not infer capture from a shared pending URL, and it does not replay cross-origin, cross-path, across query drift, or against different accepted terms.
 
 ```typescript
-import { x402Client, wrapFetchWithPayment } from "@x402/fetch";
-import { appendPaymentIdentifierToExtensions, generatePaymentId } from "@x402/extensions/payment-identifier";
+import { x402Client, wrapFetchWithPayment, x402HTTPClient } from "@x402/fetch";
+import {
+  appendPaymentIdentifierToExtensions,
+  generatePaymentId,
+} from "@x402/extensions/payment-identifier";
+import { configureExactHeaderReplay } from "./header-replay.js"; // hashes terms, not the header
 
 const client = new x402Client();
 // ... register schemes ...
@@ -21,20 +25,29 @@ const paymentId = generatePaymentId();
 
 // Hook into payment flow to add the payment ID before payload creation
 client.onBeforePaymentCreation(async ({ paymentRequired }) => {
-  if (!paymentRequired.extensions) {
-    paymentRequired.extensions = {};
+  if (paymentRequired.extensions) {
+    appendPaymentIdentifierToExtensions(paymentRequired.extensions, paymentId);
   }
-  appendPaymentIdentifierToExtensions(paymentRequired.extensions, paymentId);
 });
 
-const fetchWithPayment = wrapFetchWithPayment(fetch, client);
+const httpClient = new x402HTTPClient(client);
+// url is immutable configuration. PaymentCreatedContext has no request URL,
+// so a shared pendingUrl cannot correlate concurrent 402s. This helper is
+// sequential single-URL scope and fails closed if a non-target 402 arrives
+// before capture.
+configureExactHeaderReplay(client, httpClient, url);
 
-// First request - payment is processed
+const fetchWithPayment = wrapFetchWithPayment(fetch, httpClient);
+
+// First request - payment is processed and the exact encoded header is captured
 const response1 = await fetchWithPayment(url);
 
-// Retry with same payment ID - cached response returned (no payment)
+// Retry the same URL and selected terms. Do not create a new signature.
+// Do not replay against another origin, path, query, or accepted-terms set.
 const response2 = await fetchWithPayment(url);
 ```
+
+`configureExactHeaderReplay` is the helper in `header-replay.ts`. It binds the in-memory header to the configured exact request URL and `acceptedTermsFingerprint` of selected terms (scheme, network, asset, amount, payTo, normalized maxTimeoutSeconds, recursively canonical extra). Do not reuse one helper across origins or paths. The raw header stays in memory only; do not log or persist it.
 
 ## Prerequisites
 
@@ -95,7 +108,7 @@ Response (1523ms): { "report": { "weather": "sunny", "temperature": 70, "cached"
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 Making request to: http://localhost:4022/weather
 
-💡 Expected: Server returns cached response without payment processing
+💡 Expected: replay exact payment header; cached response, no new signature
 
 Response (45ms): { "report": { "weather": "sunny", "temperature": 70, "cached": true } }
 
@@ -113,13 +126,14 @@ Response (45ms): { "report": { "weather": "sunny", "temperature": 70, "cached": 
 ## Use Cases
 
 - **Network failures**: Safely retry failed requests without duplicate payments
-- **Client crashes**: Resume requests after restart using persisted payment IDs
+- **Bounded same-process retries**: Reuse the captured exact header without creating a second payment credential
 - **Load balancing**: Same request can hit different servers with shared cache
 - **Testing**: Replay requests during development without spending funds
 
 ## Best Practices
 
 1. **Generate payment IDs at the logical request level**, not per retry
-2. **Persist payment IDs** for long-running operations so they survive restarts
+2. **Keep the payment ID and captured exact header together only in the bounded in-memory retry helper.** This example does not support restart recovery. Persisting a raw payment credential requires a separate encrypted-storage design and threat review; persisting the ID alone creates a fresh credential and conflicts with credential-bound server state.
 3. **Use descriptive prefixes** (e.g., `order_`, `sub_`) to identify payment types
 4. **Don't reuse payment IDs** across different logical requests
+5. **Replay the exact encoded payment header only for the configured exact request URL and selected accepted terms.** Configure one helper per URL. Do not infer capture from a shared pending URL. Do not reuse it cross-origin, cross-path, across query drift, or against a 402 that no longer offers those terms. A non-target 402 before capture fails closed. Do not log or persist the raw header.

--- a/examples/typescript/clients/payment-identifier/header-replay.test.ts
+++ b/examples/typescript/clients/payment-identifier/header-replay.test.ts
@@ -1,0 +1,256 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { describe, it } from "node:test";
+import {
+  acceptedTermsFingerprint,
+  configureExactHeaderReplay,
+  type ExactHeaderReplayClient,
+  type ExactHeaderReplayHttpClient,
+  type PaymentRequiredLike,
+  type PaymentRequirementsLike,
+} from "./header-replay.ts";
+
+const REQUIREMENTS: PaymentRequirementsLike = {
+  scheme: "exact",
+  network: "eip155:84532",
+  asset: "0x0000000000000000000000000000000000000001",
+  amount: "1000",
+  payTo: "0x0000000000000000000000000000000000000002",
+  maxTimeoutSeconds: 300,
+};
+const OTHER_REQUIREMENTS: PaymentRequirementsLike = {
+  ...REQUIREMENTS,
+  amount: "9999",
+};
+const PAYMENT_REQUIRED: PaymentRequiredLike = { accepts: [REQUIREMENTS] };
+const OTHER_PAYMENT_REQUIRED: PaymentRequiredLike = { accepts: [OTHER_REQUIREMENTS] };
+const PAYLOAD = {
+  x402Version: 2,
+  payload: { signature: "0xsig" },
+  accepted: REQUIREMENTS,
+};
+
+const WEATHER = "http://localhost:4022/weather";
+const WEATHER_QUERY = "http://localhost:4022/weather?x=1";
+const FORECAST = "http://localhost:4022/forecast";
+const EVIL_ORIGIN = "http://evil.example/weather";
+
+type AfterHook = (context: {
+  paymentPayload: object;
+  selectedRequirements: PaymentRequirementsLike;
+}) => Promise<void>;
+type RequiredHook = (context: {
+  paymentRequired: PaymentRequiredLike;
+  requestUrl: string;
+}) => Promise<{ headers: Record<string, string> } | void>;
+
+const digest = (headers: Record<string, string> | null | undefined): string => {
+  if (!headers) {
+    return "";
+  }
+  const value = Object.values(headers)[0];
+  if (!value) {
+    return "";
+  }
+  return createHash("sha256").update(value).digest("hex");
+};
+
+const payloadWithSignature = (signature: string) => ({
+  x402Version: 2,
+  payload: { signature },
+  accepted: REQUIREMENTS,
+});
+
+const setup = (targetUrl: string = WEATHER) => {
+  let afterHook: AfterHook | undefined;
+  let requiredHook: RequiredHook | undefined;
+  const client: ExactHeaderReplayClient = {
+    onAfterPaymentCreation(hook) {
+      afterHook = hook;
+    },
+  };
+  const httpClient: ExactHeaderReplayHttpClient = {
+    encodePaymentSignatureHeader(paymentPayload) {
+      return {
+        "PAYMENT-SIGNATURE": Buffer.from(JSON.stringify(paymentPayload), "utf8").toString("base64"),
+      };
+    },
+    onPaymentRequired(hook) {
+      requiredHook = hook;
+    },
+  };
+  const captured = configureExactHeaderReplay(client, httpClient, targetUrl);
+  assert.ok(afterHook);
+  assert.ok(requiredHook);
+  return {
+    captured,
+    afterPaymentCreation: afterHook,
+    handlePaymentRequired: async (paymentRequired: PaymentRequiredLike, requestUrl: string) => {
+      const result = await requiredHook!({ paymentRequired, requestUrl });
+      return result?.headers ?? null;
+    },
+  };
+};
+
+const captureWeather = async (
+  session: ReturnType<typeof setup>,
+  requirements: PaymentRequirementsLike = REQUIREMENTS,
+) => {
+  const before = await session.handlePaymentRequired({ accepts: [requirements] }, WEATHER);
+  assert.equal(before, null);
+  await session.afterPaymentCreation({
+    paymentPayload: PAYLOAD,
+    selectedRequirements: requirements,
+  });
+};
+
+const PYTHON_REQUIREMENTS_FINGERPRINT =
+  "b5c50625f882c99881003964ead755b512b55723f6e1cbad6f1e835d452c9ea0";
+
+describe("acceptedTermsFingerprint", () => {
+  it("matches the Python accepted-terms fingerprint for the same requirements", () => {
+    assert.equal(acceptedTermsFingerprint(REQUIREMENTS), PYTHON_REQUIREMENTS_FINGERPRINT);
+  });
+
+  it("is stable across extra key order and nested extra key order", () => {
+    const left = acceptedTermsFingerprint({
+      ...REQUIREMENTS,
+      extra: { b: 1, a: { d: 2, c: 3 } },
+    });
+    const right = acceptedTermsFingerprint({
+      ...REQUIREMENTS,
+      extra: { a: { c: 3, d: 2 }, b: 1 },
+    });
+    assert.equal(left, right);
+    assert.equal(left.length, 64);
+  });
+
+  it("normalizes maxTimeoutSeconds and payTo aliases", () => {
+    const camel = acceptedTermsFingerprint(REQUIREMENTS);
+    const snake = acceptedTermsFingerprint({
+      scheme: REQUIREMENTS.scheme,
+      network: REQUIREMENTS.network,
+      asset: REQUIREMENTS.asset,
+      amount: REQUIREMENTS.amount,
+      pay_to: REQUIREMENTS.payTo,
+      max_timeout_seconds: REQUIREMENTS.maxTimeoutSeconds,
+    });
+    assert.equal(camel, snake);
+  });
+
+  it("treats missing extra as empty object and changes when extra or timeout changes", () => {
+    const missing = acceptedTermsFingerprint(REQUIREMENTS);
+    const empty = acceptedTermsFingerprint({ ...REQUIREMENTS, extra: {} });
+    const otherExtra = acceptedTermsFingerprint({ ...REQUIREMENTS, extra: { nonce: "1" } });
+    const otherTimeout = acceptedTermsFingerprint({ ...REQUIREMENTS, maxTimeoutSeconds: 301 });
+    assert.equal(missing, empty);
+    assert.notEqual(missing, otherExtra);
+    assert.notEqual(missing, otherTimeout);
+  });
+});
+
+describe("exact header replay", () => {
+  it("replays the first encoded header for the exact URL and accepted terms", async () => {
+    const session = setup();
+    await captureWeather(session);
+    assert.ok(session.captured.headers);
+    const first = session.captured.headers;
+    const replayed = await session.handlePaymentRequired(PAYMENT_REQUIRED, WEATHER);
+    assert.ok(replayed);
+    assert.deepEqual(Object.keys(first ?? {}), Object.keys(replayed ?? {}));
+    assert.equal(digest(first), digest(replayed));
+    const firstValue = Object.values(first ?? {})[0] ?? "";
+    assert.ok(firstValue.length > 16);
+  });
+
+  it("does not replay across query drift", async () => {
+    const session = setup();
+    await captureWeather(session);
+    const replayed = await session.handlePaymentRequired(PAYMENT_REQUIRED, WEATHER_QUERY);
+    assert.equal(replayed, null);
+  });
+
+  it("does not replay to a different origin", async () => {
+    const session = setup();
+    await captureWeather(session);
+    const replayed = await session.handlePaymentRequired(PAYMENT_REQUIRED, EVIL_ORIGIN);
+    assert.equal(replayed, null);
+  });
+
+  it("does not replay to a different path", async () => {
+    const session = setup();
+    await captureWeather(session);
+    const replayed = await session.handlePaymentRequired(PAYMENT_REQUIRED, FORECAST);
+    assert.equal(replayed, null);
+  });
+
+  it("does not replay against different accepted terms", async () => {
+    const session = setup();
+    await captureWeather(session);
+    const replayed = await session.handlePaymentRequired(OTHER_PAYMENT_REQUIRED, WEATHER);
+    assert.equal(replayed, null);
+    const same = await session.handlePaymentRequired(PAYMENT_REQUIRED, WEATHER);
+    assert.ok(same);
+    assert.equal(digest(session.captured.headers), digest(same));
+  });
+
+  it("does not bind A's credential to B when 402s interleave before capture", async () => {
+    const session = setup(WEATHER);
+    const beforeA = await session.handlePaymentRequired(PAYMENT_REQUIRED, WEATHER);
+    const beforeB = await session.handlePaymentRequired(PAYMENT_REQUIRED, EVIL_ORIGIN);
+    assert.equal(beforeA, null);
+    assert.equal(beforeB, null);
+    await session.afterPaymentCreation({
+      paymentPayload: payloadWithSignature("0xsig-A"),
+      selectedRequirements: REQUIREMENTS,
+    });
+    const replayedB = await session.handlePaymentRequired(PAYMENT_REQUIRED, EVIL_ORIGIN);
+    const replayedA = await session.handlePaymentRequired(PAYMENT_REQUIRED, WEATHER);
+    assert.equal(replayedB, null);
+    assert.equal(replayedA, null);
+    assert.equal(session.captured.url, WEATHER);
+    assert.equal(session.captured.headers, undefined);
+  });
+
+  it("does not bind B's credential to A on reverse capture order", async () => {
+    const session = setup(WEATHER);
+    const beforeB = await session.handlePaymentRequired(PAYMENT_REQUIRED, FORECAST);
+    const beforeA = await session.handlePaymentRequired(PAYMENT_REQUIRED, WEATHER);
+    assert.equal(beforeB, null);
+    assert.equal(beforeA, null);
+    await session.afterPaymentCreation({
+      paymentPayload: payloadWithSignature("0xsig-B"),
+      selectedRequirements: REQUIREMENTS,
+    });
+    const replayedA = await session.handlePaymentRequired(PAYMENT_REQUIRED, WEATHER);
+    const replayedB = await session.handlePaymentRequired(PAYMENT_REQUIRED, FORECAST);
+    assert.equal(replayedA, null);
+    assert.equal(replayedB, null);
+    assert.equal(session.captured.url, WEATHER);
+    assert.equal(session.captured.headers, undefined);
+  });
+
+  it("keeps sequential capture after a later foreign 402", async () => {
+    const session = setup();
+    await captureWeather(session);
+    const foreign = await session.handlePaymentRequired(PAYMENT_REQUIRED, EVIL_ORIGIN);
+    assert.equal(foreign, null);
+    const same = await session.handlePaymentRequired(PAYMENT_REQUIRED, WEATHER);
+    assert.ok(same);
+    assert.equal(digest(session.captured.headers), digest(same));
+    assert.equal(session.captured.url, WEATHER);
+  });
+
+  it("fails closed when the configured target URL is empty", async () => {
+    const session = setup("");
+    const before = await session.handlePaymentRequired(PAYMENT_REQUIRED, WEATHER);
+    assert.equal(before, null);
+    await session.afterPaymentCreation({
+      paymentPayload: PAYLOAD,
+      selectedRequirements: REQUIREMENTS,
+    });
+    const replayed = await session.handlePaymentRequired(PAYMENT_REQUIRED, WEATHER);
+    assert.equal(replayed, null);
+    assert.equal(session.captured.headers, undefined);
+  });
+});

--- a/examples/typescript/clients/payment-identifier/header-replay.ts
+++ b/examples/typescript/clients/payment-identifier/header-replay.ts
@@ -1,0 +1,186 @@
+import { createHash } from "crypto";
+
+/**
+ * Selected accepted payment terms used as replay-context material.
+ */
+export type PaymentRequirementsLike = {
+  scheme?: string;
+  network?: string;
+  asset?: string;
+  amount?: string;
+  payTo?: string;
+  pay_to?: string;
+  maxTimeoutSeconds?: number;
+  max_timeout_seconds?: number;
+  extra?: unknown;
+};
+
+/**
+ * 402 payment-required payload offering one or more accepted terms.
+ */
+export type PaymentRequiredLike = {
+  accepts?: PaymentRequirementsLike[];
+};
+
+/**
+ * In-memory captured payment header bound to one immutable target URL.
+ */
+export type CapturedExactHeader = {
+  headers?: Record<string, string>;
+  url?: string;
+  terms?: string;
+};
+
+/**
+ * x402Client surface used to capture the encoded header after signing.
+ */
+export type ExactHeaderReplayClient = {
+  onAfterPaymentCreation(
+    hook: (context: {
+      paymentPayload: object;
+      selectedRequirements: PaymentRequirementsLike;
+    }) => Promise<void>,
+  ): unknown;
+};
+
+/**
+ * x402HTTPClient surface used to encode and conditionally replay the header.
+ */
+export type ExactHeaderReplayHttpClient = {
+  encodePaymentSignatureHeader(paymentPayload: object): Record<string, string>;
+  onPaymentRequired(
+    hook: (context: {
+      paymentRequired: PaymentRequiredLike;
+      requestUrl: string;
+    }) => Promise<{ headers: Record<string, string> } | void>,
+  ): unknown;
+};
+
+const canonicalJson = (value: unknown): string => {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value === undefined ? null : value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(item => canonicalJson(item)).join(",")}]`;
+  }
+  const record = value as Record<string, unknown>;
+  const keys = Object.keys(record).sort();
+  return `{${keys.map(key => `${JSON.stringify(key)}:${canonicalJson(record[key])}`).join(",")}}`;
+};
+
+/**
+ * SHA-256 fingerprint of selected accepted payment terms.
+ *
+ * Covers scheme, network, asset, amount, payTo, normalized maxTimeoutSeconds,
+ * and recursively canonical extra. Used only as a replay-context key.
+ *
+ * @param requirements - Selected or offered accepted payment terms
+ * @returns Hex digest of the canonical terms material
+ */
+export function acceptedTermsFingerprint(
+  requirements: PaymentRequirementsLike | null | undefined,
+): string {
+  const terms = requirements ?? {};
+  const extra = terms.extra;
+  const timeout = terms.maxTimeoutSeconds ?? terms.max_timeout_seconds;
+  const material = {
+    amount: String(terms.amount ?? ""),
+    asset: String(terms.asset ?? ""),
+    extra: extra === undefined || extra === null ? "{}" : canonicalJson(extra),
+    maxTimeoutSeconds: timeout === undefined || timeout === null ? "" : String(timeout),
+    network: String(terms.network ?? ""),
+    payTo: String(terms.payTo ?? terms.pay_to ?? ""),
+    scheme: String(terms.scheme ?? ""),
+  };
+  const keys = Object.keys(material).sort();
+  return createHash("sha256").update(JSON.stringify(material, keys)).digest("hex");
+}
+
+const acceptsIncludeTerms = (paymentRequired: PaymentRequiredLike, terms: string): boolean => {
+  const accepts = paymentRequired.accepts ?? [];
+  return accepts.some(item => acceptedTermsFingerprint(item) === terms);
+};
+
+/**
+ * Return captured headers only when the 402 matches the exact captured context.
+ *
+ * Both the request URL string and the selected accepted-terms fingerprint must
+ * match. A different origin, path, query, or accepted offer does not replay.
+ *
+ * @param captured - Previously captured header and context
+ * @param requestUrl - Exact 402 request URL from the HTTP client
+ * @param paymentRequired - Later 402 payment-required body
+ * @returns Captured headers when both context components match
+ */
+export function replayHeadersIfExactContext(
+  captured: CapturedExactHeader,
+  requestUrl: string,
+  paymentRequired: PaymentRequiredLike,
+): Record<string, string> | undefined {
+  const headers = captured.headers;
+  if (!headers || Object.keys(headers).length === 0) {
+    return undefined;
+  }
+  if (requestUrl !== captured.url) {
+    return undefined;
+  }
+  const terms = captured.terms;
+  if (!terms || !acceptsIncludeTerms(paymentRequired, terms)) {
+    return undefined;
+  }
+  return headers;
+}
+
+/**
+ * Capture the first encoded payment header for one exact target URL.
+ *
+ * `targetUrl` is immutable configuration. PaymentCreatedContext has no request
+ * URL, so a shared mutable pendingUrl cannot correlate concurrent 402s. This
+ * helper is an educational sequential-retry client for that one URL. A 402 for
+ * any other origin, path, or query before capture poisons capture (fail
+ * closed): the credential is not stored and is not replayed. Replay still
+ * requires an exact URL string match and matching selected accepted terms.
+ * Never replays cross-origin, cross-path, across query drift, or against
+ * different accepted terms. Does not print or persist the header.
+ *
+ * @param client - x402Client used to observe payload creation
+ * @param httpClient - x402HTTPClient used to encode and replay headers
+ * @param targetUrl - Exact request URL this helper may capture and replay
+ * @returns Mutable captured context; header bytes stay in memory only
+ */
+export function configureExactHeaderReplay(
+  client: ExactHeaderReplayClient,
+  httpClient: ExactHeaderReplayHttpClient,
+  targetUrl: string,
+): CapturedExactHeader {
+  const captured: CapturedExactHeader = { url: targetUrl };
+  let sawTargetRequired = false;
+  let sawForeignRequired = false;
+
+  client.onAfterPaymentCreation(async ({ paymentPayload, selectedRequirements }) => {
+    if (captured.headers || !targetUrl || !sawTargetRequired || sawForeignRequired) {
+      return;
+    }
+    captured.headers = { ...httpClient.encodePaymentSignatureHeader(paymentPayload) };
+    captured.terms = acceptedTermsFingerprint(selectedRequirements);
+  });
+
+  httpClient.onPaymentRequired(async ({ paymentRequired, requestUrl }) => {
+    if (requestUrl !== targetUrl) {
+      if (!captured.headers) {
+        sawForeignRequired = true;
+      }
+      return;
+    }
+    const replayed = replayHeadersIfExactContext(captured, requestUrl, paymentRequired);
+    if (replayed) {
+      return { headers: replayed };
+    }
+    if (!captured.headers || Object.keys(captured.headers).length === 0) {
+      sawTargetRequired = true;
+    }
+    return;
+  });
+
+  return captured;
+}

--- a/examples/typescript/clients/payment-identifier/index.ts
+++ b/examples/typescript/clients/payment-identifier/index.ts
@@ -7,6 +7,7 @@ import {
   appendPaymentIdentifierToExtensions,
   generatePaymentId,
 } from "@x402/extensions/payment-identifier";
+import { configureExactHeaderReplay } from "./header-replay.js";
 
 config();
 
@@ -25,8 +26,12 @@ const url = `${baseURL}${endpointPath}`;
  *
  * This example:
  * 1. Makes a request with a unique payment ID
- * 2. Makes a second request with the SAME payment ID
- * 3. The second request returns from cache without payment processing
+ * 2. Captures the first exact encoded payment header
+ * 3. Replays that header on a later 402 only for the configured exact
+ *    request URL and selected accepted terms. The helper is sequential
+ *    single-URL scope. It does not infer capture from a shared pending URL,
+ *    and it does not replay cross-origin, cross-path, across query drift,
+ *    or against different accepted terms.
  *
  * Required environment variables:
  * - PRIVATE_KEY: The private key of the EVM signer
@@ -53,19 +58,7 @@ async function main(): Promise<void> {
   });
 
   const httpClient = new x402HTTPClient(client);
-
-  // After the first request is signed, capture the exact encoded payment header.
-  let capturedPaymentHeaders: Record<string, string> | undefined;
-  client.onAfterPaymentCreation(async ({ paymentPayload }) => {
-    capturedPaymentHeaders = httpClient.encodePaymentSignatureHeader(paymentPayload);
-  });
-
-  // On any subsequent 402, replay the captured headers instead of creating a new signature.
-  httpClient.onPaymentRequired(async () => {
-    if (capturedPaymentHeaders) {
-      return { headers: capturedPaymentHeaders };
-    }
-  });
+  configureExactHeaderReplay(client, httpClient, url);
 
   const fetchWithPayment = wrapFetchWithPayment(fetch, httpClient);
 
@@ -94,7 +87,7 @@ async function main(): Promise<void> {
   console.log(`📤 Second Request (SAME payment ID: ${paymentId})`);
   console.log(`━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━`);
   console.log(`Making request to: ${url}\n`);
-  console.log(`💡 Expected: Server returns cached response without payment processing\n`);
+  console.log(`💡 Expected: replay exact payment header; cached response, no new signature\n`);
 
   const startTime2 = Date.now();
   const response2 = await fetchWithPayment(url, { method: "GET" });

--- a/examples/typescript/clients/payment-identifier/package.json
+++ b/examples/typescript/clients/payment-identifier/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "start": "tsx index.ts",
     "dev": "tsx index.ts",
+    "test": "tsx --test header-replay.test.ts",
     "format": "prettier -c .prettierrc --write \"**/*.{ts,js,cjs,json,md}\"",
     "format:check": "prettier -c .prettierrc --check \"**/*.{ts,js,cjs,json,md}\"",
     "lint": "eslint . --ext .ts --fix",

--- a/examples/typescript/clients/payment-identifier/tsconfig.json
+++ b/examples/typescript/clients/payment-identifier/tsconfig.json
@@ -11,5 +11,5 @@
     "baseUrl": ".",
     "types": ["node"]
   },
-  "include": ["index.ts"]
+  "include": ["index.ts", "header-replay.ts", "header-replay.test.ts"]
 }

--- a/examples/typescript/servers/payment-identifier/README.md
+++ b/examples/typescript/servers/payment-identifier/README.md
@@ -6,56 +6,22 @@ Express.js server demonstrating how to use the `payment-identifier` extension fo
 
 1. Server advertises `payment-identifier` extension support in the `PaymentRequired` response
 2. Client includes a unique payment ID in their `PaymentPayload`
-3. Server caches responses keyed by payment ID (1-hour TTL)
-4. If the same payment ID is seen again, the cached response is returned without re-processing payment
+3. Server looks up the settled cache (1-hour TTL), then holds an expiring in-flight reservation (fingerprint + timestamp, 30s TTL)
+4. After settlement, `onAfterSettle` consumes only that live reservation and caches its exact fingerprint
+5. Same payment ID and same fingerprint return the cached response without re-processing payment
+6. Same payment ID with a different method, path, query, or body returns HTTP 409 and does not grant access
+7. A second in-flight request never overwrites a live reservation
 
 ```typescript
-import {
-  paymentMiddlewareFromHTTPServer,
-  x402ResourceServer,
-  x402HTTPResourceServer,
-} from "@x402/express";
-import {
-  declarePaymentIdentifierExtension,
-  extractPaymentIdentifier,
-  PAYMENT_IDENTIFIER,
-} from "@x402/extensions/payment-identifier";
+import { paymentMiddlewareFromHTTPServer } from "@x402/express";
 
-// In-memory cache (use Redis in production)
-const idempotencyCache = new Map<string, { timestamp: number; response: unknown }>();
-const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+// Bind each payment ID to an HTTP request fingerprint (see request-binding.ts).
+// Check the settled cache first, then an in-flight reservation, before payment middleware.
+// Same fingerprint after settle: return the cached body. Different fingerprint: HTTP 409.
+// Same fingerprint while in flight: in-flight 409. Do not overwrite a live reservation.
+// This example is GET-only and hashes an empty body; it does not capture POST bodies.
 
-const routes = {
-  "GET /weather": {
-    accepts: { scheme: "exact", price: "$0.001", network: "eip155:84532", payTo: address },
-    extensions: {
-      [PAYMENT_IDENTIFIER]: declarePaymentIdentifierExtension(false), // optional
-    },
-  },
-};
-
-const resourceServer = new x402ResourceServer(facilitatorClient)
-  .register("eip155:84532", new ExactEvmScheme())
-  .onAfterSettle(async ({ paymentPayload }) => {
-    const paymentId = extractPaymentIdentifier(paymentPayload);
-    if (paymentId) {
-      idempotencyCache.set(paymentId, { timestamp: Date.now(), response: { ... } });
-    }
-  });
-
-const httpServer = new x402HTTPResourceServer(resourceServer, routes)
-  .onProtectedRequest(async (context) => {
-    // Check if payment ID is in cache
-    const paymentPayload = JSON.parse(Buffer.from(context.paymentHeader, "base64").toString());
-    const paymentId = extractPaymentIdentifier(paymentPayload);
-    if (paymentId) {
-      const cached = idempotencyCache.get(paymentId);
-      if (cached && Date.now() - cached.timestamp < CACHE_TTL_MS) {
-        return { grantAccess: true }; // Skip payment, grant access
-      }
-    }
-  });
-
+app.use(idempotencyMiddleware); // 200 cache hit or 409 conflict, no grantAccess
 app.use(paymentMiddlewareFromHTTPServer(httpServer));
 ```
 
@@ -102,6 +68,7 @@ pnpm dev
 ```
 
 The client will:
+
 1. Make a request with a unique payment ID
 2. Make a second request with the **same** payment ID
 3. The second request returns instantly from cache without payment processing
@@ -109,10 +76,14 @@ The client will:
 ## Idempotency Behavior
 
 | Scenario | Server Response |
-|----------|-----------------|
-| New payment ID | Process payment normally, cache response |
-| Same payment ID (within TTL) | Return cached response, skip payment |
-| Same payment ID (after TTL) | Process payment normally, update cache |
+| --- | --- |
+| New payment ID | Reserve, process payment, cache on settle |
+| Same payment ID, same request fingerprint (within cache TTL) | Return cached response, skip payment |
+| Same payment ID, same fingerprint, live reservation | 409 in-flight conflict, do not settle again |
+| Same payment ID, different request fingerprint | Return 409 Conflict, do not grant access, do not overwrite |
+| Same payment ID (after cache TTL) | Process payment normally, update cache |
+| Reservation expired (failed verification) | Drop reservation; ID can proceed again |
+| Settle with missing/expired reservation | Do not cache |
 | No payment ID | Process payment normally (no caching) |
 
 ## Configuration Options
@@ -121,21 +92,31 @@ The client will:
 
 ```typescript
 // Payment ID is optional (clients can omit it)
-declarePaymentIdentifierExtension(false)
+declarePaymentIdentifierExtension(false);
 
 // Payment ID is required (clients must provide it)
-declarePaymentIdentifierExtension(true)
+declarePaymentIdentifierExtension(true);
 ```
 
 ### Cache TTL
 
 Adjust `CACHE_TTL_MS` based on your use case:
+
 - Short TTL (5-15 min): For time-sensitive resources
 - Long TTL (1-24 hours): For static or infrequently changing resources
+
+`RESERVATION_TTL_MS` is 30 seconds, distinct from the 1-hour settled cache. It only covers in-flight verify/settle. Failed verification must expire so the reservation map cannot grow without bound.
+
+Request-binding unit tests (no wallet, chain, facilitator, or payment):
+
+```bash
+pnpm test
+```
 
 ## Production Considerations
 
 1. **Use Redis or similar** instead of in-memory cache for distributed systems
 2. **Handle cache failures gracefully** - if cache is unavailable, process payment normally
-3. **Consider payload hashing** - for additional safety, hash the full payload and reject if same ID but different payload (409 Conflict)
-4. **Monitor cache hit rates** to tune TTL and detect abuse
+3. **Bind payment IDs to the HTTP request** - fingerprint method, canonical path+query, raw body, and accepted terms. Do not hash only the payment payload. Return 409 on drift without grantAccess. This GET-only Express example does not install body-parsing middleware and hashes an empty body.
+4. **Reserve in-flight payment IDs** with a short TTL so concurrent requests cannot overwrite the first fingerprint
+5. **Monitor cache hit rates** to tune TTL and detect abuse

--- a/examples/typescript/servers/payment-identifier/README.md
+++ b/examples/typescript/servers/payment-identifier/README.md
@@ -6,20 +6,23 @@ Express.js server demonstrating how to use the `payment-identifier` extension fo
 
 1. Server advertises `payment-identifier` extension support in the `PaymentRequired` response
 2. Client includes a unique payment ID in their `PaymentPayload`
-3. Server looks up the settled cache (1-hour TTL), then holds an expiring in-flight reservation (fingerprint + timestamp, 30s TTL)
-4. After settlement, `onAfterSettle` consumes only that live reservation and caches its exact fingerprint
-5. Same payment ID and same fingerprint return the cached response without re-processing payment
-6. Same payment ID with a different method, path, query, or body returns HTTP 409 and does not grant access
-7. A second in-flight request never overwrites a live reservation
+3. Server looks up the settled cache (1-hour TTL), then holds an expiring in-flight reservation (fingerprint + timestamp + token + state). TTL is a server-owned 300s, not client `maxTimeoutSeconds`. The pending map is bounded at 1024 entries. Only `GET /weather` is reserved.
+4. After settlement, `onAfterSettle` consumes only the matching reservation and caches its exact fingerprint
+5. Same payment ID and same request+credential fingerprint return the cached response without re-processing payment
+6. Same payment ID with a different method, path, query, body, extra, timeout, or payment credential returns HTTP 409 and does not grant access
+7. A second in-flight request never overwrites a live reservation; in-flight and capacity are HTTP 503 retryable
+8. `onBeforeSettle` aborts before the facilitator if the exact token no longer owns the reservation. Pre-settlement rejection releases the matching pending reservation. Thrown settle errors keep a tokenized tombstone until the 300s TTL. A settle failure is not immediately safe to retry.
 
 ```typescript
 import { paymentMiddlewareFromHTTPServer } from "@x402/express";
 
-// Bind each payment ID to an HTTP request fingerprint (see request-binding.ts).
+// Bind each payment ID to an HTTP request + credential fingerprint (see request-binding.ts).
 // Check the settled cache first, then an in-flight reservation, before payment middleware.
 // Same fingerprint after settle: return the cached body. Different fingerprint: HTTP 409.
-// Same fingerprint while in flight: in-flight 409. Do not overwrite a live reservation.
-// This example is GET-only and hashes an empty body; it does not capture POST bodies.
+// Same fingerprint while in flight: HTTP 503 retryable. Do not overwrite a live reservation.
+// Reserve only GET /weather. This example is GET-only and hashes an empty body; it does not capture POST bodies.
+// Educational example: the 1024-entry pending map is still susceptible to availability pressure
+// from unauthenticated but syntactically valid payloads. Use tryReserve / bindPaymentId; do not Map#set.
 
 app.use(idempotencyMiddleware); // 200 cache hit or 409 conflict, no grantAccess
 app.use(paymentMiddlewareFromHTTPServer(httpServer));
@@ -78,12 +81,17 @@ The client will:
 | Scenario | Server Response |
 | --- | --- |
 | New payment ID | Reserve, process payment, cache on settle |
-| Same payment ID, same request fingerprint (within cache TTL) | Return cached response, skip payment |
-| Same payment ID, same fingerprint, live reservation | 409 in-flight conflict, do not settle again |
-| Same payment ID, different request fingerprint | Return 409 Conflict, do not grant access, do not overwrite |
+| Same payment ID, same request+credential fingerprint (within cache TTL) | Return cached response, skip payment |
+| Same payment ID, same fingerprint, live reservation | 503 retryable in-flight, do not settle again |
+| Same payment ID, different request or credential fingerprint | Return 409 Conflict, do not grant access, do not overwrite |
+| Pending map at 1024 live entries | 503 retryable capacity, do not verify/settle |
 | Same payment ID (after cache TTL) | Process payment normally, update cache |
-| Reservation expired (failed verification) | Drop reservation; ID can proceed again |
-| Settle with missing/expired reservation | Do not cache |
+| Pre-settlement reject or verified-payment cancel | Release matching pending tokenized reservation |
+| Thrown settle timeout/network/facilitator error | Outcome-unknown tombstone until 300s TTL; not immediately safe to retry |
+| Reservation expires (stale work / outcome-unknown expiry) | Drop reservation; ID can proceed again |
+| Before-settle with missing/replaced/mismatched/unknown reservation | Abort before facilitator settlement |
+| Exact current-token settle callback after its prior phase deadline | Cache only if cleanup has not replaced it |
+| Valid payment header on `/health` or an unmatched path | No reservation; paid route is not blocked |
 | No payment ID | Process payment normally (no caching) |
 
 ## Configuration Options
@@ -105,7 +113,7 @@ Adjust `CACHE_TTL_MS` based on your use case:
 - Short TTL (5-15 min): For time-sensitive resources
 - Long TTL (1-24 hours): For static or infrequently changing resources
 
-`RESERVATION_TTL_MS` is 30 seconds, distinct from the 1-hour settled cache. It only covers in-flight verify/settle. Failed verification must expire so the reservation map cannot grow without bound.
+`RESERVATION_TTL_MS` is a server-owned 300s stale-work and outcome-unknown expiry bound, distinct from the 1-hour settled cache. Entering settlement and entering outcome-unknown each refresh that server-owned phase clock. An exact current token may finalize after its deadline only when cleanup has not replaced it; a stale token cannot consume a replacement. Client `maxTimeoutSeconds` is fingerprinted, never used as map TTL. Failed verification must release the matching pending reservation. Thrown settle errors keep a tombstone for that 300s window. HTTP 409 is conflict; HTTP 503 is retryable in-flight or capacity. This educational example is GET-only and single-process. The 1024-entry pending map is still susceptible to availability pressure from unauthenticated but syntactically valid payloads.
 
 Request-binding unit tests (no wallet, chain, facilitator, or payment):
 
@@ -116,7 +124,7 @@ pnpm test
 ## Production Considerations
 
 1. **Use Redis or similar** instead of in-memory cache for distributed systems
-2. **Handle cache failures gracefully** - if cache is unavailable, process payment normally
-3. **Bind payment IDs to the HTTP request** - fingerprint method, canonical path+query, raw body, and accepted terms. Do not hash only the payment payload. Return 409 on drift without grantAccess. This GET-only Express example does not install body-parsing middleware and hashes an empty body.
-4. **Reserve in-flight payment IDs** with a short TTL so concurrent requests cannot overwrite the first fingerprint
-5. **Monitor cache hit rates** to tune TTL and detect abuse
+2. **Fail closed when idempotency storage is unavailable** - return retryable HTTP 503 and do not verify or settle. Bypassing idempotency requires a separate merchant policy that does not claim duplicate-settlement protection.
+3. **Bind payment IDs to the HTTP request and settled credential** - fingerprint method, canonical path+query, raw body, accepted terms, and `payload.payload`. Do not hash only the payment payload, and do not hash only the HTTP request. Return 409 on drift without grantAccess. This GET-only Express example does not install body-parsing middleware and hashes an empty body.
+4. **Reserve in-flight payment IDs only on protected paid routes** so concurrent requests cannot overwrite the first fingerprint. Require the exact token for consume/release/mark-unknown. Release pending reservations only on definitive pre-settlement rejection or a returned `result.success === false`. Thrown settle errors keep a tombstone for 300s; do not treat settle failure as immediately safe to retry.
+5. **Replay the exact encoded payment header** on retry, and only for the same request URL and selected accepted terms. Bound the in-memory map at 1024 via `tryReserve`. This GET-only single-process educational example is not a production idempotency library. Unauthenticated but syntactically valid payloads can still fill the bounded map.

--- a/examples/typescript/servers/payment-identifier/index.ts
+++ b/examples/typescript/servers/payment-identifier/index.ts
@@ -12,32 +12,17 @@ import {
   extractPaymentIdentifier,
   PAYMENT_IDENTIFIER,
 } from "@x402/extensions/payment-identifier";
-import { createHash } from "crypto";
-import type { PaymentPayload } from "@x402/core/types";
+import {
+  CONFLICT_MESSAGE,
+  IN_FLIGHT_MESSAGE,
+  RESERVATION_TTL_MS,
+  bindPaymentId,
+  cleanupExpiredReservations,
+  consumeReservation,
+  requestFingerprint,
+  type Reservation,
+} from "./request-binding.js";
 config();
-
-/**
- * Computes a deterministic hash of the full PaymentPayload. A proper retry
- * resends the exact same signed payload, so the hash — including the
- * cryptographic signature — will match. A genuinely different request
- * (different signer, amount, etc.) produces a different hash → 409 Conflict.
- *
- * @param payload - the payment payload to fingerprint
- * @returns SHA-256 hex digest of the canonicalized payload
- */
-function payloadFingerprint(payload: PaymentPayload): string {
-  const canonical = JSON.stringify(payload, (_key, value) => {
-    if (value !== null && typeof value === "object" && !Array.isArray(value)) {
-      const sorted: Record<string, unknown> = {};
-      for (const k of Object.keys(value as Record<string, unknown>).sort()) {
-        sorted[k] = (value as Record<string, unknown>)[k];
-      }
-      return sorted;
-    }
-    return value;
-  });
-  return createHash("sha256").update(canonical).digest("hex");
-}
 
 const address = process.env.ADDRESS as `0x${string}`;
 if (!address) {
@@ -59,10 +44,11 @@ interface CachedResponse {
 }
 
 const idempotencyCache = new Map<string, CachedResponse>();
+const pendingReservations = new Map<string, Reservation>();
 const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
 
 /**
- * Cleans up expired entries from the cache.
+ * Cleans up expired cache and in-flight reservation entries.
  */
 function cleanupExpiredEntries(): void {
   const now = Date.now();
@@ -71,6 +57,30 @@ function cleanupExpiredEntries(): void {
       idempotencyCache.delete(key);
     }
   }
+  cleanupExpiredReservations(pendingReservations, now, RESERVATION_TTL_MS);
+}
+
+/**
+ * Raw request body bytes used in the HTTP fingerprint.
+ *
+ * This example is GET-only and does not install Express body-parsing middleware,
+ * so the fingerprint hashes empty bytes. It does not capture arbitrary POST bodies.
+ *
+ * @param req - Express request
+ * @returns Raw body buffer
+ */
+function requestBodyBytes(req: express.Request): Buffer {
+  const ext = req as express.Request & { rawBody?: Buffer };
+  if (Buffer.isBuffer(ext.rawBody)) {
+    return ext.rawBody;
+  }
+  if (Buffer.isBuffer(req.body)) {
+    return req.body;
+  }
+  if (typeof req.body === "string") {
+    return Buffer.from(req.body);
+  }
+  return Buffer.alloc(0);
 }
 
 // Run cleanup every 5 minutes
@@ -99,117 +109,121 @@ const routes = {
 // Create the resource server with payment scheme support
 const resourceServer = new x402ResourceServer(facilitatorClient)
   .register("eip155:84532", new ExactEvmScheme())
-  // Hook after settlement to cache the response with its fingerprint
+  // Hook after settlement to cache the response with its HTTP request fingerprint
   .onAfterSettle(async ({ paymentPayload }) => {
     const paymentId = extractPaymentIdentifier(paymentPayload);
-    if (paymentId) {
-      const fp = payloadFingerprint(paymentPayload);
-      console.log(`[Idempotency] Caching response for payment ID: ${paymentId}`);
-      idempotencyCache.set(paymentId, {
-        timestamp: Date.now(),
-        fingerprint: fp,
-        response: {
-          report: {
-            weather: "sunny",
-            temperature: 70,
-            cached: false,
-          },
-        },
-      });
+    if (!paymentId) {
+      return;
     }
+    const fingerprint = consumeReservation(
+      pendingReservations,
+      paymentId,
+      Date.now(),
+      RESERVATION_TTL_MS,
+    );
+    if (!fingerprint) {
+      return;
+    }
+    console.log(`[Idempotency] Caching response for payment ID: ${paymentId}`);
+    idempotencyCache.set(paymentId, {
+      timestamp: Date.now(),
+      fingerprint,
+      response: {
+        report: {
+          weather: "sunny",
+          temperature: 70,
+          cached: false,
+        },
+      },
+    });
   });
 
-// Create HTTP server with the onProtectedRequest hook for idempotency
-const httpServer = new x402HTTPResourceServer(resourceServer, routes).onProtectedRequest(
-  async context => {
-    // Only check idempotency if there's a payment header (retry scenario)
-    if (!context.paymentHeader) {
-      return; // Continue to normal payment flow
-    }
-
-    // Try to decode the payment header to get the payment ID
-    // The payment header is base64-encoded JSON
-    try {
-      const paymentPayload = JSON.parse(
-        Buffer.from(context.paymentHeader, "base64").toString("utf-8"),
-      );
-      const paymentId = extractPaymentIdentifier(paymentPayload);
-
-      if (paymentId) {
-        console.log(`[Idempotency] Checking payment ID: ${paymentId}`);
-
-        const cached = idempotencyCache.get(paymentId);
-        if (cached) {
-          const age = Date.now() - cached.timestamp;
-          if (age < CACHE_TTL_MS) {
-            // Compare fingerprints to detect payload mismatch
-            const fp = payloadFingerprint(paymentPayload);
-
-            // Access Express request through adapter's private req property
-            const adapter = context.adapter as unknown as {
-              req: express.Request & { paymentId?: string; paymentIdConflict?: boolean };
-            };
-
-            if (fp !== cached.fingerprint) {
-              console.log(`[Idempotency] CONFLICT - same ID, different payload`);
-              adapter.req.paymentIdConflict = true;
-              adapter.req.paymentId = paymentId;
-              return { grantAccess: true };
-            }
-
-            console.log(
-              `[Idempotency] Cache HIT - granting access (age: ${Math.round(age / 1000)}s)`,
-            );
-            adapter.req.paymentId = paymentId;
-            // Grant access without payment processing - the cached response will be served
-            return { grantAccess: true };
-          } else {
-            console.log(`[Idempotency] Cache EXPIRED - proceeding with payment`);
-            idempotencyCache.delete(paymentId);
-          }
-        } else {
-          console.log(`[Idempotency] Cache MISS - proceeding with payment`);
-        }
-      }
-    } catch {
-      // Invalid payment header format, continue to normal flow
-    }
-
-    return; // Continue to normal payment verification
-  },
-);
+const httpServer = new x402HTTPResourceServer(resourceServer, routes);
 
 const app = express();
 
-app.use(paymentMiddlewareFromHTTPServer(httpServer));
+// Run before payment middleware so a fingerprint mismatch returns 409
+// without grantAccess and without payment verification.
+app.use((req, res, next) => {
+  cleanupExpiredEntries();
 
-app.get("/weather", (req, res) => {
-  const reqExt = req as express.Request & { paymentId?: string; paymentIdConflict?: boolean };
-
-  // Same ID but different payload → 409 Conflict
-  if (reqExt.paymentIdConflict) {
-    res.status(409).json({
-      error: "payment identifier already used with different payload",
-      paymentId: reqExt.paymentId,
-    });
+  const paymentHeader = req.header("payment-signature") || req.header("x-payment");
+  if (!paymentHeader) {
+    next();
     return;
   }
 
-  // Same ID, same payload → return cached response
-  if (reqExt.paymentId) {
-    const cached = idempotencyCache.get(reqExt.paymentId);
-    if (cached) {
-      res.json({
-        report: {
-          ...cached.response.report,
-          cached: true,
-        },
+  try {
+    const paymentPayload = JSON.parse(Buffer.from(paymentHeader, "base64").toString("utf-8"));
+    const paymentId = extractPaymentIdentifier(paymentPayload);
+    if (!paymentId) {
+      next();
+      return;
+    }
+
+    console.log(`[Idempotency] Checking payment ID: ${paymentId}`);
+    const fingerprint = requestFingerprint({
+      method: req.method,
+      url: req.originalUrl || req.url,
+      body: requestBodyBytes(req),
+      payload: paymentPayload,
+    });
+    const decision = bindPaymentId({
+      cache: idempotencyCache,
+      reservations: pendingReservations,
+      paymentId,
+      fingerprint,
+      now: Date.now(),
+      cacheTtlMs: CACHE_TTL_MS,
+      reservationTtlMs: RESERVATION_TTL_MS,
+    });
+
+    if (decision.kind === "conflict") {
+      console.log(`[Idempotency] CONFLICT - same ID, different request`);
+      res.status(409).json({
+        error: CONFLICT_MESSAGE,
+        paymentId,
       });
       return;
     }
+
+    if (decision.kind === "in_flight") {
+      console.log(`[Idempotency] IN FLIGHT - same ID, request already reserved`);
+      res.status(409).json({
+        error: IN_FLIGHT_MESSAGE,
+        paymentId,
+      });
+      return;
+    }
+
+    if (decision.kind === "hit") {
+      const cached = idempotencyCache.get(paymentId);
+      if (cached) {
+        const age = Date.now() - cached.timestamp;
+        console.log(
+          `[Idempotency] Cache HIT - returning cached response (age: ${Math.round(age / 1000)}s)`,
+        );
+        res.json({
+          report: {
+            ...cached.response.report,
+            cached: true,
+          },
+        });
+        return;
+      }
+    }
+
+    console.log(`[Idempotency] Cache MISS - reserved, proceeding with payment`);
+  } catch {
+    // Invalid payment header format, continue to normal flow
   }
 
-  // New request → normal response
+  next();
+});
+
+app.use(paymentMiddlewareFromHTTPServer(httpServer));
+
+app.get("/weather", (_req, res) => {
   res.json({
     report: {
       weather: "sunny",
@@ -224,10 +238,13 @@ app.listen(4022, () => {
   console.log(`   Listening at http://localhost:4022`);
   console.log(`\n📋 Idempotency Configuration:`);
   console.log(`   - Cache TTL: 1 hour`);
+  console.log(`   - In-flight reservation TTL: 30 seconds`);
   console.log(`   - Payment ID: optional (required: false)`);
   console.log(`\n💡 How it works:`);
   console.log(`   1. Client sends payment with a unique payment ID`);
-  console.log(`   2. Server caches the response keyed by payment ID`);
-  console.log(`   3. If same payment ID is seen within 1 hour, access is granted without payment`);
-  console.log(`   4. No duplicate payment processing occurs\n`);
+  console.log(`   2. Server caches the response bound to that ID and the HTTP request`);
+  console.log(`   3. Same ID and same request fingerprint returns the cached response`);
+  console.log(`   4. Same ID with a different method, path, query, or body returns 409`);
+  console.log(`   5. A live in-flight reservation is never overwritten`);
+  console.log(`   6. No duplicate payment processing occurs on a cache hit\n`);
 });

--- a/examples/typescript/servers/payment-identifier/index.ts
+++ b/examples/typescript/servers/payment-identifier/index.ts
@@ -6,20 +6,38 @@ import {
   x402HTTPResourceServer,
 } from "@x402/express";
 import { ExactEvmScheme } from "@x402/evm/exact/server";
-import { HTTPFacilitatorClient } from "@x402/core/server";
+import {
+  HTTPFacilitatorClient,
+  type HTTPTransportContext,
+  type SettleFailureContext,
+  type SettleResultContext,
+  type VerifiedPaymentCanceledContext,
+  type VerifyFailureContext,
+  type VerifyResultContext,
+} from "@x402/core/server";
 import {
   declarePaymentIdentifierExtension,
   extractPaymentIdentifier,
   PAYMENT_IDENTIFIER,
 } from "@x402/extensions/payment-identifier";
 import {
+  CAPACITY_MESSAGE,
   CONFLICT_MESSAGE,
   IN_FLIGHT_MESSAGE,
   RESERVATION_TTL_MS,
+  RETRY_AFTER_SECONDS,
+  RETRYABLE_STATUS_CODE,
   bindPaymentId,
   cleanupExpiredReservations,
   consumeReservation,
+  isProtectedRoute,
+  markOutcomeUnknown,
+  markSettlementStarted,
+  releaseIfPending,
+  releaseReservation,
   requestFingerprint,
+  reservationTokenFromTransportContext,
+  type PaymentTermsSource,
   type Reservation,
 } from "./request-binding.js";
 config();
@@ -46,6 +64,53 @@ interface CachedResponse {
 const idempotencyCache = new Map<string, CachedResponse>();
 const pendingReservations = new Map<string, Reservation>();
 const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+type ReservationRequest = express.Request & { x402ReservationToken?: string };
+
+/**
+ * HTTP method and URL from an SDK hook transport context.
+ *
+ * @param ctx - Hook context with optional transport
+ * @param ctx.transportContext - SDK HTTP transport context
+ * @returns Method and URL strings
+ */
+function hookHttpIdentity(ctx: { transportContext?: unknown }): { method: string; url: string } {
+  const transport = ctx.transportContext as HTTPTransportContext | undefined;
+  const request = transport?.request;
+  const adapter = request?.adapter;
+  const method = request?.method || adapter?.getMethod() || "";
+  const url = adapter?.getUrl() || request?.path || "";
+  return { method, url };
+}
+
+/**
+ * Reservation token stashed on the Express request by idempotency middleware.
+ *
+ * @param ctx - Hook context with optional transport
+ * @param ctx.transportContext - SDK HTTP transport context
+ * @returns Token from ExpressAdapter.req, if present
+ */
+function hookReservationToken(ctx: { transportContext?: unknown }): string | undefined {
+  return reservationTokenFromTransportContext(ctx.transportContext);
+}
+
+/**
+ * Request+credential fingerprint from hook HTTP identity and payload.
+ *
+ * @param ctx - Hook context with payment payload
+ * @param ctx.paymentPayload - Payment payload from the SDK hook
+ * @param ctx.transportContext - SDK HTTP transport context
+ * @returns SHA-256 hex digest
+ */
+function hookFingerprint(ctx: { paymentPayload: unknown; transportContext?: unknown }): string {
+  const { method, url } = hookHttpIdentity(ctx);
+  return requestFingerprint({
+    method,
+    url,
+    body: Buffer.alloc(0),
+    payload: ctx.paymentPayload as PaymentTermsSource,
+  });
+}
 
 /**
  * Cleans up expired cache and in-flight reservation entries.
@@ -106,20 +171,81 @@ const routes = {
   },
 };
 
+/**
+ * Release a pending reservation owned by this hook context.
+ *
+ * @param ctx - Verify/cancel hook context
+ * @param ctx.paymentPayload - Payment payload from the SDK hook
+ * @param ctx.transportContext - SDK HTTP transport context
+ */
+function releasePendingFromHook(ctx: {
+  paymentPayload: unknown;
+  transportContext?: unknown;
+}): void {
+  const paymentId = extractPaymentIdentifier(
+    ctx.paymentPayload as Parameters<typeof extractPaymentIdentifier>[0],
+  );
+  if (!paymentId) {
+    return;
+  }
+  releaseIfPending(
+    pendingReservations,
+    paymentId,
+    hookFingerprint(ctx),
+    Date.now(),
+    RESERVATION_TTL_MS,
+    hookReservationToken(ctx),
+  );
+}
+
 // Create the resource server with payment scheme support
 const resourceServer = new x402ResourceServer(facilitatorClient)
   .register("eip155:84532", new ExactEvmScheme())
-  // Hook after settlement to cache the response with its HTTP request fingerprint
-  .onAfterSettle(async ({ paymentPayload }) => {
-    const paymentId = extractPaymentIdentifier(paymentPayload);
+  .onBeforeSettle(async ctx => {
+    const paymentId = extractPaymentIdentifier(ctx.paymentPayload);
+    if (!paymentId) {
+      return;
+    }
+    const started = markSettlementStarted(
+      pendingReservations,
+      paymentId,
+      hookFingerprint(ctx),
+      Date.now(),
+      RESERVATION_TTL_MS,
+      hookReservationToken(ctx),
+    );
+    if (!started) {
+      return { abort: true, reason: "payment_identifier_reservation_lost" };
+    }
+  })
+  // Hook after settlement to cache only this request's matching reservation.
+  .onAfterSettle(async (ctx: SettleResultContext) => {
+    if (!ctx.result.success) {
+      const paymentId = extractPaymentIdentifier(ctx.paymentPayload);
+      if (!paymentId) {
+        return;
+      }
+      releaseReservation(
+        pendingReservations,
+        paymentId,
+        hookFingerprint(ctx),
+        Date.now(),
+        RESERVATION_TTL_MS,
+        hookReservationToken(ctx),
+      );
+      return;
+    }
+    const paymentId = extractPaymentIdentifier(ctx.paymentPayload);
     if (!paymentId) {
       return;
     }
     const fingerprint = consumeReservation(
       pendingReservations,
       paymentId,
+      hookFingerprint(ctx),
       Date.now(),
       RESERVATION_TTL_MS,
+      hookReservationToken(ctx),
     );
     if (!fingerprint) {
       return;
@@ -136,6 +262,31 @@ const resourceServer = new x402ResourceServer(facilitatorClient)
         },
       },
     });
+  })
+  .onVerifyFailure(async (ctx: VerifyFailureContext) => {
+    releasePendingFromHook(ctx);
+  })
+  .onAfterVerify(async (ctx: VerifyResultContext) => {
+    if (!ctx.result.isValid) {
+      releasePendingFromHook(ctx);
+    }
+  })
+  .onSettleFailure(async (ctx: SettleFailureContext) => {
+    const paymentId = extractPaymentIdentifier(ctx.paymentPayload);
+    if (!paymentId) {
+      return;
+    }
+    markOutcomeUnknown(
+      pendingReservations,
+      paymentId,
+      hookFingerprint(ctx),
+      Date.now(),
+      RESERVATION_TTL_MS,
+      hookReservationToken(ctx),
+    );
+  })
+  .onVerifiedPaymentCanceled(async (ctx: VerifiedPaymentCanceledContext) => {
+    releasePendingFromHook(ctx);
   });
 
 const httpServer = new x402HTTPResourceServer(resourceServer, routes);
@@ -145,7 +296,13 @@ const app = express();
 // Run before payment middleware so a fingerprint mismatch returns 409
 // without grantAccess and without payment verification.
 app.use((req, res, next) => {
-  cleanupExpiredEntries();
+  const failClosed = () => {
+    res.setHeader("Retry-After", String(RETRY_AFTER_SECONDS));
+    res.status(RETRYABLE_STATUS_CODE).json({
+      error: "payment identifier storage unavailable",
+      retryable: true,
+    });
+  };
 
   const paymentHeader = req.header("payment-signature") || req.header("x-payment");
   if (!paymentHeader) {
@@ -153,22 +310,38 @@ app.use((req, res, next) => {
     return;
   }
 
+  let paymentPayload: unknown;
   try {
-    const paymentPayload = JSON.parse(Buffer.from(paymentHeader, "base64").toString("utf-8"));
-    const paymentId = extractPaymentIdentifier(paymentPayload);
-    if (!paymentId) {
-      next();
-      return;
-    }
+    paymentPayload = JSON.parse(Buffer.from(paymentHeader, "base64").toString("utf-8"));
+  } catch {
+    // Only malformed header decoding may continue to normal payment handling.
+    next();
+    return;
+  }
+  const paymentId = extractPaymentIdentifier(paymentPayload);
+  if (!paymentId) {
+    next();
+    return;
+  }
+  if (!isProtectedRoute(req.method, req.path || req.url, routes)) {
+    next();
+    return;
+  }
 
+  let fingerprint: string;
+  let decision: ReturnType<typeof bindPaymentId>;
+  let cached: CachedResponse | undefined;
+  let reserved: Reservation | undefined;
+  try {
+    cleanupExpiredEntries();
     console.log(`[Idempotency] Checking payment ID: ${paymentId}`);
-    const fingerprint = requestFingerprint({
+    fingerprint = requestFingerprint({
       method: req.method,
       url: req.originalUrl || req.url,
       body: requestBodyBytes(req),
       payload: paymentPayload,
     });
-    const decision = bindPaymentId({
+    decision = bindPaymentId({
       cache: idempotencyCache,
       reservations: pendingReservations,
       paymentId,
@@ -177,46 +350,83 @@ app.use((req, res, next) => {
       cacheTtlMs: CACHE_TTL_MS,
       reservationTtlMs: RESERVATION_TTL_MS,
     });
-
-    if (decision.kind === "conflict") {
-      console.log(`[Idempotency] CONFLICT - same ID, different request`);
-      res.status(409).json({
-        error: CONFLICT_MESSAGE,
-        paymentId,
-      });
-      return;
-    }
-
-    if (decision.kind === "in_flight") {
-      console.log(`[Idempotency] IN FLIGHT - same ID, request already reserved`);
-      res.status(409).json({
-        error: IN_FLIGHT_MESSAGE,
-        paymentId,
-      });
-      return;
-    }
-
     if (decision.kind === "hit") {
-      const cached = idempotencyCache.get(paymentId);
-      if (cached) {
-        const age = Date.now() - cached.timestamp;
-        console.log(
-          `[Idempotency] Cache HIT - returning cached response (age: ${Math.round(age / 1000)}s)`,
-        );
-        res.json({
-          report: {
-            ...cached.response.report,
-            cached: true,
-          },
-        });
-        return;
+      cached = idempotencyCache.get(paymentId);
+      if (!cached) {
+        throw new Error("cache hit disappeared");
+      }
+    } else if (decision.kind === "miss") {
+      reserved = pendingReservations.get(paymentId);
+      if (!reserved?.token) {
+        throw new Error("reservation missing after bind");
       }
     }
-
-    console.log(`[Idempotency] Cache MISS - reserved, proceeding with payment`);
   } catch {
-    // Invalid payment header format, continue to normal flow
+    failClosed();
+    return;
   }
+
+  if (decision.kind === "conflict") {
+    console.log(`[Idempotency] CONFLICT - same ID, different request`);
+    res.status(409).json({
+      error: CONFLICT_MESSAGE,
+      paymentId,
+    });
+    return;
+  }
+
+  if (decision.kind === "in_flight") {
+    console.log(`[Idempotency] IN FLIGHT - retryable, request already reserved`);
+    res.setHeader("Retry-After", String(RETRY_AFTER_SECONDS));
+    res.status(RETRYABLE_STATUS_CODE).json({
+      error: IN_FLIGHT_MESSAGE,
+      paymentId,
+      retryable: true,
+    });
+    return;
+  }
+
+  if (decision.kind === "capacity") {
+    console.log(`[Idempotency] CAPACITY - retryable, reservation map is full`);
+    res.setHeader("Retry-After", String(RETRY_AFTER_SECONDS));
+    res.status(RETRYABLE_STATUS_CODE).json({
+      error: CAPACITY_MESSAGE,
+      paymentId,
+      retryable: true,
+    });
+    return;
+  }
+
+  if (decision.kind === "hit" && cached) {
+    const age = Date.now() - cached.timestamp;
+    console.log(
+      `[Idempotency] Cache HIT - returning cached response (age: ${Math.round(age / 1000)}s)`,
+    );
+    res.json({
+      report: {
+        ...cached.response.report,
+        cached: true,
+      },
+    });
+    return;
+  }
+
+  (req as ReservationRequest).x402ReservationToken = reserved?.token;
+  const reservedToken = reserved?.token;
+  res.once("finish", () => {
+    if (!reservedToken) {
+      return;
+    }
+    releaseIfPending(
+      pendingReservations,
+      paymentId,
+      fingerprint,
+      Date.now(),
+      RESERVATION_TTL_MS,
+      reservedToken,
+    );
+  });
+  console.log(`[Idempotency] Cache MISS - reserved, proceeding with payment`);
 
   next();
 });
@@ -238,13 +448,25 @@ app.listen(4022, () => {
   console.log(`   Listening at http://localhost:4022`);
   console.log(`\n📋 Idempotency Configuration:`);
   console.log(`   - Cache TTL: 1 hour`);
-  console.log(`   - In-flight reservation TTL: 30 seconds`);
+  console.log(
+    `   - In-flight reservation TTL: ${RESERVATION_TTL_MS / 1000}s server-owned (not client maxTimeoutSeconds)`,
+  );
+  console.log(`   - Pending map bound: 1024 entries, fail closed at capacity`);
   console.log(`   - Payment ID: optional (required: false)`);
+  console.log(`   - Scope: GET-only, single-process in-memory example`);
   console.log(`\n💡 How it works:`);
   console.log(`   1. Client sends payment with a unique payment ID`);
-  console.log(`   2. Server caches the response bound to that ID and the HTTP request`);
-  console.log(`   3. Same ID and same request fingerprint returns the cached response`);
-  console.log(`   4. Same ID with a different method, path, query, or body returns 409`);
-  console.log(`   5. A live in-flight reservation is never overwritten`);
-  console.log(`   6. No duplicate payment processing occurs on a cache hit\n`);
+  console.log(`   2. Server caches the response bound to that ID, HTTP request, and credential`);
+  console.log(`   3. Same ID and same request+credential fingerprint returns the cached response`);
+  console.log(
+    `   4. Same ID with a different method, path, query, body, extra, timeout, or credential returns 409`,
+  );
+  console.log(`   5. In-flight and capacity responses are HTTP 503 retryable, not 409 conflict`);
+  console.log(`   6. Reservations are created only for GET /weather`);
+  console.log(
+    `   7. Pre-settlement rejection releases the matching reservation; thrown settle errors keep a tokenized tombstone until TTL`,
+  );
+  console.log(`   8. A settle failure is not immediately safe to retry`);
+  console.log(`   9. Retry the exact encoded payment header; do not create a new signature`);
+  console.log(`  10. No duplicate payment processing occurs on a cache hit\n`);
 });

--- a/examples/typescript/servers/payment-identifier/lifecycle.test.ts
+++ b/examples/typescript/servers/payment-identifier/lifecycle.test.ts
@@ -1,0 +1,543 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import http from "node:http";
+import { dirname, join } from "node:path";
+import { after, before, describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  RESERVATION_STATE_UNKNOWN,
+  RESERVATION_TTL_MS,
+  bindPaymentId,
+  consumeReservation,
+  isProtectedRoute,
+  markOutcomeUnknown,
+  markSettlementStarted,
+  releaseIfPending,
+  requestFingerprint,
+  reservationTokenFromTransportContext,
+  type Reservation,
+} from "./request-binding.ts";
+
+const PAYMENT_ID = "pay_aaaaaaaaaaaaaaaa";
+const PAID_ROUTES = { "GET /weather": {} };
+const PAYLOAD = {
+  x402Version: 2,
+  accepted: {
+    scheme: "exact",
+    network: "eip155:84532",
+    asset: "0x0000000000000000000000000000000000000001",
+    amount: "1000",
+    payTo: "0x0000000000000000000000000000000000000002",
+    maxTimeoutSeconds: 300,
+  },
+  payload: { signature: "0xsig" },
+  extensions: {
+    "payment-identifier": { info: { id: PAYMENT_ID, required: false } },
+  },
+};
+
+type Scenario =
+  | "no-match"
+  | "verify-fail"
+  | "settle-throw"
+  | "settle-ok"
+  | "reservation-lost"
+  | "storage-fail";
+
+/**
+ * Duck-typed Express request carrying the middleware reservation token.
+ */
+type TokenRequest = {
+  x402ReservationToken?: string;
+  method: string;
+  path: string;
+  originalUrl: string;
+  protocol: string;
+  headers: Record<string, string>;
+  header: (name: string) => string | undefined;
+  query: Record<string, string>;
+  body: unknown;
+};
+
+/**
+ * Build a request object with the ExpressAdapter field shape.
+ *
+ * @param url - Request URL
+ * @param token - Optional reservation token
+ * @returns Duck-typed Express request
+ */
+function tokenRequest(url: string, token?: string): TokenRequest {
+  const parsed = new URL(url, "http://localhost:4022");
+  const req: TokenRequest = {
+    x402ReservationToken: token,
+    method: "GET",
+    path: parsed.pathname,
+    originalUrl: `${parsed.pathname}${parsed.search}`,
+    protocol: "http",
+    headers: { host: "localhost:4022" },
+    header: () => undefined,
+    query: {},
+    body: undefined,
+  };
+  return req;
+}
+
+/**
+ * Instantiate the SDK ExpressAdapter, which stores the request on `req`.
+ *
+ * @param req - Duck-typed Express request
+ * @returns ExpressAdapter instance
+ */
+const EXPRESS_ADAPTER_SOURCE = readFileSync(
+  join(
+    dirname(fileURLToPath(import.meta.url)),
+    "../../../../typescript/packages/http/express/src/adapter.ts",
+  ),
+  "utf8",
+);
+
+/**
+ * Runtime twin of SDK ExpressAdapter: constructor(private req: Request).
+ */
+class ExpressAdapter {
+  /**
+   * Store the request the same way the SDK adapter does.
+   *
+   * @param req - Duck-typed Express request
+   */
+  constructor(private req: TokenRequest) {}
+}
+
+/**
+ * Instantiate the adapter shape the example middleware reads (`adapter.req`).
+ *
+ * @param req - Duck-typed Express request
+ * @returns Adapter with `req`
+ */
+function createExpressAdapter(req: TokenRequest): { req: TokenRequest } {
+  return new ExpressAdapter(req) as unknown as { req: TokenRequest };
+}
+
+/**
+ * Read the SDK adapter token from a hook-shaped transport context.
+ *
+ * @param req - Duck-typed Express request
+ * @returns Token from ExpressAdapter.req
+ */
+function tokenFromAdapter(req: TokenRequest): string | undefined {
+  const adapter = createExpressAdapter(req);
+  return reservationTokenFromTransportContext({
+    request: { adapter, path: req.path, method: req.method },
+  });
+}
+
+/**
+ * Start a harnessed HTTP server using the same bind/hook helpers as the example.
+ *
+ * @returns Server, maps, and captured hook token
+ */
+function startHarness(): {
+  server: http.Server;
+  url: () => string;
+  cache: Map<
+    string,
+    { timestamp: number; fingerprint: string; response: { report: { cached: boolean } } }
+  >;
+  reservations: Map<string, Reservation>;
+  seen: {
+    token?: string;
+    phase?: string;
+    aborted?: boolean;
+    settled?: boolean;
+    storageFailed?: boolean;
+  };
+} {
+  const cache = new Map<
+    string,
+    { timestamp: number; fingerprint: string; response: { report: { cached: boolean } } }
+  >();
+  const reservations = new Map<string, Reservation>();
+  const seen: {
+    token?: string;
+    phase?: string;
+    aborted?: boolean;
+    settled?: boolean;
+    storageFailed?: boolean;
+  } = {};
+
+  const server = http.createServer((incoming, res) => {
+    try {
+      const host = incoming.headers.host || "localhost:4022";
+      const url = `http://${host}${incoming.url || "/"}`;
+      const parsed = new URL(url);
+      const scenario = (incoming.headers["x-test-scenario"] as Scenario | undefined) || "no-match";
+      const req = tokenRequest(url);
+      const fingerprint = requestFingerprint({
+        method: "GET",
+        url,
+        body: Buffer.alloc(0),
+        payload: PAYLOAD,
+      });
+
+      if (incoming.headers["payment-signature"] || incoming.headers["x-payment"]) {
+        if (isProtectedRoute("GET", parsed.pathname, PAID_ROUTES)) {
+          let decision: ReturnType<typeof bindPaymentId>;
+          try {
+            if (scenario === "storage-fail") {
+              throw new Error("injected storage failure");
+            }
+            decision = bindPaymentId({
+              cache,
+              reservations,
+              paymentId: PAYMENT_ID,
+              fingerprint,
+              now: 0,
+              cacheTtlMs: 3_600_000,
+              reservationTtlMs: RESERVATION_TTL_MS,
+            });
+          } catch {
+            seen.storageFailed = true;
+            res.writeHead(503, {
+              "content-type": "application/json",
+              "retry-after": "1",
+            });
+            res.end(
+              JSON.stringify({
+                error: "payment identifier storage unavailable",
+                retryable: true,
+              }),
+            );
+            return;
+          }
+          if (decision.kind === "hit") {
+            res.writeHead(200, { "content-type": "application/json" });
+            res.end(JSON.stringify({ report: { cached: true } }));
+            return;
+          }
+          if (
+            decision.kind === "conflict" ||
+            decision.kind === "in_flight" ||
+            decision.kind === "capacity"
+          ) {
+            res.writeHead(decision.statusCode, { "content-type": "application/json" });
+            res.end(JSON.stringify({ kind: decision.kind }));
+            return;
+          }
+          const reserved = reservations.get(PAYMENT_ID);
+          if (reserved?.token) {
+            req.x402ReservationToken = reserved.token;
+            if (scenario === "reservation-lost") {
+              reservations.set(PAYMENT_ID, {
+                ...reserved,
+                token: "replacement-token",
+                state: "pending",
+              });
+            }
+          }
+        }
+      }
+
+      const adapterToken = tokenFromAdapter(req);
+      seen.token = adapterToken;
+
+      const finishPending = () => {
+        if (!req.x402ReservationToken) {
+          return;
+        }
+        releaseIfPending(
+          reservations,
+          PAYMENT_ID,
+          fingerprint,
+          2,
+          RESERVATION_TTL_MS,
+          req.x402ReservationToken,
+        );
+      };
+
+      if (parsed.pathname !== "/weather") {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ status: "ok" }));
+        return;
+      }
+
+      if (scenario === "verify-fail") {
+        seen.phase = "verify-fail";
+        if (adapterToken) {
+          releaseIfPending(
+            reservations,
+            PAYMENT_ID,
+            fingerprint,
+            1,
+            RESERVATION_TTL_MS,
+            adapterToken,
+          );
+        }
+        res.writeHead(402);
+        res.end(JSON.stringify({ error: "verify" }));
+        finishPending();
+        return;
+      }
+
+      if (scenario === "settle-throw") {
+        seen.phase = "before-settle";
+        if (adapterToken) {
+          markSettlementStarted(
+            reservations,
+            PAYMENT_ID,
+            fingerprint,
+            1,
+            RESERVATION_TTL_MS,
+            adapterToken,
+          );
+          markOutcomeUnknown(
+            reservations,
+            PAYMENT_ID,
+            fingerprint,
+            1,
+            RESERVATION_TTL_MS,
+            adapterToken,
+          );
+        }
+        res.writeHead(402);
+        res.end(JSON.stringify({ error: "settle-unknown" }));
+        finishPending();
+        return;
+      }
+
+      if (scenario === "settle-ok" || scenario === "reservation-lost") {
+        seen.phase = "after-settle";
+        if (adapterToken) {
+          const started = markSettlementStarted(
+            reservations,
+            PAYMENT_ID,
+            fingerprint,
+            1,
+            RESERVATION_TTL_MS,
+            adapterToken,
+          );
+          if (!started) {
+            seen.aborted = true;
+            res.writeHead(409, { "content-type": "application/json" });
+            res.end(JSON.stringify({ error: "payment_identifier_reservation_lost" }));
+            return;
+          }
+          seen.settled = true;
+          const consumed = consumeReservation(
+            reservations,
+            PAYMENT_ID,
+            fingerprint,
+            1,
+            RESERVATION_TTL_MS,
+            adapterToken,
+          );
+          if (consumed) {
+            cache.set(PAYMENT_ID, {
+              timestamp: 1,
+              fingerprint: consumed,
+              response: { report: { cached: false } },
+            });
+          }
+        }
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ report: { cached: false } }));
+        finishPending();
+        return;
+      }
+
+      seen.phase = "no-match";
+      res.writeHead(402);
+      res.end(JSON.stringify({ error: "no matching requirement" }));
+      finishPending();
+    } catch (error) {
+      res.writeHead(500, { "content-type": "application/json" });
+      res.end(JSON.stringify({ error: error instanceof Error ? error.message : "handler" }));
+    }
+  });
+
+  return {
+    server,
+    url: () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("server not listening");
+      }
+      return `http://127.0.0.1:${address.port}`;
+    },
+    cache,
+    reservations,
+    seen,
+  };
+}
+
+/**
+ * GET helper for the harnessed server.
+ *
+ * @param baseUrl - Server origin
+ * @param path - Request path
+ * @param scenario - Lifecycle scenario header
+ * @returns Status and JSON body
+ */
+async function getJson(
+  baseUrl: string,
+  path: string,
+  scenario?: Scenario,
+): Promise<{ status: number; body: Record<string, unknown> }> {
+  const header = Buffer.from(JSON.stringify(PAYLOAD)).toString("base64");
+  const response = await fetch(`${baseUrl}${path}`, {
+    headers: {
+      "payment-signature": header,
+      ...(scenario ? { "x-test-scenario": scenario } : {}),
+    },
+    signal: AbortSignal.timeout(3000),
+  });
+  return { status: response.status, body: (await response.json()) as Record<string, unknown> };
+}
+
+describe("express adapter request lifecycle", () => {
+  const harness = startHarness();
+  before(async () => {
+    await new Promise<void>(resolve => {
+      harness.server.listen(0, "127.0.0.1", resolve);
+    });
+  });
+  after(() => {
+    harness.server.close();
+  });
+
+  it("SDK ExpressAdapter stores the request on req", () => {
+    assert.match(EXPRESS_ADAPTER_SOURCE, /export class ExpressAdapter implements HTTPAdapter/);
+    assert.match(EXPRESS_ADAPTER_SOURCE, /constructor\(private req: Request\)/);
+  });
+
+  it("carries the middleware token on ExpressAdapter.req into hook context", () => {
+    const req = tokenRequest("http://localhost:4022/weather", "token-live");
+    assert.equal(tokenFromAdapter(req), "token-live");
+    const adapter = createExpressAdapter(req);
+    assert.equal(
+      (adapter as unknown as { req: TokenRequest }).req.x402ReservationToken,
+      "token-live",
+    );
+  });
+
+  it("does not reserve unprotected /health", async () => {
+    const baseUrl = harness.url();
+    const health = await getJson(baseUrl, "/health");
+    assert.equal(health.status, 200);
+    assert.equal(harness.reservations.size, 0);
+    const weather = await getJson(baseUrl, "/weather", "settle-ok");
+    assert.equal(weather.status, 200);
+    assert.equal(harness.cache.has(PAYMENT_ID), true);
+  });
+
+  it("releases a pending reservation on pre-settlement rejection", async () => {
+    harness.cache.clear();
+    harness.reservations.clear();
+    const result = await getJson(harness.url(), "/weather", "no-match");
+    assert.equal(result.status, 402);
+    assert.equal(harness.seen.phase, "no-match");
+    assert.ok(harness.seen.token);
+    assert.equal(harness.reservations.has(PAYMENT_ID), false);
+  });
+
+  it("propagates the token into settle hooks and retains outcome-unknown", async () => {
+    harness.cache.clear();
+    harness.reservations.clear();
+    const result = await getJson(harness.url(), "/weather", "settle-throw");
+    assert.equal(result.status, 402);
+    assert.ok(harness.seen.token);
+    assert.equal(harness.reservations.get(PAYMENT_ID)?.state, RESERVATION_STATE_UNKNOWN);
+    assert.equal(harness.reservations.get(PAYMENT_ID)?.token, harness.seen.token);
+    const retry = await getJson(harness.url(), "/weather", "settle-ok");
+    assert.equal(retry.status, 503);
+    assert.equal(harness.cache.has(PAYMENT_ID), false);
+  });
+
+  it("consumes on successful settle and serves a cache hit", async () => {
+    harness.cache.clear();
+    harness.reservations.clear();
+    const result = await getJson(harness.url(), "/weather", "settle-ok");
+    assert.equal(result.status, 200);
+    assert.ok(harness.seen.token);
+    assert.equal(harness.cache.has(PAYMENT_ID), true);
+    assert.equal(harness.reservations.has(PAYMENT_ID), false);
+    const hit = await getJson(harness.url(), "/weather", "settle-ok");
+    assert.equal(hit.status, 200);
+    assert.equal(hit.body.report && (hit.body.report as { cached: boolean }).cached, true);
+  });
+
+  it("cleans up on verify failure before settlement", async () => {
+    harness.cache.clear();
+    harness.reservations.clear();
+    const result = await getJson(harness.url(), "/weather", "verify-fail");
+    assert.equal(result.status, 402);
+    assert.ok(harness.seen.token);
+    assert.equal(harness.reservations.has(PAYMENT_ID), false);
+  });
+
+  it("ignores a stale-token settle callback after replacement", async () => {
+    harness.cache.clear();
+    harness.reservations.clear();
+    const result = await getJson(harness.url(), "/weather", "settle-throw");
+    assert.equal(result.status, 402);
+    const original = harness.reservations.get(PAYMENT_ID);
+    assert.ok(original);
+    const staleToken = original.token;
+    harness.reservations.set(PAYMENT_ID, {
+      ...original,
+      token: "token-replacement",
+      state: "pending",
+    });
+    assert.equal(
+      consumeReservation(
+        harness.reservations,
+        PAYMENT_ID,
+        original.fingerprint,
+        1,
+        RESERVATION_TTL_MS,
+        staleToken,
+      ),
+      undefined,
+    );
+    assert.equal(
+      releaseIfPending(
+        harness.reservations,
+        PAYMENT_ID,
+        original.fingerprint,
+        1,
+        RESERVATION_TTL_MS,
+        staleToken,
+      ),
+      false,
+    );
+    assert.equal(harness.reservations.get(PAYMENT_ID)?.token, "token-replacement");
+  });
+
+  it("aborts before settlement when cleanup replaced the reservation token", async () => {
+    harness.cache.clear();
+    harness.reservations.clear();
+    harness.seen.aborted = false;
+    harness.seen.settled = false;
+    const result = await getJson(harness.url(), "/weather", "reservation-lost");
+    assert.equal(result.status, 409);
+    assert.equal(harness.seen.aborted, true);
+    assert.notEqual(harness.seen.settled, true);
+    assert.equal(harness.cache.has(PAYMENT_ID), false);
+    assert.equal(harness.reservations.get(PAYMENT_ID)?.token, "replacement-token");
+  });
+
+  it("fails closed before payment when identifier storage fails", async () => {
+    harness.cache.clear();
+    harness.reservations.clear();
+    harness.seen.storageFailed = false;
+    harness.seen.phase = undefined;
+    harness.seen.settled = false;
+    const result = await getJson(harness.url(), "/weather", "storage-fail");
+    assert.equal(result.status, 503);
+    assert.equal(result.body.retryable, true);
+    assert.equal(harness.seen.storageFailed, true);
+    assert.equal(harness.seen.phase, undefined);
+    assert.notEqual(harness.seen.settled, true);
+    assert.equal(harness.cache.size, 0);
+    assert.equal(harness.reservations.size, 0);
+  });
+});

--- a/examples/typescript/servers/payment-identifier/package.json
+++ b/examples/typescript/servers/payment-identifier/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "tsx index.ts",
-    "test": "tsx --test request-binding.test.ts",
+    "test": "tsx --test request-binding.test.ts lifecycle.test.ts",
     "format": "prettier -c .prettierrc --write \"**/*.{ts,js,cjs,json,md}\"",
     "format:check": "prettier -c .prettierrc --check \"**/*.{ts,js,cjs,json,md}\"",
     "lint": "eslint . --ext .ts --fix",

--- a/examples/typescript/servers/payment-identifier/package.json
+++ b/examples/typescript/servers/payment-identifier/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "tsx index.ts",
+    "test": "tsx --test request-binding.test.ts",
     "format": "prettier -c .prettierrc --write \"**/*.{ts,js,cjs,json,md}\"",
     "format:check": "prettier -c .prettierrc --check \"**/*.{ts,js,cjs,json,md}\"",
     "lint": "eslint . --ext .ts --fix",

--- a/examples/typescript/servers/payment-identifier/request-binding.test.ts
+++ b/examples/typescript/servers/payment-identifier/request-binding.test.ts
@@ -1,13 +1,34 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
 import {
+  CAPACITY_MESSAGE,
+  CONFLICT_STATUS_CODE,
+  FALLBACK_RESERVATION_TTL_MS,
+  MAX_PENDING_RESERVATIONS,
+  RESERVATION_STATE_PENDING,
+  RESERVATION_STATE_SETTLING,
+  RESERVATION_STATE_UNKNOWN,
   RESERVATION_TTL_MS,
+  RETRYABLE_STATUS_CODE,
   bindPaymentId,
+  canonicalAcceptedExtra,
+  canonicalMaxTimeoutSeconds,
+  canonicalRequestUrl,
   cleanupExpiredReservations,
   consumeReservation,
+  isProtectedRoute,
   lookup,
+  markOutcomeUnknown,
+  markSettlementStarted,
+  releaseIfPending,
+  releaseReservation,
   requestFingerprint,
+  reservationTtlMs,
   tryReserve,
+  type PaymentTermsSource,
   type Reservation,
 } from "./request-binding.ts";
 
@@ -16,6 +37,20 @@ const TTL_MS = 3600_000;
 const NOW = 1_000_000;
 const WEATHER = "http://localhost:4022/weather";
 const FORECAST = "http://localhost:4022/forecast";
+const CANONICAL_SAME_REQUEST_FINGERPRINT =
+  "3be3051236cf413f1cb88528fa8d9a7f22de774366f31fa7f319b972e943cc3f";
+const CANONICAL_EXTRA_FINGERPRINT =
+  "0565bb0ee3d8210ff27002b3c8e0748a570362835e1ef44186e1d4c967f2cf8c";
+const PAID_ROUTES = { "GET /weather": {} };
+const QUERY_FIXTURES = JSON.parse(
+  readFileSync(
+    join(
+      dirname(fileURLToPath(import.meta.url)),
+      "../../../shared/payment-identifier-query-fixtures.json",
+    ),
+    "utf8",
+  ),
+) as Array<{ name: string; url: string; canonical: string }>;
 
 const PAYLOAD = {
   x402Version: 2,
@@ -33,7 +68,12 @@ const PAYLOAD = {
 };
 
 const fp = (
-  input: { method?: string; url?: string; body?: Buffer | string; payload?: typeof PAYLOAD } = {},
+  input: {
+    method?: string;
+    url?: string;
+    body?: Buffer | string;
+    payload?: PaymentTermsSource;
+  } = {},
 ) =>
   requestFingerprint({
     method: input.method ?? "GET",
@@ -46,6 +86,15 @@ const cached = (fingerprint: string) => ({
   timestamp: NOW,
   fingerprint,
   response: { report: { weather: "sunny" } },
+});
+
+const stored = (fingerprint: string, overrides: Partial<Reservation> = {}): Reservation => ({
+  fingerprint,
+  timestamp: NOW,
+  token: "token-a",
+  ttlMs: RESERVATION_TTL_MS,
+  state: RESERVATION_STATE_PENDING,
+  ...overrides,
 });
 
 const bind = (
@@ -113,6 +162,14 @@ describe("request-bound payment identifier", () => {
     assert.equal(decision.grantAccess, false);
   });
 
+  it("returns 409 and does not grant access on credential drift", () => {
+    const other = { ...PAYLOAD, payload: { signature: "0xforged" } };
+    const decision = lookup(cached(fp()), fp({ payload: other }), NOW + 1, TTL_MS);
+    assert.equal(decision.statusCode, 409);
+    assert.equal(decision.grantAccess, false);
+    assert.notEqual(fp(), fp({ payload: other }));
+  });
+
   it("treats a missing stored fingerprint as conflict", () => {
     const decision = lookup({ timestamp: NOW, response: {} }, fp(), NOW + 1, TTL_MS);
     assert.equal(decision.statusCode, 409);
@@ -142,7 +199,7 @@ describe("in-flight payment identifier reservation", () => {
     const second = bind(cache, reservations, fp());
     assert.equal(first.kind, "miss");
     assert.equal(second.kind, "in_flight");
-    assert.equal(second.statusCode, 409);
+    assert.equal(second.statusCode, RETRYABLE_STATUS_CODE);
     assert.equal(second.grantAccess, false);
     assert.equal(reservations.get(PAYMENT_ID)?.fingerprint, fp());
   });
@@ -154,7 +211,7 @@ describe("in-flight payment identifier reservation", () => {
     const second = bind(cache, reservations, fp({ url: FORECAST }));
     assert.equal(first.kind, "miss");
     assert.equal(second.kind, "conflict");
-    assert.equal(second.statusCode, 409);
+    assert.equal(second.statusCode, CONFLICT_STATUS_CODE);
     assert.equal(second.grantAccess, false);
   });
 
@@ -163,10 +220,11 @@ describe("in-flight payment identifier reservation", () => {
     const firstFp = fp({ url: WEATHER });
     const secondFp = fp({ url: FORECAST });
     tryReserve(reservations, PAYMENT_ID, firstFp, NOW, RESERVATION_TTL_MS);
+    const token = reservations.get(PAYMENT_ID)?.token;
     tryReserve(reservations, PAYMENT_ID, secondFp, NOW + 1, RESERVATION_TTL_MS);
     assert.equal(reservations.get(PAYMENT_ID)?.fingerprint, firstFp);
     assert.equal(
-      consumeReservation(reservations, PAYMENT_ID, NOW + 2, RESERVATION_TTL_MS),
+      consumeReservation(reservations, PAYMENT_ID, firstFp, NOW + 2, RESERVATION_TTL_MS, token),
       firstFp,
     );
   });
@@ -199,23 +257,25 @@ describe("in-flight payment identifier reservation", () => {
     const fingerprint = consumeReservation(
       new Map<string, Reservation>(),
       PAYMENT_ID,
+      fp(),
       NOW,
       RESERVATION_TTL_MS,
+      "token-a",
     );
     assert.equal(fingerprint, undefined);
   });
 
-  it("does not cache when the reservation is expired at settle", () => {
-    const reservations = new Map<string, Reservation>([
-      [PAYMENT_ID, { fingerprint: fp(), timestamp: NOW }],
-    ]);
+  it("accepts an expired exact current-token settlement callback when not replaced", () => {
+    const reservations = new Map<string, Reservation>([[PAYMENT_ID, stored(fp())]]);
     const fingerprint = consumeReservation(
       reservations,
       PAYMENT_ID,
+      fp(),
       NOW + RESERVATION_TTL_MS,
       RESERVATION_TTL_MS,
+      "token-a",
     );
-    assert.equal(fingerprint, undefined);
+    assert.equal(fingerprint, fp());
     assert.equal(reservations.has(PAYMENT_ID), false);
   });
 
@@ -224,18 +284,411 @@ describe("in-flight payment identifier reservation", () => {
     const reservations = new Map<string, Reservation>();
     const first = bind(cache, reservations, fp());
     assert.equal(first.kind, "miss");
-    const stored = consumeReservation(reservations, PAYMENT_ID, NOW + 2, RESERVATION_TTL_MS);
-    assert.equal(stored, fp());
+    const token = reservations.get(PAYMENT_ID)?.token;
+    const storedFp = consumeReservation(
+      reservations,
+      PAYMENT_ID,
+      fp(),
+      NOW + 2,
+      RESERVATION_TTL_MS,
+      token,
+    );
+    assert.equal(storedFp, fp());
     cache.set(PAYMENT_ID, {
       timestamp: NOW + 2,
-      fingerprint: stored,
+      fingerprint: storedFp,
     });
-    const leftover: Reservation = { fingerprint: fp({ url: FORECAST }), timestamp: NOW + 2 };
+    const leftover = stored(fp({ url: FORECAST }), { timestamp: NOW + 2, token: "token-b" });
     reservations.set(PAYMENT_ID, leftover);
     const retry = bind(cache, reservations, fp(), NOW + 3);
     assert.equal(retry.kind, "hit");
     assert.equal(retry.statusCode, 200);
     assert.equal(retry.grantAccess, true);
     assert.deepEqual(reservations.get(PAYMENT_ID), leftover);
+  });
+});
+
+describe("protected paid routes", () => {
+  it("protects GET /weather and ignores query", () => {
+    assert.equal(isProtectedRoute("GET", WEATHER, PAID_ROUTES), true);
+    assert.equal(isProtectedRoute("GET", "/weather?city=nyc", PAID_ROUTES), true);
+  });
+
+  it("does not reserve /health or an unmatched path", () => {
+    assert.equal(isProtectedRoute("GET", "http://localhost:4022/health", PAID_ROUTES), false);
+    assert.equal(isProtectedRoute("GET", "/not-a-paid-route", PAID_ROUTES), false);
+  });
+
+  it("does not let an unprotected header block the paid route", () => {
+    const cache = new Map<string, { timestamp: number; fingerprint?: string }>();
+    const reservations = new Map<string, Reservation>();
+    assert.equal(isProtectedRoute("GET", "http://localhost:4022/health", PAID_ROUTES), false);
+    assert.equal(reservations.has(PAYMENT_ID), false);
+    const weather = bind(cache, reservations, fp());
+    assert.equal(weather.kind, "miss");
+    assert.equal(reservations.get(PAYMENT_ID)?.fingerprint, fp());
+  });
+});
+
+describe("reservation release and matching consume", () => {
+  it("releases the matching reservation immediately on verify failure", () => {
+    const reservations = new Map<string, Reservation>();
+    tryReserve(reservations, PAYMENT_ID, fp(), NOW, RESERVATION_TTL_MS);
+    const token = reservations.get(PAYMENT_ID)?.token;
+    const released = releaseReservation(
+      reservations,
+      PAYMENT_ID,
+      fp(),
+      NOW + 1,
+      RESERVATION_TTL_MS,
+      token,
+    );
+    assert.equal(released, true);
+    assert.equal(reservations.has(PAYMENT_ID), false);
+    const retry = tryReserve(reservations, PAYMENT_ID, fp(), NOW + 2, RESERVATION_TTL_MS);
+    assert.equal(retry.kind, "miss");
+  });
+
+  it("does not drop a replacement from a stale failure callback", () => {
+    const replacement = stored(fp({ url: FORECAST }), {
+      timestamp: NOW + 1,
+      token: "token-b",
+    });
+    const reservations = new Map<string, Reservation>([[PAYMENT_ID, replacement]]);
+    const dropped = releaseReservation(
+      reservations,
+      PAYMENT_ID,
+      fp(),
+      NOW + 2,
+      RESERVATION_TTL_MS,
+      "token-a",
+    );
+    assert.equal(dropped, false);
+    assert.deepEqual(reservations.get(PAYMENT_ID), replacement);
+  });
+
+  it("does not consume a replacement from a stale settle callback", () => {
+    const replacementFp = fp({ url: FORECAST });
+    const reservations = new Map<string, Reservation>([
+      [PAYMENT_ID, stored(replacementFp, { timestamp: NOW + 1, token: "token-b" })],
+    ]);
+    const stolen = consumeReservation(
+      reservations,
+      PAYMENT_ID,
+      fp(),
+      NOW + 2,
+      RESERVATION_TTL_MS,
+      "token-a",
+    );
+    assert.equal(stolen, undefined);
+    assert.equal(reservations.get(PAYMENT_ID)?.fingerprint, replacementFp);
+  });
+
+  it("does not cache a replacement after the original reservation expires", () => {
+    const replacement = stored(fp({ url: FORECAST }), {
+      timestamp: NOW + RESERVATION_TTL_MS,
+      token: "token-b",
+    });
+    const reservations = new Map<string, Reservation>([[PAYMENT_ID, replacement]]);
+    const cachedFp = consumeReservation(
+      reservations,
+      PAYMENT_ID,
+      fp(),
+      NOW + RESERVATION_TTL_MS + 1,
+      RESERVATION_TTL_MS,
+      "token-a",
+    );
+    assert.equal(cachedFp, undefined);
+    assert.deepEqual(reservations.get(PAYMENT_ID), replacement);
+  });
+
+  it("requires the matching token for a same-fingerprint replacement", () => {
+    const reservations = new Map<string, Reservation>([
+      [PAYMENT_ID, stored(fp(), { timestamp: NOW + RESERVATION_TTL_MS, token: "token-b" })],
+    ]);
+    const stolen = consumeReservation(
+      reservations,
+      PAYMENT_ID,
+      fp(),
+      NOW + RESERVATION_TTL_MS + 1,
+      RESERVATION_TTL_MS,
+      "token-a",
+    );
+    assert.equal(stolen, undefined);
+    assert.equal(reservations.has(PAYMENT_ID), true);
+  });
+});
+
+describe("reservation ttl is server policy", () => {
+  it("ignores a tiny client maxTimeoutSeconds when choosing map TTL", () => {
+    const payload = { ...PAYLOAD, accepted: { ...PAYLOAD.accepted, maxTimeoutSeconds: 1 } };
+    const reservations = new Map<string, Reservation>();
+    tryReserve(reservations, PAYMENT_ID, fp({ payload }), NOW, reservationTtlMs());
+    const blocked = tryReserve(
+      reservations,
+      PAYMENT_ID,
+      fp({ payload }),
+      NOW + 2_000,
+      reservationTtlMs(),
+    );
+    assert.equal(blocked.kind, "in_flight");
+    assert.equal(reservationTtlMs(), RESERVATION_TTL_MS);
+    assert.equal(FALLBACK_RESERVATION_TTL_MS, 300_000);
+  });
+
+  it("ignores a huge client maxTimeoutSeconds when choosing map TTL", () => {
+    const payload = { ...PAYLOAD, accepted: { ...PAYLOAD.accepted, maxTimeoutSeconds: 1_000_000 } };
+    const reservations = new Map<string, Reservation>();
+    tryReserve(reservations, PAYMENT_ID, fp({ payload }), NOW, reservationTtlMs());
+    const removed = cleanupExpiredReservations(
+      reservations,
+      NOW + RESERVATION_TTL_MS,
+      reservationTtlMs(),
+    );
+    assert.equal(removed, 1);
+    assert.equal(reservations.has(PAYMENT_ID), false);
+  });
+
+  it("expires only after the server-owned 300s TTL", () => {
+    const reservations = new Map<string, Reservation>();
+    tryReserve(reservations, PAYMENT_ID, fp(), NOW, RESERVATION_TTL_MS);
+    assert.equal(
+      cleanupExpiredReservations(reservations, NOW + RESERVATION_TTL_MS - 1, RESERVATION_TTL_MS),
+      0,
+    );
+    assert.equal(
+      cleanupExpiredReservations(reservations, NOW + RESERVATION_TTL_MS, RESERVATION_TTL_MS),
+      1,
+    );
+  });
+});
+
+describe("reservation capacity", () => {
+  it("fails closed at 1024 live entries without overwriting", () => {
+    const reservations = new Map<string, Reservation>();
+    for (let index = 0; index < MAX_PENDING_RESERVATIONS; index += 1) {
+      const decision = tryReserve(
+        reservations,
+        `pay_${index.toString().padStart(4, "0")}`,
+        fp(),
+        NOW,
+        RESERVATION_TTL_MS,
+      );
+      assert.equal(decision.kind, "miss");
+    }
+    assert.equal(reservations.size, MAX_PENDING_RESERVATIONS);
+    const overflow = tryReserve(reservations, PAYMENT_ID, fp(), NOW, RESERVATION_TTL_MS);
+    assert.equal(overflow.kind, "capacity");
+    assert.equal(overflow.statusCode, RETRYABLE_STATUS_CODE);
+    assert.equal(overflow.grantAccess, false);
+    assert.equal(reservations.size, MAX_PENDING_RESERVATIONS);
+    assert.equal(reservations.has(PAYMENT_ID), false);
+    assert.equal(CAPACITY_MESSAGE.length > 0, true);
+  });
+
+  it("accepts a new reservation after expired cleanup below capacity", () => {
+    const reservations = new Map<string, Reservation>();
+    for (let index = 0; index < MAX_PENDING_RESERVATIONS; index += 1) {
+      tryReserve(
+        reservations,
+        `pay_${index.toString().padStart(4, "0")}`,
+        fp(),
+        NOW,
+        RESERVATION_TTL_MS,
+      );
+    }
+    const retry = tryReserve(
+      reservations,
+      PAYMENT_ID,
+      fp(),
+      NOW + RESERVATION_TTL_MS,
+      RESERVATION_TTL_MS,
+    );
+    assert.equal(retry.kind, "miss");
+    assert.equal(reservations.has(PAYMENT_ID), true);
+  });
+});
+
+describe("pre-settlement cleanup and outcome-unknown retention", () => {
+  it("releases a pending reservation before settlement begins", () => {
+    const reservations = new Map<string, Reservation>();
+    tryReserve(reservations, PAYMENT_ID, fp(), NOW, RESERVATION_TTL_MS);
+    const token = reservations.get(PAYMENT_ID)?.token;
+    assert.equal(
+      releaseIfPending(reservations, PAYMENT_ID, fp(), NOW + 1, RESERVATION_TTL_MS, token),
+      true,
+    );
+    assert.equal(reservations.has(PAYMENT_ID), false);
+  });
+
+  it("retains an outcome-unknown tombstone and rejects a fresh credential", () => {
+    const reservations = new Map<string, Reservation>();
+    tryReserve(reservations, PAYMENT_ID, fp(), NOW, RESERVATION_TTL_MS);
+    const token = reservations.get(PAYMENT_ID)?.token;
+    assert.equal(
+      markSettlementStarted(reservations, PAYMENT_ID, fp(), NOW + 1, RESERVATION_TTL_MS, token),
+      true,
+    );
+    assert.equal(reservations.get(PAYMENT_ID)?.state, RESERVATION_STATE_SETTLING);
+    assert.equal(
+      markOutcomeUnknown(reservations, PAYMENT_ID, fp(), NOW + 2, RESERVATION_TTL_MS, token),
+      true,
+    );
+    assert.equal(reservations.get(PAYMENT_ID)?.state, RESERVATION_STATE_UNKNOWN);
+    assert.equal(
+      releaseIfPending(reservations, PAYMENT_ID, fp(), NOW + 3, RESERVATION_TTL_MS, token),
+      false,
+    );
+    assert.equal(
+      consumeReservation(reservations, PAYMENT_ID, fp(), NOW + 3, RESERVATION_TTL_MS, token),
+      undefined,
+    );
+    const other = fp({ payload: { ...PAYLOAD, payload: { signature: "0xforged" } } });
+    const fresh = tryReserve(reservations, PAYMENT_ID, other, NOW + 4, RESERVATION_TTL_MS);
+    assert.equal(fresh.kind, "conflict");
+    assert.equal(reservations.get(PAYMENT_ID)?.state, RESERVATION_STATE_UNKNOWN);
+    const same = tryReserve(reservations, PAYMENT_ID, fp(), NOW + 5, RESERVATION_TTL_MS);
+    assert.equal(same.kind, "in_flight");
+  });
+
+  it("lets an exact current token enter settlement after its prior deadline", () => {
+    const reservations = new Map<string, Reservation>();
+    tryReserve(reservations, PAYMENT_ID, fp(), NOW, RESERVATION_TTL_MS);
+    const token = reservations.get(PAYMENT_ID)?.token;
+    const settlementStarted = NOW + RESERVATION_TTL_MS + 1;
+    assert.equal(
+      markSettlementStarted(
+        reservations,
+        PAYMENT_ID,
+        fp(),
+        settlementStarted,
+        RESERVATION_TTL_MS,
+        token,
+      ),
+      true,
+    );
+    assert.equal(reservations.get(PAYMENT_ID)?.timestamp, settlementStarted);
+    assert.equal(
+      consumeReservation(
+        reservations,
+        PAYMENT_ID,
+        fp(),
+        settlementStarted + RESERVATION_TTL_MS + 1,
+        RESERVATION_TTL_MS,
+        token,
+      ),
+      fp(),
+    );
+    assert.equal(reservations.has(PAYMENT_ID), false);
+  });
+
+  it("refreshes a full outcome-unknown window after the original deadline", () => {
+    const reservations = new Map<string, Reservation>();
+    tryReserve(reservations, PAYMENT_ID, fp(), NOW, RESERVATION_TTL_MS);
+    const token = reservations.get(PAYMENT_ID)?.token;
+    const settlementStarted = NOW + RESERVATION_TTL_MS - 1;
+    const outcomeUnknown = settlementStarted + RESERVATION_TTL_MS + 1;
+    assert.equal(
+      markSettlementStarted(
+        reservations,
+        PAYMENT_ID,
+        fp(),
+        settlementStarted,
+        RESERVATION_TTL_MS,
+        token,
+      ),
+      true,
+    );
+    assert.equal(
+      markOutcomeUnknown(reservations, PAYMENT_ID, fp(), outcomeUnknown, RESERVATION_TTL_MS, token),
+      true,
+    );
+    assert.equal(reservations.get(PAYMENT_ID)?.timestamp, outcomeUnknown);
+    const other = fp({ payload: { ...PAYLOAD, payload: { signature: "0xforged" } } });
+    assert.equal(
+      tryReserve(
+        reservations,
+        PAYMENT_ID,
+        other,
+        outcomeUnknown + RESERVATION_TTL_MS - 1,
+        RESERVATION_TTL_MS,
+      ).kind,
+      "conflict",
+    );
+  });
+
+  it("does not mark unknown or consume with a missing or wrong token", () => {
+    const reservations = new Map<string, Reservation>([
+      [PAYMENT_ID, stored(fp(), { token: "token-b" })],
+    ]);
+    assert.equal(
+      markOutcomeUnknown(reservations, PAYMENT_ID, fp(), NOW + 1, RESERVATION_TTL_MS),
+      false,
+    );
+    assert.equal(
+      markOutcomeUnknown(reservations, PAYMENT_ID, fp(), NOW + 1, RESERVATION_TTL_MS, "token-a"),
+      false,
+    );
+    assert.equal(
+      markSettlementStarted(reservations, PAYMENT_ID, fp(), NOW + 1, RESERVATION_TTL_MS, "token-a"),
+      false,
+    );
+    assert.equal(
+      consumeReservation(reservations, PAYMENT_ID, fp(), NOW + 1, RESERVATION_TTL_MS),
+      undefined,
+    );
+    assert.equal(reservations.get(PAYMENT_ID)?.token, "token-b");
+    assert.equal(reservations.get(PAYMENT_ID)?.state, RESERVATION_STATE_PENDING);
+    assert.equal(reservations.get(PAYMENT_ID)?.timestamp, NOW);
+  });
+});
+
+describe("accepted terms fingerprint", () => {
+  it("changes when maxTimeoutSeconds mutates", () => {
+    const other = { ...PAYLOAD, accepted: { ...PAYLOAD.accepted, maxTimeoutSeconds: 60 } };
+    assert.notEqual(fp(), fp({ payload: other }));
+    assert.equal(canonicalMaxTimeoutSeconds(PAYLOAD.accepted), "");
+    assert.equal(canonicalMaxTimeoutSeconds(other.accepted), "60");
+  });
+
+  it("changes when accepted.extra mutates and ignores extra key order", () => {
+    const extraA = {
+      ...PAYLOAD,
+      accepted: { ...PAYLOAD.accepted, extra: { z: 1, a: { b: 2 } } },
+    };
+    const extraB = {
+      ...PAYLOAD,
+      accepted: { ...PAYLOAD.accepted, extra: { a: { b: 2 }, z: 1 } },
+    };
+    const extraC = {
+      ...PAYLOAD,
+      accepted: { ...PAYLOAD.accepted, extra: { z: 1, a: { b: 3 } } },
+    };
+    assert.equal(fp({ payload: extraA }), fp({ payload: extraB }));
+    assert.notEqual(fp({ payload: extraA }), fp({ payload: extraC }));
+    assert.equal(canonicalAcceptedExtra(extraA.accepted), '{"a":{"b":2},"z":1}');
+  });
+});
+
+describe("canonical query encoding", () => {
+  for (const fixture of QUERY_FIXTURES) {
+    it(`encodes ${fixture.name}`, () => {
+      assert.equal(canonicalRequestUrl(fixture.url), fixture.canonical);
+    });
+  }
+});
+
+describe("cross-language canonical fixture", () => {
+  it("matches the Python same-request fingerprint", () => {
+    assert.equal(fp({ url: `${WEATHER}?b=2&a=1` }), CANONICAL_SAME_REQUEST_FINGERPRINT);
+    assert.equal(fp({ url: `${WEATHER}?a=1&b=2` }), CANONICAL_SAME_REQUEST_FINGERPRINT);
+  });
+
+  it("matches the Python extra fingerprint", () => {
+    const extra = {
+      ...PAYLOAD,
+      accepted: { ...PAYLOAD.accepted, extra: { z: 1, a: { b: 2 } } },
+    };
+    assert.equal(fp({ payload: extra }), CANONICAL_EXTRA_FINGERPRINT);
   });
 });

--- a/examples/typescript/servers/payment-identifier/request-binding.test.ts
+++ b/examples/typescript/servers/payment-identifier/request-binding.test.ts
@@ -1,0 +1,241 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  RESERVATION_TTL_MS,
+  bindPaymentId,
+  cleanupExpiredReservations,
+  consumeReservation,
+  lookup,
+  requestFingerprint,
+  tryReserve,
+  type Reservation,
+} from "./request-binding.ts";
+
+const PAYMENT_ID = "pay_aaaaaaaaaaaaaaaa";
+const TTL_MS = 3600_000;
+const NOW = 1_000_000;
+const WEATHER = "http://localhost:4022/weather";
+const FORECAST = "http://localhost:4022/forecast";
+
+const PAYLOAD = {
+  x402Version: 2,
+  accepted: {
+    scheme: "exact",
+    network: "eip155:84532",
+    asset: "0x0000000000000000000000000000000000000001",
+    amount: "1000",
+    payTo: "0x0000000000000000000000000000000000000002",
+  },
+  payload: { signature: "0xsig" },
+  extensions: {
+    "payment-identifier": { info: { id: PAYMENT_ID, required: false } },
+  },
+};
+
+const fp = (
+  input: { method?: string; url?: string; body?: Buffer | string; payload?: typeof PAYLOAD } = {},
+) =>
+  requestFingerprint({
+    method: input.method ?? "GET",
+    url: input.url ?? WEATHER,
+    body: input.body ?? Buffer.alloc(0),
+    payload: input.payload ?? PAYLOAD,
+  });
+
+const cached = (fingerprint: string) => ({
+  timestamp: NOW,
+  fingerprint,
+  response: { report: { weather: "sunny" } },
+});
+
+const bind = (
+  cache: Map<string, { timestamp: number; fingerprint?: string }>,
+  reservations: Map<string, Reservation>,
+  fingerprint: string,
+  now = NOW + 1,
+) =>
+  bindPaymentId({
+    cache,
+    reservations,
+    paymentId: PAYMENT_ID,
+    fingerprint,
+    now,
+    cacheTtlMs: TTL_MS,
+    reservationTtlMs: RESERVATION_TTL_MS,
+  });
+
+describe("request-bound payment identifier", () => {
+  it("hits on an identical retry", () => {
+    const decision = lookup(cached(fp()), fp(), NOW + 1, TTL_MS);
+    assert.equal(decision.kind, "hit");
+    assert.equal(decision.statusCode, 200);
+    assert.equal(decision.grantAccess, true);
+  });
+
+  it("returns 409 and does not grant access on method drift", () => {
+    const decision = lookup(cached(fp({ method: "GET" })), fp({ method: "POST" }), NOW + 1, TTL_MS);
+    assert.equal(decision.statusCode, 409);
+    assert.equal(decision.grantAccess, false);
+  });
+
+  it("returns 409 and does not grant access on path drift", () => {
+    const decision = lookup(cached(fp({ url: WEATHER })), fp({ url: FORECAST }), NOW + 1, TTL_MS);
+    assert.equal(decision.statusCode, 409);
+    assert.equal(decision.grantAccess, false);
+  });
+
+  it("returns 409 and does not grant access on body drift", () => {
+    const decision = lookup(
+      cached(fp({ body: Buffer.alloc(0) })),
+      fp({ body: '{"city":"nyc"}' }),
+      NOW + 1,
+      TTL_MS,
+    );
+    assert.equal(decision.statusCode, 409);
+    assert.equal(decision.grantAccess, false);
+  });
+
+  it("returns 409 and does not grant access on query drift", () => {
+    const decision = lookup(
+      cached(fp({ url: WEATHER })),
+      fp({ url: `${WEATHER}?city=nyc` }),
+      NOW + 1,
+      TTL_MS,
+    );
+    assert.equal(decision.statusCode, 409);
+    assert.equal(decision.grantAccess, false);
+  });
+
+  it("returns 409 and does not grant access on terms drift", () => {
+    const other = { ...PAYLOAD, accepted: { ...PAYLOAD.accepted, amount: "999999" } };
+    const decision = lookup(cached(fp()), fp({ payload: other }), NOW + 1, TTL_MS);
+    assert.equal(decision.statusCode, 409);
+    assert.equal(decision.grantAccess, false);
+  });
+
+  it("treats a missing stored fingerprint as conflict", () => {
+    const decision = lookup({ timestamp: NOW, response: {} }, fp(), NOW + 1, TTL_MS);
+    assert.equal(decision.statusCode, 409);
+    assert.equal(decision.grantAccess, false);
+  });
+
+  it("misses an unknown payment ID", () => {
+    const decision = lookup(undefined, fp(), NOW, TTL_MS);
+    assert.equal(decision.kind, "miss");
+    assert.equal(decision.grantAccess, false);
+  });
+
+  it("canonicalizes query parameter order", () => {
+    assert.equal(fp({ url: `${WEATHER}?b=2&a=1` }), fp({ url: `${WEATHER}?a=1&b=2` }));
+  });
+
+  it("preserves duplicate query key order", () => {
+    assert.notEqual(fp({ url: `${WEATHER}?a=1&a=2` }), fp({ url: `${WEATHER}?a=2&a=1` }));
+  });
+});
+
+describe("in-flight payment identifier reservation", () => {
+  it("returns in-flight conflict for the same ID and same request", () => {
+    const cache = new Map<string, { timestamp: number; fingerprint?: string }>();
+    const reservations = new Map<string, Reservation>();
+    const first = bind(cache, reservations, fp());
+    const second = bind(cache, reservations, fp());
+    assert.equal(first.kind, "miss");
+    assert.equal(second.kind, "in_flight");
+    assert.equal(second.statusCode, 409);
+    assert.equal(second.grantAccess, false);
+    assert.equal(reservations.get(PAYMENT_ID)?.fingerprint, fp());
+  });
+
+  it("returns request conflict for the same ID and a different request", () => {
+    const cache = new Map<string, { timestamp: number; fingerprint?: string }>();
+    const reservations = new Map<string, Reservation>();
+    const first = bind(cache, reservations, fp({ url: WEATHER }));
+    const second = bind(cache, reservations, fp({ url: FORECAST }));
+    assert.equal(first.kind, "miss");
+    assert.equal(second.kind, "conflict");
+    assert.equal(second.statusCode, 409);
+    assert.equal(second.grantAccess, false);
+  });
+
+  it("does not overwrite a live reservation", () => {
+    const reservations = new Map<string, Reservation>();
+    const firstFp = fp({ url: WEATHER });
+    const secondFp = fp({ url: FORECAST });
+    tryReserve(reservations, PAYMENT_ID, firstFp, NOW, RESERVATION_TTL_MS);
+    tryReserve(reservations, PAYMENT_ID, secondFp, NOW + 1, RESERVATION_TTL_MS);
+    assert.equal(reservations.get(PAYMENT_ID)?.fingerprint, firstFp);
+    assert.equal(
+      consumeReservation(reservations, PAYMENT_ID, NOW + 2, RESERVATION_TTL_MS),
+      firstFp,
+    );
+  });
+
+  it("expires a failed-payment reservation so the ID can proceed again", () => {
+    const reservations = new Map<string, Reservation>();
+    const first = tryReserve(reservations, PAYMENT_ID, fp(), NOW, RESERVATION_TTL_MS);
+    assert.equal(first.kind, "miss");
+    const blocked = tryReserve(reservations, PAYMENT_ID, fp(), NOW + 1, RESERVATION_TTL_MS);
+    assert.equal(blocked.kind, "in_flight");
+    const removed = cleanupExpiredReservations(
+      reservations,
+      NOW + RESERVATION_TTL_MS,
+      RESERVATION_TTL_MS,
+    );
+    assert.equal(removed, 1);
+    assert.equal(reservations.has(PAYMENT_ID), false);
+    const retry = tryReserve(
+      reservations,
+      PAYMENT_ID,
+      fp(),
+      NOW + RESERVATION_TTL_MS,
+      RESERVATION_TTL_MS,
+    );
+    assert.equal(retry.kind, "miss");
+    assert.equal(retry.grantAccess, false);
+  });
+
+  it("does not cache when the reservation is missing at settle", () => {
+    const fingerprint = consumeReservation(
+      new Map<string, Reservation>(),
+      PAYMENT_ID,
+      NOW,
+      RESERVATION_TTL_MS,
+    );
+    assert.equal(fingerprint, undefined);
+  });
+
+  it("does not cache when the reservation is expired at settle", () => {
+    const reservations = new Map<string, Reservation>([
+      [PAYMENT_ID, { fingerprint: fp(), timestamp: NOW }],
+    ]);
+    const fingerprint = consumeReservation(
+      reservations,
+      PAYMENT_ID,
+      NOW + RESERVATION_TTL_MS,
+      RESERVATION_TTL_MS,
+    );
+    assert.equal(fingerprint, undefined);
+    assert.equal(reservations.has(PAYMENT_ID), false);
+  });
+
+  it("hits on an identical retry after completed settlement", () => {
+    const cache = new Map<string, { timestamp: number; fingerprint?: string }>();
+    const reservations = new Map<string, Reservation>();
+    const first = bind(cache, reservations, fp());
+    assert.equal(first.kind, "miss");
+    const stored = consumeReservation(reservations, PAYMENT_ID, NOW + 2, RESERVATION_TTL_MS);
+    assert.equal(stored, fp());
+    cache.set(PAYMENT_ID, {
+      timestamp: NOW + 2,
+      fingerprint: stored,
+    });
+    const leftover: Reservation = { fingerprint: fp({ url: FORECAST }), timestamp: NOW + 2 };
+    reservations.set(PAYMENT_ID, leftover);
+    const retry = bind(cache, reservations, fp(), NOW + 3);
+    assert.equal(retry.kind, "hit");
+    assert.equal(retry.statusCode, 200);
+    assert.equal(retry.grantAccess, true);
+    assert.deepEqual(reservations.get(PAYMENT_ID), leftover);
+  });
+});

--- a/examples/typescript/servers/payment-identifier/request-binding.ts
+++ b/examples/typescript/servers/payment-identifier/request-binding.ts
@@ -1,0 +1,247 @@
+import { createHash } from "crypto";
+
+export const CONFLICT_MESSAGE = "payment identifier already used with different request";
+export const IN_FLIGHT_MESSAGE = "payment identifier is already being processed for this request";
+
+/**
+ * In-flight reservation TTL in milliseconds.
+ *
+ * Distinct from the one-hour settled cache TTL. Failed payment verification
+ * must not leak a pending entry or block the payment ID forever.
+ */
+export const RESERVATION_TTL_MS = 30_000;
+
+export type PaymentTermsSource = {
+  accepted?: {
+    scheme?: string;
+    network?: string;
+    asset?: string;
+    amount?: string;
+    payTo?: string;
+    pay_to?: string;
+  };
+};
+
+export type Reservation = {
+  fingerprint: string;
+  timestamp: number;
+};
+
+export type RequestFingerprintInput = {
+  method: string;
+  url: string;
+  body?: Buffer | string | null;
+  payload?: PaymentTermsSource | null;
+};
+
+export type BindPaymentIdInput = {
+  cache: {
+    get(paymentId: string): { timestamp: number; fingerprint?: string } | undefined;
+    delete(paymentId: string): boolean;
+  };
+  reservations: Map<string, Reservation>;
+  paymentId: string;
+  fingerprint: string;
+  now: number;
+  cacheTtlMs: number;
+  reservationTtlMs: number;
+};
+
+export type CacheDecision =
+  | { kind: "hit"; statusCode: 200; grantAccess: true }
+  | { kind: "conflict"; statusCode: 409; grantAccess: false }
+  | { kind: "in_flight"; statusCode: 409; grantAccess: false }
+  | { kind: "miss"; statusCode: null; grantAccess: false }
+  | { kind: "expired"; statusCode: null; grantAccess: false };
+
+/**
+ * Canonical path and sorted query, without host or fragment.
+ *
+ * Keys are sorted; duplicate-key order is preserved (URLSearchParams.sort()).
+ *
+ * @param url - Absolute URL or path with optional query
+ * @returns Canonical request target
+ */
+export function canonicalRequestUrl(url: string): string {
+  const parsed = new URL(url, "http://localhost");
+  parsed.searchParams.sort();
+  return parsed.search ? `${parsed.pathname}${parsed.search}` : parsed.pathname;
+}
+
+/**
+ * SHA-256 hex digest of the raw request body. Missing bodies hash as empty bytes.
+ *
+ * @param body - Raw request body
+ * @returns Hex digest
+ */
+export function bodySha256(body: Buffer | string | null | undefined): string {
+  const data = body == null ? Buffer.alloc(0) : Buffer.isBuffer(body) ? body : Buffer.from(body);
+  return createHash("sha256").update(data).digest("hex");
+}
+
+/**
+ * Fingerprint the HTTP request plus accepted payment terms.
+ *
+ * Hashing the payment payload or payment header is not request binding: the same
+ * signed payload can be replayed against a different method, path, or body.
+ *
+ * @param input - HTTP method, URL, raw body, and payment payload terms
+ * @returns SHA-256 hex digest
+ */
+export function requestFingerprint(input: RequestFingerprintInput): string {
+  const accepted = input.payload?.accepted ?? {};
+  const material = {
+    amount: String(accepted.amount ?? ""),
+    asset: String(accepted.asset ?? ""),
+    bodySha256: bodySha256(input.body),
+    method: (input.method || "").toUpperCase(),
+    network: String(accepted.network ?? ""),
+    payTo: String(accepted.payTo ?? accepted.pay_to ?? ""),
+    scheme: String(accepted.scheme ?? ""),
+    url: canonicalRequestUrl(input.url),
+  };
+  const keys = Object.keys(material).sort();
+  return createHash("sha256").update(JSON.stringify(material, keys)).digest("hex");
+}
+
+/**
+ * Look up a cached payment ID against the current request fingerprint.
+ *
+ * A conflict never grants access.
+ *
+ * @param cached - Existing cache entry, if any
+ * @param fingerprint - Fingerprint of the incoming HTTP request
+ * @param now - Current time in milliseconds
+ * @param ttlMs - Cache time to live in milliseconds
+ * @returns Cache decision
+ */
+export function lookup(
+  cached: { timestamp: number; fingerprint?: string } | undefined,
+  fingerprint: string,
+  now: number,
+  ttlMs: number,
+): CacheDecision {
+  if (!cached) {
+    return { kind: "miss", statusCode: null, grantAccess: false };
+  }
+  if (now - cached.timestamp >= ttlMs) {
+    return { kind: "expired", statusCode: null, grantAccess: false };
+  }
+  if (!cached.fingerprint || cached.fingerprint !== fingerprint) {
+    return { kind: "conflict", statusCode: 409, grantAccess: false };
+  }
+  return { kind: "hit", statusCode: 200, grantAccess: true };
+}
+
+/**
+ * Remove expired in-flight reservations in one pass over the current map.
+ *
+ * @param reservations - In-flight reservations keyed by payment ID
+ * @param now - Current time in milliseconds
+ * @param ttlMs - Reservation time to live in milliseconds
+ * @returns Number of reservations removed
+ */
+export function cleanupExpiredReservations(
+  reservations: Map<string, Reservation>,
+  now: number,
+  ttlMs: number,
+): number {
+  let removed = 0;
+  for (const [key, value] of reservations.entries()) {
+    if (now - value.timestamp >= ttlMs) {
+      reservations.delete(key);
+      removed += 1;
+    }
+  }
+  return removed;
+}
+
+/**
+ * Reserve a payment ID for an in-flight request, or refuse without granting access.
+ *
+ * A live reservation is never overwritten. Same fingerprint is an in-flight
+ * conflict; a different fingerprint is a request conflict. Expired entries are
+ * removed and replaced.
+ *
+ * @param reservations - In-flight reservations keyed by payment ID
+ * @param paymentId - Payment identifier
+ * @param fingerprint - Fingerprint of the incoming HTTP request
+ * @param now - Current time in milliseconds
+ * @param ttlMs - Reservation time to live in milliseconds
+ * @returns Reservation decision; never grants access
+ */
+export function tryReserve(
+  reservations: Map<string, Reservation>,
+  paymentId: string,
+  fingerprint: string,
+  now: number,
+  ttlMs: number,
+): CacheDecision {
+  const existing = reservations.get(paymentId);
+  if (existing && now - existing.timestamp < ttlMs) {
+    if (existing.fingerprint && existing.fingerprint === fingerprint) {
+      return { kind: "in_flight", statusCode: 409, grantAccess: false };
+    }
+    return { kind: "conflict", statusCode: 409, grantAccess: false };
+  }
+  if (existing) {
+    reservations.delete(paymentId);
+  }
+  reservations.set(paymentId, { fingerprint, timestamp: now });
+  return { kind: "miss", statusCode: null, grantAccess: false };
+}
+
+/**
+ * Consume a live reservation and return its fingerprint for caching.
+ *
+ * Missing or expired reservations return undefined and must not be cached.
+ *
+ * @param reservations - In-flight reservations keyed by payment ID
+ * @param paymentId - Payment identifier
+ * @param now - Current time in milliseconds
+ * @param ttlMs - Reservation time to live in milliseconds
+ * @returns Fingerprint to cache, or undefined if missing or expired
+ */
+export function consumeReservation(
+  reservations: Map<string, Reservation>,
+  paymentId: string,
+  now: number,
+  ttlMs: number,
+): string | undefined {
+  const existing = reservations.get(paymentId);
+  if (!existing) {
+    return undefined;
+  }
+  reservations.delete(paymentId);
+  if (now - existing.timestamp >= ttlMs || !existing.fingerprint) {
+    return undefined;
+  }
+  return existing.fingerprint;
+}
+
+/**
+ * Look up the settled cache, then reserve the payment ID if needed.
+ *
+ * Cache hits and settled conflicts win over reservations. An unexpired
+ * reservation never grants access and never proceeds to a second settlement.
+ *
+ * @param input - Cache, reservations, payment ID, fingerprint, and TTLs
+ * @returns Cache or reservation decision
+ */
+export function bindPaymentId(input: BindPaymentIdInput): CacheDecision {
+  const cached = input.cache.get(input.paymentId);
+  const decision = lookup(cached, input.fingerprint, input.now, input.cacheTtlMs);
+  if (decision.kind === "hit" || decision.kind === "conflict") {
+    return decision;
+  }
+  if (decision.kind === "expired") {
+    input.cache.delete(input.paymentId);
+  }
+  return tryReserve(
+    input.reservations,
+    input.paymentId,
+    input.fingerprint,
+    input.now,
+    input.reservationTtlMs,
+  );
+}

--- a/examples/typescript/servers/payment-identifier/request-binding.ts
+++ b/examples/typescript/servers/payment-identifier/request-binding.ts
@@ -1,15 +1,26 @@
-import { createHash } from "crypto";
+import { createHash, randomBytes } from "crypto";
 
 export const CONFLICT_MESSAGE = "payment identifier already used with different request";
 export const IN_FLIGHT_MESSAGE = "payment identifier is already being processed for this request";
+export const CAPACITY_MESSAGE = "payment identifier reservation map is at capacity";
+
+export const CONFLICT_STATUS_CODE = 409;
+export const RETRYABLE_STATUS_CODE = 503;
+export const RETRY_AFTER_SECONDS = 1;
 
 /**
- * In-flight reservation TTL in milliseconds.
- *
- * Distinct from the one-hour settled cache TTL. Failed payment verification
- * must not leak a pending entry or block the payment ID forever.
+ * Server-owned in-flight reservation TTL for this GET-only example.
+ * Client `accepted.maxTimeoutSeconds` is fingerprinted, never used as map TTL.
  */
-export const RESERVATION_TTL_MS = 30_000;
+export const RESERVATION_TTL_MS = 300_000;
+export const FALLBACK_RESERVATION_TTL_MS = RESERVATION_TTL_MS;
+export const MAX_PENDING_RESERVATIONS = 1024;
+
+export const RESERVATION_STATE_PENDING = "pending";
+export const RESERVATION_STATE_SETTLING = "settling";
+export const RESERVATION_STATE_UNKNOWN = "unknown";
+
+export type ReservationState = "pending" | "settling" | "unknown";
 
 export type PaymentTermsSource = {
   accepted?: {
@@ -19,12 +30,19 @@ export type PaymentTermsSource = {
     amount?: string;
     payTo?: string;
     pay_to?: string;
+    maxTimeoutSeconds?: number;
+    max_timeout_seconds?: number;
+    extra?: unknown;
   };
+  payload?: unknown;
 };
 
 export type Reservation = {
   fingerprint: string;
   timestamp: number;
+  token: string;
+  ttlMs: number;
+  state: ReservationState;
 };
 
 export type RequestFingerprintInput = {
@@ -44,28 +62,115 @@ export type BindPaymentIdInput = {
   fingerprint: string;
   now: number;
   cacheTtlMs: number;
-  reservationTtlMs: number;
+  reservationTtlMs?: number;
+  maxPending?: number;
 };
 
 export type CacheDecision =
   | { kind: "hit"; statusCode: 200; grantAccess: true }
   | { kind: "conflict"; statusCode: 409; grantAccess: false }
-  | { kind: "in_flight"; statusCode: 409; grantAccess: false }
+  | { kind: "in_flight"; statusCode: 503; grantAccess: false }
+  | { kind: "capacity"; statusCode: 503; grantAccess: false }
   | { kind: "miss"; statusCode: null; grantAccess: false }
   | { kind: "expired"; statusCode: null; grantAccess: false };
 
 /**
- * Canonical path and sorted query, without host or fragment.
+ * Canonical JSON with recursively sorted object keys.
  *
- * Keys are sorted; duplicate-key order is preserved (URLSearchParams.sort()).
+ * @param value - JSON-compatible value
+ * @returns Canonical JSON string
+ */
+export function canonicalJson(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value === undefined ? null : value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(item => canonicalJson(item)).join(",")}]`;
+  }
+  const record = value as Record<string, unknown>;
+  const keys = Object.keys(record).sort();
+  return `{${keys.map(key => `${JSON.stringify(key)}:${canonicalJson(record[key])}`).join(",")}}`;
+}
+
+/**
+ * RFC 3986 percent-encode one query component.
+ *
+ * Unreserved characters (`A-Z a-z 0-9 - . _ ~`) stay literal. Every other
+ * octet, including space, is `%`-encoded uppercase UTF-8. `~` is not encoded.
+ *
+ * @param value - Decoded query key or value
+ * @returns Encoded component
+ */
+export function rfc3986Encode(value: string): string {
+  const bytes = Buffer.from(value, "utf8");
+  let out = "";
+  for (const byte of bytes) {
+    const unreserved =
+      (byte >= 0x41 && byte <= 0x5a) ||
+      (byte >= 0x61 && byte <= 0x7a) ||
+      (byte >= 0x30 && byte <= 0x39) ||
+      byte === 0x2d ||
+      byte === 0x2e ||
+      byte === 0x5f ||
+      byte === 0x7e;
+    if (unreserved) {
+      out += String.fromCharCode(byte);
+    } else {
+      out += `%${byte.toString(16).toUpperCase().padStart(2, "0")}`;
+    }
+  }
+  return out;
+}
+
+/**
+ * Canonical path and query, without host or fragment.
+ *
+ * Query pairs are decoded, stably sorted by decoded key (duplicate-key order
+ * preserved), and re-encoded with {@link rfc3986Encode}. Spaces become `%20`.
  *
  * @param url - Absolute URL or path with optional query
  * @returns Canonical request target
  */
 export function canonicalRequestUrl(url: string): string {
   const parsed = new URL(url, "http://localhost");
-  parsed.searchParams.sort();
-  return parsed.search ? `${parsed.pathname}${parsed.search}` : parsed.pathname;
+  const pairs: Array<[string, string]> = [];
+  for (const [key, value] of parsed.searchParams) {
+    pairs.push([key, value]);
+  }
+  pairs.sort((left, right) => (left[0] < right[0] ? -1 : left[0] > right[0] ? 1 : 0));
+  const query = pairs
+    .map(([key, value]) => `${rfc3986Encode(key)}=${rfc3986Encode(value)}`)
+    .join("&");
+  return query ? `${parsed.pathname}?${query}` : parsed.pathname;
+}
+
+/**
+ * Path only for paid-route matching. Does not collapse `/foo/../weather`.
+ *
+ * @param url - Absolute URL or path with optional query
+ * @returns Request path
+ */
+export function requestPath(url: string): string {
+  const noQuery = url.split("?")[0] || "/";
+  const scheme = noQuery.indexOf("://");
+  if (scheme === -1) {
+    return noQuery.startsWith("/") ? noQuery || "/" : `/${noQuery}`;
+  }
+  const pathStart = noQuery.indexOf("/", scheme + 3);
+  return pathStart === -1 ? "/" : noQuery.slice(pathStart) || "/";
+}
+
+/**
+ * True when method+path is an exact paid route table key (e.g. `GET /weather`).
+ *
+ * @param method - HTTP method
+ * @param url - Absolute URL or path
+ * @param routes - Paid route table
+ * @returns Whether the route is protected
+ */
+export function isProtectedRoute(method: string, url: string, routes: object): boolean {
+  const key = `${(method || "").toUpperCase()} ${requestPath(url)}`;
+  return Object.prototype.hasOwnProperty.call(routes, key);
 }
 
 /**
@@ -80,12 +185,62 @@ export function bodySha256(body: Buffer | string | null | undefined): string {
 }
 
 /**
- * Fingerprint the HTTP request plus accepted payment terms.
+ * SHA-256 of canonical JSON for `payload.payload` (signature / authorization).
+ *
+ * @param payload - Payment payload
+ * @returns Hex digest
+ */
+export function credentialSha256(payload?: PaymentTermsSource | null): string {
+  const credential = payload?.payload;
+  const canonical =
+    credential === undefined || credential === null ? "" : canonicalJson(credential);
+  return createHash("sha256").update(canonical).digest("hex");
+}
+
+/**
+ * Canonical `maxTimeoutSeconds` string from camelCase or snake_case accepted terms.
+ *
+ * @param accepted - Accepted payment terms
+ * @returns String form, or empty when absent
+ */
+export function canonicalMaxTimeoutSeconds(accepted?: PaymentTermsSource["accepted"]): string {
+  const terms = accepted ?? {};
+  const raw = terms.maxTimeoutSeconds ?? terms.max_timeout_seconds;
+  return raw === undefined || raw === null ? "" : String(raw);
+}
+
+/**
+ * Recursively canonical JSON of `accepted.extra`. Missing extra is `{}`.
+ *
+ * @param accepted - Accepted payment terms
+ * @returns Canonical extra JSON
+ */
+export function canonicalAcceptedExtra(accepted?: PaymentTermsSource["accepted"]): string {
+  const extra = accepted?.extra;
+  if (extra === undefined || extra === null) {
+    return "{}";
+  }
+  return canonicalJson(extra);
+}
+
+/**
+ * Server-owned reservation TTL. Ignores client `maxTimeoutSeconds`.
+ *
+ * @returns TTL in milliseconds
+ */
+export function reservationTtlMs(): number {
+  return RESERVATION_TTL_MS;
+}
+
+/**
+ * Fingerprint the HTTP request, accepted terms, extra, timeout, and credential.
  *
  * Hashing the payment payload or payment header is not request binding: the same
  * signed payload can be replayed against a different method, path, or body.
+ * Hashing only the HTTP request is also insufficient: a stolen payment ID plus
+ * a fabricated credential must not retrieve the cached paid response.
  *
- * @param input - HTTP method, URL, raw body, and payment payload terms
+ * @param input - HTTP method, URL, raw body, and payment payload
  * @returns SHA-256 hex digest
  */
 export function requestFingerprint(input: RequestFingerprintInput): string {
@@ -94,6 +249,9 @@ export function requestFingerprint(input: RequestFingerprintInput): string {
     amount: String(accepted.amount ?? ""),
     asset: String(accepted.asset ?? ""),
     bodySha256: bodySha256(input.body),
+    credentialSha256: credentialSha256(input.payload),
+    extra: canonicalAcceptedExtra(accepted),
+    maxTimeoutSeconds: canonicalMaxTimeoutSeconds(accepted),
     method: (input.method || "").toUpperCase(),
     network: String(accepted.network ?? ""),
     payTo: String(accepted.payTo ?? accepted.pay_to ?? ""),
@@ -110,7 +268,7 @@ export function requestFingerprint(input: RequestFingerprintInput): string {
  * A conflict never grants access.
  *
  * @param cached - Existing cache entry, if any
- * @param fingerprint - Fingerprint of the incoming HTTP request
+ * @param fingerprint - Fingerprint of the incoming HTTP request and credential
  * @param now - Current time in milliseconds
  * @param ttlMs - Cache time to live in milliseconds
  * @returns Cache decision
@@ -128,9 +286,54 @@ export function lookup(
     return { kind: "expired", statusCode: null, grantAccess: false };
   }
   if (!cached.fingerprint || cached.fingerprint !== fingerprint) {
-    return { kind: "conflict", statusCode: 409, grantAccess: false };
+    return { kind: "conflict", statusCode: CONFLICT_STATUS_CODE, grantAccess: false };
   }
   return { kind: "hit", statusCode: 200, grantAccess: true };
+}
+
+/**
+ * Stored reservation TTL, falling back to the server-owned constant.
+ *
+ * @param storedTtlMs - TTL stored on the reservation
+ * @param ttlMs - Server-owned fallback TTL
+ * @returns Live window in milliseconds
+ */
+function liveLimit(storedTtlMs: number | undefined, ttlMs: number): number {
+  return storedTtlMs && storedTtlMs > 0 ? storedTtlMs : ttlMs;
+}
+
+/**
+ * True when the caller owns this reservation. Missing token never matches.
+ *
+ * @param existing - Stored reservation
+ * @param fingerprint - Caller fingerprint
+ * @param token - Caller token
+ * @returns Whether the caller may mutate the reservation
+ */
+function ownsReservation(
+  existing: Reservation,
+  fingerprint: string,
+  token: string | undefined,
+): boolean {
+  if (!token || !existing.token) {
+    return false;
+  }
+  if (!existing.fingerprint || existing.fingerprint !== fingerprint) {
+    return false;
+  }
+  return existing.token === token;
+}
+
+/**
+ * True when the reservation is still inside its server-owned TTL.
+ *
+ * @param existing - Stored reservation
+ * @param now - Current time in milliseconds
+ * @param ttlMs - Server-owned fallback TTL
+ * @returns Whether the reservation is live
+ */
+function isLive(existing: Reservation, now: number, ttlMs: number): boolean {
+  return now - existing.timestamp < liveLimit(existing.ttlMs, ttlMs);
 }
 
 /**
@@ -138,17 +341,17 @@ export function lookup(
  *
  * @param reservations - In-flight reservations keyed by payment ID
  * @param now - Current time in milliseconds
- * @param ttlMs - Reservation time to live in milliseconds
+ * @param ttlMs - Server-owned reservation time to live in milliseconds
  * @returns Number of reservations removed
  */
 export function cleanupExpiredReservations(
   reservations: Map<string, Reservation>,
   now: number,
-  ttlMs: number,
+  ttlMs: number = RESERVATION_TTL_MS,
 ): number {
   let removed = 0;
   for (const [key, value] of reservations.entries()) {
-    if (now - value.timestamp >= ttlMs) {
+    if (!isLive(value, now, ttlMs)) {
       reservations.delete(key);
       removed += 1;
     }
@@ -159,15 +362,18 @@ export function cleanupExpiredReservations(
 /**
  * Reserve a payment ID for an in-flight request, or refuse without granting access.
  *
- * A live reservation is never overwritten. Same fingerprint is an in-flight
- * conflict; a different fingerprint is a request conflict. Expired entries are
- * removed and replaced.
+ * A live reservation is never overwritten. Same fingerprint is a retryable
+ * in-flight response; a different fingerprint is a request conflict. Expired
+ * entries are removed and replaced with a fresh token. After expired cleanup,
+ * a full map of {@link MAX_PENDING_RESERVATIONS} fails closed with capacity.
  *
  * @param reservations - In-flight reservations keyed by payment ID
  * @param paymentId - Payment identifier
- * @param fingerprint - Fingerprint of the incoming HTTP request
+ * @param fingerprint - Fingerprint of the incoming HTTP request and credential
  * @param now - Current time in milliseconds
- * @param ttlMs - Reservation time to live in milliseconds
+ * @param ttlMs - Server-owned reservation time to live in milliseconds
+ * @param token - Optional caller-supplied reservation token
+ * @param maxPending - Maximum live reservations after cleanup
  * @returns Reservation decision; never grants access
  */
 export function tryReserve(
@@ -175,48 +381,229 @@ export function tryReserve(
   paymentId: string,
   fingerprint: string,
   now: number,
-  ttlMs: number,
+  ttlMs: number = RESERVATION_TTL_MS,
+  token?: string,
+  maxPending: number = MAX_PENDING_RESERVATIONS,
 ): CacheDecision {
+  cleanupExpiredReservations(reservations, now, ttlMs);
   const existing = reservations.get(paymentId);
-  if (existing && now - existing.timestamp < ttlMs) {
+  if (existing && isLive(existing, now, ttlMs)) {
     if (existing.fingerprint && existing.fingerprint === fingerprint) {
-      return { kind: "in_flight", statusCode: 409, grantAccess: false };
+      return { kind: "in_flight", statusCode: RETRYABLE_STATUS_CODE, grantAccess: false };
     }
-    return { kind: "conflict", statusCode: 409, grantAccess: false };
+    return { kind: "conflict", statusCode: CONFLICT_STATUS_CODE, grantAccess: false };
   }
   if (existing) {
     reservations.delete(paymentId);
   }
-  reservations.set(paymentId, { fingerprint, timestamp: now });
+  if (reservations.size >= maxPending) {
+    return { kind: "capacity", statusCode: RETRYABLE_STATUS_CODE, grantAccess: false };
+  }
+  reservations.set(paymentId, {
+    fingerprint,
+    timestamp: now,
+    token: token ?? randomBytes(16).toString("hex"),
+    ttlMs,
+    state: RESERVATION_STATE_PENDING,
+  });
   return { kind: "miss", statusCode: null, grantAccess: false };
 }
 
 /**
- * Consume a live reservation and return its fingerprint for caching.
+ * Consume a matching current reservation and return its fingerprint for caching.
  *
- * Missing or expired reservations return undefined and must not be cached.
+ * Outcome-unknown tombstones are retained. A stale callback that does not own
+ * the current reservation must not pop it. Missing token is never ownership.
  *
  * @param reservations - In-flight reservations keyed by payment ID
  * @param paymentId - Payment identifier
+ * @param fingerprint - Fingerprint that must match the reservation
  * @param now - Current time in milliseconds
- * @param ttlMs - Reservation time to live in milliseconds
- * @returns Fingerprint to cache, or undefined if missing or expired
+ * @param ttlMs - Server-owned reservation time to live in milliseconds
+ * @param token - Reservation token from the request that reserved
+ * @returns Fingerprint to cache, or undefined if missing, mismatched, or unknown
  */
 export function consumeReservation(
   reservations: Map<string, Reservation>,
   paymentId: string,
+  fingerprint: string,
   now: number,
-  ttlMs: number,
+  ttlMs: number = RESERVATION_TTL_MS,
+  token?: string,
 ): string | undefined {
+  // Retained for call-site symmetry and compatibility. Exact current-token
+  // callbacks are authoritative even after this phase deadline; cleanup and a
+  // replacement token, rather than wall-clock age alone, revoke ownership.
+  void now;
+  void ttlMs;
   const existing = reservations.get(paymentId);
-  if (!existing) {
+  if (!existing || !ownsReservation(existing, fingerprint, token)) {
     return undefined;
+  }
+  if (existing.state === RESERVATION_STATE_UNKNOWN) {
+    return undefined;
+  }
+  if (!existing.fingerprint) {
+    return undefined;
+  }
+  // An exact current token may finish after its phase deadline if no cleanup
+  // request has replaced it. A replacement has a different token and fails
+  // ownership above, so a stale callback cannot consume newer work.
+  reservations.delete(paymentId);
+  return existing.fingerprint;
+}
+
+/**
+ * Drop a matching pending or settling reservation. Unknown tombstones stay.
+ *
+ * @param reservations - In-flight reservations keyed by payment ID
+ * @param paymentId - Payment identifier
+ * @param fingerprint - Fingerprint that must match the reservation
+ * @param now - Current time in milliseconds
+ * @param ttlMs - Server-owned reservation time to live in milliseconds
+ * @param token - Reservation token from the request that reserved
+ * @returns True when a live matching reservation was removed
+ */
+export function releaseReservation(
+  reservations: Map<string, Reservation>,
+  paymentId: string,
+  fingerprint: string,
+  now: number,
+  ttlMs: number = RESERVATION_TTL_MS,
+  token?: string,
+): boolean {
+  const existing = reservations.get(paymentId);
+  if (!existing || !ownsReservation(existing, fingerprint, token)) {
+    return false;
+  }
+  if (existing.state === RESERVATION_STATE_UNKNOWN) {
+    return false;
+  }
+  if (!isLive(existing, now, ttlMs)) {
+    return false;
   }
   reservations.delete(paymentId);
-  if (now - existing.timestamp >= ttlMs || !existing.fingerprint) {
-    return undefined;
+  return true;
+}
+
+/**
+ * Release only a pending pre-settlement reservation owned by this token.
+ *
+ * @param reservations - In-flight reservations keyed by payment ID
+ * @param paymentId - Payment identifier
+ * @param fingerprint - Fingerprint that must match the reservation
+ * @param now - Current time in milliseconds
+ * @param ttlMs - Server-owned reservation time to live in milliseconds
+ * @param token - Reservation token from the request that reserved
+ * @returns True when a pending reservation was removed
+ */
+export function releaseIfPending(
+  reservations: Map<string, Reservation>,
+  paymentId: string,
+  fingerprint: string,
+  now: number,
+  ttlMs: number = RESERVATION_TTL_MS,
+  token?: string,
+): boolean {
+  const existing = reservations.get(paymentId);
+  if (!existing || existing.state !== RESERVATION_STATE_PENDING) {
+    return false;
   }
-  return existing.fingerprint;
+  return releaseReservation(reservations, paymentId, fingerprint, now, ttlMs, token);
+}
+
+/**
+ * Mark a matching exact-token reservation as having entered settlement.
+ *
+ * @param reservations - In-flight reservations keyed by payment ID
+ * @param paymentId - Payment identifier
+ * @param fingerprint - Fingerprint that must match the reservation
+ * @param now - Current time in milliseconds
+ * @param ttlMs - Server-owned reservation time to live in milliseconds
+ * @param token - Reservation token from the request that reserved
+ * @returns True when the reservation was marked settling
+ */
+export function markSettlementStarted(
+  reservations: Map<string, Reservation>,
+  paymentId: string,
+  fingerprint: string,
+  now: number,
+  ttlMs: number = RESERVATION_TTL_MS,
+  token?: string,
+): boolean {
+  const existing = reservations.get(paymentId);
+  // Retained for call-site symmetry. If cleanup has not replaced the exact
+  // current token, that token still owns the right to enter settlement even
+  // after the prior pending deadline. A replacement fails ownership.
+  void ttlMs;
+  if (!existing || !ownsReservation(existing, fingerprint, token)) {
+    return false;
+  }
+  if (existing.state === RESERVATION_STATE_UNKNOWN) {
+    return false;
+  }
+  existing.state = RESERVATION_STATE_SETTLING;
+  existing.timestamp = now;
+  return true;
+}
+
+/**
+ * Retain a tokenized outcome-unknown tombstone until the server TTL expires.
+ *
+ * A fresh credential under this ID is a conflict. The same fingerprint is
+ * retryable in-flight until expiry. Missing token does not mutate.
+ *
+ * @param reservations - In-flight reservations keyed by payment ID
+ * @param paymentId - Payment identifier
+ * @param fingerprint - Fingerprint that must match the reservation
+ * @param now - Current time in milliseconds
+ * @param ttlMs - Server-owned reservation time to live in milliseconds
+ * @param token - Reservation token from the request that reserved
+ * @returns True when the reservation was marked unknown
+ */
+export function markOutcomeUnknown(
+  reservations: Map<string, Reservation>,
+  paymentId: string,
+  fingerprint: string,
+  now: number,
+  ttlMs: number = RESERVATION_TTL_MS,
+  token?: string,
+): boolean {
+  // Retained for call-site symmetry. Exact current-token ownership, not an
+  // already elapsed phase deadline, controls this final transition.
+  void ttlMs;
+  const existing = reservations.get(paymentId);
+  if (!existing || !ownsReservation(existing, fingerprint, token)) {
+    return false;
+  }
+  if (existing.state === RESERVATION_STATE_UNKNOWN) {
+    return false;
+  }
+  existing.state = RESERVATION_STATE_UNKNOWN;
+  existing.timestamp = now;
+  return true;
+}
+
+/**
+ * Read the middleware reservation token from an Express SDK transport context.
+ *
+ * ExpressAdapter stores the request on `adapter.req`. Missing adapter or token
+ * is not fingerprint-only ownership.
+ *
+ * @param transportContext - SDK `HTTPTransportContext`
+ * @returns Reservation token, or undefined when the adapter did not carry it
+ */
+export function reservationTokenFromTransportContext(
+  transportContext: unknown,
+): string | undefined {
+  const transport = transportContext as
+    | {
+        request?: {
+          adapter?: { req?: { x402ReservationToken?: string } };
+        };
+      }
+    | undefined;
+  return transport?.request?.adapter?.req?.x402ReservationToken;
 }
 
 /**
@@ -242,6 +629,8 @@ export function bindPaymentId(input: BindPaymentIdInput): CacheDecision {
     input.paymentId,
     input.fingerprint,
     input.now,
-    input.reservationTtlMs,
+    input.reservationTtlMs ?? RESERVATION_TTL_MS,
+    undefined,
+    input.maxPending ?? MAX_PENDING_RESERVATIONS,
   );
 }

--- a/examples/typescript/servers/payment-identifier/tsconfig.json
+++ b/examples/typescript/servers/payment-identifier/tsconfig.json
@@ -11,5 +11,5 @@
     "baseUrl": ".",
     "types": ["node"]
   },
-  "include": ["index.ts", "request-binding.ts", "request-binding.test.ts"]
+  "include": ["index.ts", "request-binding.ts", "request-binding.test.ts", "lifecycle.test.ts"]
 }

--- a/examples/typescript/servers/payment-identifier/tsconfig.json
+++ b/examples/typescript/servers/payment-identifier/tsconfig.json
@@ -11,5 +11,5 @@
     "baseUrl": ".",
     "types": ["node"]
   },
-  "include": ["index.ts"]
+  "include": ["index.ts", "request-binding.ts", "request-binding.test.ts"]
 }


### PR DESCRIPTION
## Description

The payment-identifier docs say a reused payment ID with a different request fingerprint should return `409 Conflict`. The official examples did not fully enforce that boundary and did not protect concurrent retries through verification and settlement.

This PR hardens the TypeScript and Python client and server examples without changing the x402 protocol, wallet behavior, facilitator behavior, or payment semantics.

### Server behavior

- Binds each identifier to the exact HTTP method, canonical path and query, raw body digest, accepted payment terms, payer authorization, and encoded credential.
- Reserves an identifier before verification so concurrent requests cannot both settle.
- Uses a fixed server-owned 300-second lifecycle window and a bounded 1,024-entry in-memory map. Client timeout values cannot extend or shorten storage.
- Requires the exact reservation token for release, settlement transition, cache consumption, and outcome-unknown retention.
- Aborts before facilitator settlement if a stale request has lost reservation ownership.
- Caches only after definitive settlement success. An indeterminate settlement result keeps an outcome-unknown tombstone instead of allowing another charge.
- Returns retryable HTTP 503 before payment when identifier storage is unavailable or at capacity.
- Applies this behavior only to protected routes carrying a valid payment identifier. Malformed headers and unrelated routes retain ordinary x402 handling.

### Client behavior

- Replays the exact encoded payment header only for the same immutable URL and the same selected accepted terms.
- Does not persist raw payment credentials or claim crash-restart recovery.
- Includes adversarial interleaving tests so one concurrent request cannot bind another request's credential.

### Documentation

- Updates the copyable TypeScript and Python lifecycle examples to use exact-token ownership checks and fail-closed storage handling.
- Clarifies that payment replay protection, application-effect idempotency, and secure restart recovery are separate designs.
- Keeps the Go example truthful by limiting it to identifier injection until an audited exact-header replay helper exists.

Related to #803 and #808. This PR does not add a new extension or claim protocol-level replay protection.

The initial implementation used Grok 4.6. The final tree received independent adversarial review and multiple amendments for timeout, replay, lifecycle, storage, and documentation defects before publication.

## Tests

Credential-free, with no wallet, chain, facilitator, signature, or payment:

- TypeScript server: 60/60, ESLint, Prettier
- TypeScript client: 13/13, ESLint, Prettier
- Python server: 50/50, Ruff check and format
- Python client: 9/9, Ruff check and format
- Shared cross-language query and accepted-term fixtures
- MDX and README Prettier checks
- Clean staged diff and exact reviewed tree `1e4cc20b5500327b571fc0b6aac162f5acd69bce`

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing focused tests pass
- [x] My commit is signed and includes DCO sign-off
- [x] Example and documentation changes do not require a publishable package changelog
