### PR TITLE
docs(exact/svm): add multi-payee splits to the exact scheme

### DIFF
--- a/specs/schemes/exact/scheme_exact.md
+++ b/specs/schemes/exact/scheme_exact.md
@@ -22,9 +22,9 @@ While implementation details vary by network, facilitators MUST enforce security
 
 ### SVM
 
-- Fee payer safety: the fee payer MUST NOT appear as an account in sensitive instructions or be the transfer authority/source.
+- Fee payer safety: the fee payer MUST NOT appear as an account in sensitive instructions or be the transfer authority/source. The sole bounded exception is fee-payer-funded ATA creation for authorized split recipients (see Multi-Payee Splits below).
 - Destination correctness: the receiver MUST match the `payTo` derived destination for the specified `asset`.
-- Amount exactness: the transferred amount MUST equal `maxAmountRequired`.
+- Amount exactness: the transferred amount MUST equal `maxAmountRequired`. When splits are present, the amount is distributed across legs and the merchant receives the remainder (see Multi-Payee Splits below).
 
 ### Stellar
 
@@ -51,3 +51,18 @@ While implementation details vary by network, facilitators MUST enforce security
 - Simulation verification: MUST simulate the settlement and fail closed unless it shows exactly one asset `Transfer` from payer to `payTo` for the exact amount.
 
 Network-specific rules are in per-network documents: `scheme_exact_svm.md` (Solana), `scheme_exact_stellar.md` (Stellar), `scheme_exact_evm.md` (EVM), `scheme_exact_sui.md` (SUI), `scheme_exact_ton.md` (TON), `scheme_exact_starknet.md` (Starknet).
+
+## Multi-Payee Splits (Optional Extension)
+
+The `exact` scheme MAY carry an optional `extra.splits` array that distributes a single client payment across the primary recipient (`payTo`) and one or more additional recipients in the same atomic settlement. This enables platform fees, revenue sharing, referral commissions, and fee-payer cost recovery without multiple round-trips or separate transactions.
+
+The extension is network-agnostic in shape but network-specific in encoding and verification. Common rules across networks:
+
+- Each split entry declares an absolute `amount` in base units of the same `asset` (not a percentage or basis points).
+- The primary recipient (`payTo`) receives the remainder: `amount − Σ splits[].amount`. This remainder MUST be greater than zero; requirements that consume the entire amount with splits MUST be rejected.
+- Each payment leg (primary plus each split) MUST be settled to its declared recipient for its declared amount, and a verifier MUST match each leg to a distinct on-chain transfer.
+- Clients MUST verify that `splits` contains only recipients and amounts they agreed to before authorizing payment; a malicious server could otherwise inject splits to divert funds.
+
+When `extra.splits` is absent or empty, the scheme behaves as a single-payee `exact` payment. Networks that do not implement the extension MUST reject requirements that carry a non-empty `splits` array rather than silently ignoring it (which would misdirect the merchant's expected distribution).
+
+Solana defines the full schema, transaction structure, ATA-creation authorization, and verification rules for this extension in `scheme_exact_svm.md` (§5). Other networks MAY specify their own encoding of the same model.

--- a/specs/schemes/exact/scheme_exact_svm.md
+++ b/specs/schemes/exact/scheme_exact_svm.md
@@ -23,6 +23,8 @@ How transaction fees are sponsored—and how the sponsoring party evaluates risk
   - a **third-party facilitator**.
 - **Fee Payer (`feePayer`)**: The Solana account of the Sponsor that pays transaction fees and provides the final required signature.
 - **Smart wallet**: A program-controlled account (e.g. Squads, Swig, SPL Governance, Metaplex Core) that executes a token transfer via Cross-Program Invocation (CPI) rather than as a top-level `TransferChecked`.
+- **Primary payment**: The transfer to the merchant identified by `payTo`. In the absence of splits this is the entire `amount`; with splits it is the remainder (§5).
+- **Split**: An additional payee, beyond the merchant, that receives a fixed carve-out of the total `amount` in the same atomic transaction. Declared in `extra.splits` (§5). Used for platform fees, revenue sharing, referral commissions, or fee-payer cost recovery.
 
 ---
 
@@ -73,6 +75,7 @@ In addition to the standard x402 `PaymentRequirements` fields, the `exact` schem
 - `extra.memo` (optional): A seller-defined UTF-8 string to include in the transaction's Memo instruction. When present, the client MUST use this value as the Memo instruction data instead of a random nonce. Maximum 256 bytes. This enables sellers to attach payment references (e.g., invoice IDs) to on-chain transactions for reconciliation without requiring unique deposit addresses.
 - `extra.recentBlockhash` (optional): A recent blockhash for the Client to use as the transaction's lifetime, supplied by the Resource Server. When present and valid, the Client SHOULD use it instead of fetching its own via `getLatestBlockhash`, saving an RPC round-trip and pinning the transaction to a blockhash the settling RPC has observed. When absent or malformed, the Client MUST fetch a recent blockhash itself. A Resource Server SHOULD only set this when it has an RPC endpoint whose view of recent blockhashes matches the settling Sponsor's; a stale or fork-divergent blockhash will cause the transaction to expire or fail to land.
 - `extra.lastValidBlockHeight` (optional): The last block height at which `extra.recentBlockhash` is valid, as a decimal string. This informational hint is not serialized into the transaction and MAY be ignored by the Client or Sponsor. It is ignored when `recentBlockhash` is absent.
+- `extra.splits` (optional): An array of additional payees that receive fixed carve-outs of `amount` in the same transaction. When present, the merchant (`payTo`) receives the remainder rather than the full `amount`. See **Multi-Payee Splits** (§5) for the schema and semantics. When absent or empty, the scheme behaves exactly as specified in §1–§4 (a single transfer to `payTo`).
 
 These optional fields are transaction-construction hints. They do not bind the submitted transaction to the hinted blockhash, and the facilitator's verification does not compare the transaction blockhash with `extra.recentBlockhash`.
 
@@ -154,6 +157,8 @@ The payment MUST be:
 
 The transfer MAY appear either as a top-level instruction or as an inner instruction (CPI) emitted by another program. This is what allows smart wallets to satisfy the scheme: the payment outcome is what matters, not the instruction that produced it.
 
+When `extra.splits` is present, the required outcome comprises multiple payment legs (one to `payTo` plus one per split), and `PaymentRequirements.amount` is the total across all legs. The single-transfer definition below applies per leg; see §5.
+
 ### 1.2 Payment Identification (MUST)
 
 A verifier MUST be able to deterministically identify the payment and confirm:
@@ -184,6 +189,8 @@ Across all top-level instructions and the full CPI trace, **exactly one** transf
 
 A matching transfer MAY exceed `PaymentRequirements.amount` (overpayment is tolerated to accommodate smart wallets with internal fee rounding); it MUST NOT be less.
 
+When `extra.splits` is present, this rule applies **per payment leg**: exactly one matching transfer per leg, matched to a distinct instruction (§5.3). Only the primary leg tolerates overpayment; split legs MUST match their declared amount exactly.
+
 ---
 
 ## 2. Sponsor Acceptance Policy (Reference)
@@ -207,6 +214,8 @@ If the fee payer is never referenced by any instruction, the Solana runtime cann
 
 The `feePayer` MAY appear as the payment recipient when `feePayer == payTo`, since receiving funds does not require the fee payer to be a signer on a debiting instruction.
 
+The `feePayer` MAY additionally appear solely as the funding `payer` of an idempotent ATA-creation instruction for an authorized split recipient. This is the one bounded exception to fee-payer isolation and is tightly scoped in §5.4; it MUST NOT be read as permitting the fee payer in any other instruction's accounts.
+
 #### 2.1.2 Address Lookup Table Visibility (MUST)
 
 If the transaction uses Address Lookup Tables (ALTs), the sponsor MUST resolve them so that every account the transaction can touch is visible before the isolation check in §2.1.1 runs. A sponsor that cannot resolve a transaction's ALTs MUST reject it rather than verify against an incomplete account set (`smart_wallet_alt_resolution_not_available`). A transient failure to resolve ALTs MUST fail closed (reject / retryable), never open.
@@ -215,13 +224,15 @@ If the transaction uses Address Lookup Tables (ALTs), the sponsor MUST resolve t
 
 The sponsor MUST reject any transaction in which the sponsor's funds could be debited beyond the network fee — including SOL transfers from sponsor-controlled accounts, token transfers for which the sponsor is the authority, or account closures/reallocations that move the sponsor's lamports. Enforcing §2.1.1 and §2.1.2 is sufficient to prevent these conditions for standard Solana programs.
 
+The sole intentional exception is fee-payer-funded ATA rent for split recipients that the sponsor has opted into via `ataCreationRequired` (§5.4). This is bounded (≈0.002 SOL per created ATA), opt-in per split recipient, and forbidden for the primary recipient or arbitrary owners; a sponsor that does not offer splits, or offers splits without ATA sponsorship, is unaffected.
+
 #### 2.1.4 Signer Set Integrity (MUST)
 
 The transaction MUST NOT require any signatures beyond the client and the sponsor (`feePayer`). Additional signatures MAY be present but MUST NOT be required for transaction validity.
 
 #### 2.1.5 Exact Payment Verification (MUST)
 
-The transaction MUST satisfy the **Exact Payment Outcome Definition** (§1), including the exactly-one-matching-transfer rule (§1.4).
+The transaction MUST satisfy the **Exact Payment Outcome Definition** (§1), including the exactly-one-matching-transfer rule (§1.4). When `extra.splits` is present, this extends to every payment leg and the split-specific acceptance rules of §5.5.
 
 ### 2.2 Cost and Griefing Controls (Recommended SHOULDs)
 
@@ -302,6 +313,8 @@ The fast path for standard wallets. The decompiled transaction MUST contain 3 to
 - If `extra.memo` is present, the facilitator MUST verify that exactly one Memo instruction exists and that its data matches `extra.memo` encoded as UTF-8.
 - Fee payer isolation, compute budget validity (compute unit price ≤ 5 lamports/CU on this path), destination ATA derivation, and exact amount match are enforced as before.
 
+When `extra.splits` is present, the static layout generalizes to include one `TransferChecked` per payment leg plus optional idempotent ATA-creation instructions for authorized split recipients; see §5.7.
+
 ### 3.2 Path 2 — Simulation-Based Smart Wallet Verification
 
 Smart wallet programs wrap the transfer inside their own instruction (e.g. Squads `vaultTransactionExecute`, Swig `SignV2`), so Path 1 sees an unknown program at the transfer position and rejects it. Path 2 verifies the **outcome** instead of the instruction format:
@@ -311,7 +324,7 @@ Smart wallet programs wrap the transfer inside their own instruction (e.g. Squad
 3. **Program allowlist** (§2.2.2): the wrapping program MUST be on the allowlist.
 4. **Memo enforcement**: if `extra.memo` is present, exactly one top-level Memo instruction MUST match it (mirrors Path 1, so a seller-required memo cannot be bypassed by routing through a smart wallet).
 5. **Simulate with inner instructions**: `simulateTransaction` is called with `innerInstructions: true` to obtain the full CPI trace (no additional round-trip — simulation is already the final verification step). The RPC may return inner instructions in either `jsonParsed` or compiled (base58) format; both are handled.
-6. **Match exactly one transfer** (§1.4): across top-level and inner instructions, exactly one `TransferChecked` MUST match the required mint, destination ATA (derived for both token programs), and amount (`>=` required). The fee payer / sponsor MUST NOT be the authority on any observed transfer (self-spend protection).
+6. **Match exactly one transfer** (§1.4): across top-level and inner instructions, exactly one `TransferChecked` MUST match the required mint, destination ATA (derived for both token programs), and amount (`>=` required). The fee payer / sponsor MUST NOT be the authority on any observed transfer (self-spend protection). When `extra.splits` is present, this generalizes to exactly one matching `TransferChecked` per payment leg (§5.3) — one for the primary remainder and one for each split — and no `asset` transfer to any account outside the declared recipient set (§5.5).
 
 ### 3.3 Path Selection (Path 1 → Path 2)
 
@@ -345,6 +358,126 @@ The verification model upholds the following invariants:
 | I5 | **Simulation is non-critical** | Simulation saves fees; security comes from I1 (pre-sign) and I3 (post-settle) (§2.2.3, §3.4). |
 | I6 | **No hidden accounts** | ALTs resolved so every reachable account is visible to verification (§2.1.2). |
 | I7 | **Known programs only** | Only allowlisted wallet programs reach simulation-based verification (§2.2.2). |
+
+---
+
+## 5. Multi-Payee Splits (Optional)
+
+The `exact` scheme MAY distribute a single client payment across the merchant and up to eight additional recipients in one atomic transaction. This supports platform fees, revenue sharing, referral commissions, and fee-payer cost recovery without extra round-trips or separate transactions.
+
+Splits are declared by the Resource Server in `PaymentRequirements.extra.splits`. When the field is absent or empty, the scheme behaves exactly as specified in §1–§4 (a single transfer to `payTo`), and this section does not apply.
+
+### 5.1 `extra.splits` Schema
+
+```json
+{
+  "scheme": "exact",
+  "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+  "amount": "1050000",
+  "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+  "payTo": "2wKupLR9q6wXYppw8Gr2NvWxKBUqm4PPJKkQfoxHDBg4",
+  "maxTimeoutSeconds": 60,
+  "extra": {
+    "feePayer": "EwWqGE4ZFKLofuestmU4LDdK7XM1N4ALgdZccwYugwGd",
+    "memo": "pi_3abc123def456",
+    "splits": [
+      {
+        "payTo": "3pF8Kg2aHbNvJkLMwEqR7YtDxZ5sGhJn4UV6mWcXrT9A",
+        "amount": "50000",
+        "memo": "platform fee",
+        "ataCreationRequired": false
+      }
+    ]
+  }
+}
+```
+
+In the example the client pays `1050000` base units in total: `50000` to the split recipient and the `1000000` remainder to `payTo`.
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `splits` | array | OPTIONAL | 1–8 entries. Absent or empty ⇒ single-payee `exact`. |
+| `splits[].payTo` | string | REQUIRED | Base58-encoded recipient public key. |
+| `splits[].amount` | string | REQUIRED | Decimal string in base units of `asset`. An **absolute** amount, not a percentage or basis points. |
+| `splits[].memo` | string | OPTIONAL | Human-readable label for off-chain reconciliation, ≤ 566 bytes. Informational only; it is **not** emitted as an on-chain Memo instruction. The single on-chain Memo remains governed by `extra.memo` (§3.1). |
+| `splits[].ataCreationRequired` | boolean | OPTIONAL | Default `false`. Authorizes fee-payer-funded creation of this recipient's ATA (§5.4). Meaningful only for SPL / Token-2022 assets. |
+
+Every split shares the top-level `asset`; a split MUST NOT name a different mint. Split `payTo` values SHOULD be distinct from one another and from the primary `payTo`; when they are not, each leg is still matched to its own distinct transfer instruction (§5.3).
+
+### 5.2 Amount Semantics (MUST)
+
+- The top-level `amount` is the total the client pays.
+- Each `splits[].amount` is an absolute carve-out from that total.
+- The **primary payment** to `payTo` is the remainder: `primary = amount − Σ splits[].amount`.
+- `Σ splits[].amount` MUST be strictly less than `amount`; equivalently, the primary remainder MUST be greater than zero. A Resource Server MUST NOT issue, and a Sponsor MUST reject, requirements in which splits consume the entire amount (`split_remainder_not_positive`).
+- All amounts are integers in base units. No rounding or remainder redistribution is performed; the arithmetic MUST balance exactly.
+
+A charge with `N` splits produces `N + 1` payment legs (one primary plus `N` splits), for a maximum of nine legs. The practical maximum may be lower than eight splits: the transaction MUST still fit Solana's 1232-byte limit, which additional `TransferChecked` and ATA-creation instructions consume; Address Lookup Tables MAY be used to raise this ceiling (subject to §2.1.2).
+
+### 5.3 Payment Outcome with Splits (MUST)
+
+When `extra.splits` is present, the transaction MUST produce, atomically:
+
+- One transfer of the primary remainder (§5.2) of `asset` to the ATA derived from `payTo`, and
+- For each split, one transfer of that split's `amount` of `asset` to the ATA derived from that split's `payTo`.
+
+Each required payment leg MUST be matched to a **distinct** transfer instruction. A single transfer MUST NOT satisfy more than one leg, even when two legs share the same recipient. This generalizes the exactly-one-matching-transfer rule (§1.4): the verifier requires exactly one matching transfer *per leg*, and MUST reject if any leg is unmatched (`split_leg_unmatched`) or if any `asset` transfer matches no declared leg (`split_unexpected_transfer`).
+
+Split legs MUST match their declared `amount` **exactly** (`==`). The primary leg retains the base overpayment tolerance (`≥ primary`, §1.4) to accommodate smart-wallet fee rounding; any excess accrues to `payTo` and never to a split recipient.
+
+### 5.4 Split Recipient ATA Creation (MUST)
+
+A split recipient may not yet hold an Associated Token Account for `asset`, and a transfer to a missing ATA fails. The transaction MAY therefore include an **idempotent** ATA-creation instruction (`AssociatedTokenProgram: CreateIdempotent`) for a split recipient. Because ATA creation spends the funding account's lamports (rent, ≈0.002 SOL) beyond the network fee, it is tightly scoped:
+
+- A `CreateIdempotent` instruction MAY be funded by the `feePayer` **only** for a split recipient whose entry sets `ataCreationRequired: true`.
+- When the fee payer sponsors rent, the client MUST include one `CreateIdempotent` instruction for each split whose entry sets `ataCreationRequired: true`, and MUST NOT include ATA-creation instructions for the primary `payTo`, for unmarked split recipients, or for any other owner.
+- Fee-payer-funded creation of the **primary** `payTo` ATA is FORBIDDEN. The merchant MUST maintain its own receiving ATA. This prevents a merchant from offloading its own rent onto a third-party sponsor on every charge.
+- When the fee payer does not sponsor rent (for example a merchant-operated fee payer, or `feePayer == payTo`), the client MAY still include idempotent ATA-creation instructions for split recipients marked `ataCreationRequired: true`, funded by the client.
+
+This is a deliberate, bounded exception to Fee Payer Isolation (§2.1.1) and Fee Payer Fund Safety (§2.1.3): the fee payer MAY appear solely as the funding `payer` of a `CreateIdempotent` instruction whose created account is the ATA of an authorized split recipient, and MUST NOT appear in any other instruction's accounts. A Sponsor MUST reject any transaction in which the fee payer funds ATA creation for the primary recipient, for an unmarked split, or for an owner not present in `splits` (`split_ata_creation_not_authorized`).
+
+### 5.5 Sponsor Acceptance with Splits (MUST)
+
+A Sponsor that signs a split transaction as `feePayer` MUST, in addition to the baseline in §2.1:
+
+- Recompute `primary = amount − Σ splits[].amount` from the requirements and reject if `primary ≤ 0` (§5.2).
+- Match every payment leg to a distinct transfer per §5.3.
+- Enforce the ATA-creation authorization rules of §5.4.
+- Confirm that no `asset` transfer sends funds to any account other than the ATA derived from `payTo` or from a declared split `payTo` (`split_unexpected_transfer`).
+
+A Sponsor MAY decline splits entirely, or offer splits without ATA-rent sponsorship (accepting only `ataCreationRequired: false` entries), as a matter of local policy (§2.3). Clients SHOULD NOT assume universal split support.
+
+### 5.6 Client-Side Verification (MUST)
+
+Before signing, the client MUST verify that `extra.splits` — when present — contains only the recipients and amounts it expects. A malicious Resource Server could otherwise inject or alter splits to divert a portion of the payment. Specifically, the client MUST:
+
+- Confirm each split `payTo` and `amount` against the terms it agreed to.
+- Independently compute the primary remainder (`amount − Σ splits[].amount`) and confirm it is the amount reaching the merchant.
+- Reject requirements whose split recipients or amounts it did not agree to, and reject any `ataCreationRequired: true` it is unwilling to fund when it (not the fee payer) sponsors rent.
+
+### 5.7 Static Layout with Splits (Reference)
+
+Path 1 (§3.1) generalizes for splits. The decompiled transaction consists of, in order:
+
+1. Compute Budget: Set Compute Unit Limit
+2. Compute Budget: Set Compute Unit Price
+3. Zero or more `AssociatedTokenProgram: CreateIdempotent` instructions — one per split recipient marked `ataCreationRequired: true` (§5.4)
+4. One `TransferChecked` for the primary payment (the remainder)
+5. One `TransferChecked` per split
+6. (Optional) the same wallet-injected Lighthouse / SPL Memo instructions permitted in §3.1
+
+The exactly-one-Memo rule for `extra.memo` (§3.1) is unchanged: a single on-chain Memo governs the whole charge, not one per leg. Smart-wallet (Path 2, §3.2) charges verify the same `N + 1`-leg outcome across the CPI trace, and post-settlement verification (§3.4) confirms every leg landed on-chain, not simulation alone.
+
+### 5.8 Security Invariants (Splits)
+
+These extend the invariants of §4 when `extra.splits` is present.
+
+| # | Invariant | How it is enforced |
+|---|---|---|
+| I8 | **No fund diversion** | Every `asset` transfer lands on an ATA derived from `payTo` or a declared split `payTo`; unexpected transfers rejected (§5.3, §5.5). |
+| I9 | **Bounded rent exposure** | Fee payer funds ATA creation only for split recipients explicitly marked `ataCreationRequired`; primary-recipient and arbitrary-owner creation forbidden (§5.4). |
+| I10 | **Exact carve-outs** | Each split leg matches its declared amount exactly; only the primary leg tolerates overpayment (§5.3). |
+| I11 | **Consented distribution** | Client verifies split recipients and amounts before signing (§5.6). |
 
 ---
 


### PR DESCRIPTION
## Summary

Adds an optional **multi-payee splits** capability to the `exact` scheme on SVM, letting a single client payment be distributed atomically across the merchant (`payTo`) and up to eight additional recipients in one transaction — for platform fees, revenue sharing, referral commissions, and fee-payer cost recovery. No extra round-trips or separate transactions.

Splits are declared by the Resource Server in `PaymentRequirements.extra.splits`. When the field is absent or empty, the scheme behaves exactly as today (a single transfer to `payTo`), so the change is fully backward compatible.

```jsonc
"extra": {
  "feePayer": "EwWqGE4ZFKLofuestmU4LDdK7XM1N4ALgdZccwYugwGd",
  "memo": "pi_3abc123def456",
  "splits": [
    { "payTo": "3pF8…", "amount": "50000", "memo": "platform fee", "ataCreationRequired": false }
  ]
}
```

## What changed

- **`specs/schemes/exact/scheme_exact_svm.md`** — new self-contained **§5 Multi-Payee Splits**: the `extra.splits` schema, amount/remainder semantics, per-leg payment outcome, split-recipient ATA creation authorization, sponsor acceptance rules, client-side verification, generalized static layout, and split-specific security invariants. Surgical pointers were added in §1.1, §1.4, §2.1.1, §2.1.3, §2.1.5, §3.1, and §3.2 so the base definitions stay intact and simply generalize "one transfer" → "one transfer per leg" when splits are present.
- **`specs/schemes/exact/scheme_exact.md`** — a network-agnostic **Multi-Payee Splits (Optional Extension)** note and split-aware wording in the SVM validation bullets, so other networks can adopt the same model.

## Design decisions

- **Absolute amounts, not basis points.** Each `splits[].amount` is an absolute carve-out in base units of the same `asset`. The primary `payTo` receives the remainder `amount − Σ splits[].amount`, which MUST be `> 0`.
- **Per-leg matching.** Each payment leg (primary + each split) MUST map to a *distinct* on-chain `TransferChecked`; no transfer satisfies two legs even when recipients coincide.
- **Overpayment asymmetry.** Split legs MUST match their declared amount exactly; the primary leg keeps the existing overpayment tolerance (`≥ remainder`) for smart-wallet fee rounding, so any excess accrues to the merchant and never to a split recipient.
- **Bounded ATA-creation exception.** Fee-payer-funded ATA creation is the one intentional exception to fee-payer isolation (§2.1.1) / fund safety (§2.1.3): allowed only for split recipients explicitly marked `ataCreationRequired: true`, and **forbidden** for the primary recipient or arbitrary owners.
- **Max 8 splits (9 legs).** With a note that the practical ceiling is bounded by the 1232-byte transaction limit; ALTs may raise it.

Adapted from the multi-payee/splits model in the Solana Charge Intent draft (paymentauth.org/draft-solana-charge-00.html), rewritten to x402 `exact` prose and terminology (`payTo`/`amount`, fee-payer sponsorship, ATA verification).

## Open questions for reviewers

1. **Primary overpayment tolerance** — kept `≥` on the primary leg for backward-compat with the existing base rule; splits are exact. Prefer exact on all legs?
2. **Placement** — splits are specified inline in the SVM doc with a generic note in `scheme_exact.md`. Would a standalone `specs/extensions/splits.md` be preferred instead?
3. **Per-split `memo`** — carried as an informational reconciliation label only (not an on-chain Memo). Keep, or drop in favor of the single `extra.memo`?

Spec-only PR; reference-implementation changes to `@x402/svm` will follow in a separate PR.
