### PR TITLE
feat(evm): add Sei default stablecoins

### DIFF
--- a/docs/core-concepts/network-and-token-support.mdx
+++ b/docs/core-concepts/network-and-token-support.mdx
@@ -129,6 +129,8 @@ When you use `"$0.01"` syntax, x402 needs to know which stablecoin to use. The f
 | Flare | `eip155:14` | `0xe7cd86e13AC4309349F30B3435a9d337750fC82D` | USD₮0 | 6 | EIP-3009 |
 | Celo | `eip155:42220` | `0xcebA9300f2b948710d2653dD7B07f33A8B32118C` | USDC | 6 | EIP-3009 |
 | Celo Sepolia | `eip155:11142220` | `0x01C5C0122039549AD1493B8220cABEdD739BC44E` | USDC | 6 | EIP-3009 |
+| Sei | `eip155:1329` | `0xe15fC38F6D8c56aF07bbCBe3BAf5708A2Bf42392` | USDC | 6 | EIP-3009 |
+| Sei Testnet | `eip155:1328` | `0x4fCF1784B31630811181f670Aea7A7bEF803eaED` | USDC | 6 | EIP-3009 |
 
 
 

--- a/go/.changes/unreleased/add-sei-default-stablecoin.yaml
+++ b/go/.changes/unreleased/add-sei-default-stablecoin.yaml
@@ -1,0 +1,2 @@
+kind: added
+body: Add Sei mainnet (chain ID 1329) and Sei Testnet (chain ID 1328) with native USDC as the default stablecoin

--- a/go/mechanisms/evm/constants.go
+++ b/go/mechanisms/evm/constants.go
@@ -92,6 +92,8 @@ var (
 	ChainIDFlare         = big.NewInt(14)
 	ChainIDCelo          = big.NewInt(42220)
 	ChainIDCeloSepolia   = big.NewInt(11142220)
+	ChainIDSei           = big.NewInt(1329)
+	ChainIDSeiTestnet    = big.NewInt(1328)
 
 	// Network configurations
 	// See DEFAULT_ASSETS.md for guidelines on adding new chains
@@ -331,6 +333,26 @@ var (
 			ChainID: ChainIDCeloSepolia,
 			DefaultAsset: AssetInfo{
 				Address:  "0x01C5C0122039549AD1493B8220cABEdD739BC44E", // USDC on Celo Sepolia
+				Name:     "USDC",
+				Version:  "2",
+				Decimals: DefaultDecimals,
+			},
+		},
+		// Sei Mainnet
+		"eip155:1329": {
+			ChainID: ChainIDSei,
+			DefaultAsset: AssetInfo{
+				Address:  "0xe15fC38F6D8c56aF07bbCBe3BAf5708A2Bf42392", // USDC on Sei
+				Name:     "USDC",
+				Version:  "2",
+				Decimals: DefaultDecimals,
+			},
+		},
+		// Sei Testnet
+		"eip155:1328": {
+			ChainID: ChainIDSeiTestnet,
+			DefaultAsset: AssetInfo{
+				Address:  "0x4fCF1784B31630811181f670Aea7A7bEF803eaED", // USDC on Sei Testnet
 				Name:     "USDC",
 				Version:  "2",
 				Decimals: DefaultDecimals,

--- a/go/mechanisms/evm/default_assets.go
+++ b/go/mechanisms/evm/default_assets.go
@@ -86,6 +86,12 @@ var DefaultAssets = map[string][]DefaultAssetInfo{
 	"eip155:11142220": {
 		{Asset: "0x01C5C0122039549AD1493B8220cABEdD739BC44E", Name: "USDC", Version: "2", Decimals: 6, Symbol: "USDC"},
 	},
+	"eip155:1329": {
+		{Asset: "0xe15fC38F6D8c56aF07bbCBe3BAf5708A2Bf42392", Name: "USDC", Version: "2", Decimals: 6, Symbol: "USDC"},
+	},
+	"eip155:1328": {
+		{Asset: "0x4fCF1784B31630811181f670Aea7A7bEF803eaED", Name: "USDC", Version: "2", Decimals: 6, Symbol: "USDC"},
+	},
 }
 
 // legacyNetworkChainIDs maps v1 network names to chain IDs (mirrors v1.NetworkChainIDs).

--- a/python/x402/changelog.d/add-sei-default-stablecoin.feature.md
+++ b/python/x402/changelog.d/add-sei-default-stablecoin.feature.md
@@ -1,0 +1,1 @@
+Add Sei mainnet (chain ID 1329) and Sei Testnet (chain ID 1328) with native USDC as the default stablecoin, and correct the legacy Sei testnet chain ID.

--- a/python/x402/mechanisms/evm/constants.py
+++ b/python/x402/mechanisms/evm/constants.py
@@ -640,6 +640,26 @@ NETWORK_CONFIGS: dict[str, NetworkConfig] = {
             "decimals": 6,
         },
     },
+    # Sei Mainnet
+    "eip155:1329": {
+        "chain_id": 1329,
+        "default_asset": {
+            "address": "0xe15fC38F6D8c56aF07bbCBe3BAf5708A2Bf42392",
+            "name": "USDC",
+            "version": "2",
+            "decimals": 6,
+        },
+    },
+    # Sei Testnet
+    "eip155:1328": {
+        "chain_id": 1328,
+        "default_asset": {
+            "address": "0x4fCF1784B31630811181f670Aea7A7bEF803eaED",
+            "name": "USDC",
+            "version": "2",
+            "decimals": 6,
+        },
+    },
 }
 
 # V1 legacy constants are in x402.mechanisms.evm.v1.constants

--- a/python/x402/mechanisms/evm/default_assets.py
+++ b/python/x402/mechanisms/evm/default_assets.py
@@ -236,6 +236,24 @@ DEFAULT_ASSETS: dict[str, list[ExactDefaultAssetInfo]] = {
             "symbol": "USDC",
         },
     ],  # Celo Sepolia testnet USDC (EIP-3009 supported)
+    "eip155:1329": [
+        {
+            "asset": "0xe15fC38F6D8c56aF07bbCBe3BAf5708A2Bf42392",
+            "name": "USDC",
+            "version": "2",
+            "decimals": 6,
+            "symbol": "USDC",
+        },
+    ],  # Sei mainnet USDC (EIP-3009 supported)
+    "eip155:1328": [
+        {
+            "asset": "0x4fCF1784B31630811181f670Aea7A7bEF803eaED",
+            "name": "USDC",
+            "version": "2",
+            "decimals": 6,
+            "symbol": "USDC",
+        },
+    ],  # Sei testnet USDC (EIP-3009 supported)
 }
 
 

--- a/python/x402/mechanisms/evm/v1/constants.py
+++ b/python/x402/mechanisms/evm/v1/constants.py
@@ -28,6 +28,18 @@ V1_DEFAULT_ASSETS: dict[str, AssetInfo] = {
         "version": "2",
         "decimals": 6,
     },
+    "sei": {
+        "address": "0xe15fC38F6D8c56aF07bbCBe3BAf5708A2Bf42392",
+        "name": "USDC",
+        "version": "2",
+        "decimals": 6,
+    },
+    "sei-testnet": {
+        "address": "0x4fCF1784B31630811181f670Aea7A7bEF803eaED",
+        "name": "USDC",
+        "version": "2",
+        "decimals": 6,
+    },
     "polygon": {
         "address": "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
         "name": "USD Coin",
@@ -104,7 +116,7 @@ V1_NETWORK_CHAIN_IDS: dict[str, int] = {
     "abstract-testnet": 11124,
     "iotex": 4689,
     "sei": 1329,
-    "sei-testnet": 713715,
+    "sei-testnet": 1328,
     "peaq": 3338,
     "story": 1513,
     "educhain": 656476,

--- a/typescript/.changeset/add-sei-default-stablecoin.md
+++ b/typescript/.changeset/add-sei-default-stablecoin.md
@@ -1,0 +1,6 @@
+---
+'@x402/evm': minor
+'@x402/paywall': patch
+---
+
+Add Sei mainnet (chain ID 1329) and Sei Testnet (chain ID 1328) with native USDC as the default stablecoin

--- a/typescript/packages/http/paywall/src/faucetUrls.ts
+++ b/typescript/packages/http/paywall/src/faucetUrls.ts
@@ -13,6 +13,7 @@ export const FAUCET_URLS: Record<string, string> = {
   "eip155:2201": "https://faucet.stable.xyz/faucet", // Stable Testnet
   "eip155:72344": "https://testnet.radiustech.xyz/wallet", // Radius Testnet
   "eip155:11142220": "https://faucet.circle.com/", // Celo Sepolia
+  "eip155:1328": "https://faucet.circle.com/", // Sei Testnet
   // SVM testnets
   "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1": "https://faucet.circle.com/",
   // AVM testnets

--- a/typescript/packages/mechanisms/evm/src/defaultAssets.ts
+++ b/typescript/packages/mechanisms/evm/src/defaultAssets.ts
@@ -247,6 +247,24 @@ export const DEFAULT_ASSETS: DefaultAssetTable<ExactDefaultAssetInfo> = {
       symbol: "USDC",
     },
   ], // Celo Sepolia testnet USDC (EIP-3009 supported)
+  "eip155:1329": [
+    {
+      asset: "0xe15fC38F6D8c56aF07bbCBe3BAf5708A2Bf42392",
+      name: "USDC",
+      version: "2",
+      decimals: 6,
+      symbol: "USDC",
+    },
+  ], // Sei mainnet USDC (EIP-3009 supported)
+  "eip155:1328": [
+    {
+      asset: "0x4fCF1784B31630811181f670Aea7A7bEF803eaED",
+      name: "USDC",
+      version: "2",
+      decimals: 6,
+      symbol: "USDC",
+    },
+  ], // Sei testnet USDC (EIP-3009 supported)
 };
 
 /**


### PR DESCRIPTION
## Summary
- add native USDC defaults for Sei mainnet (`eip155:1329`) and Sei Testnet (`eip155:1328`) across the TypeScript, Go, and Python EVM SDKs
- enable dollar-string pricing and spend-control recognition, and correct Python's legacy Sei Testnet chain ID from `713715` to `1328`
- document both defaults and add the Circle faucet for Sei Testnet

## On-chain verification
- mainnet USDC `0xe15fC38F6D8c56aF07bbCBe3BAf5708A2Bf42392`
- testnet USDC `0x4fCF1784B31630811181f670Aea7A7bEF803eaED`
- both contracts report `USDC`, version `2`, six decimals, expose EIP-3009 authorization state, and match locally computed EIP-712 domain separators

## Review feedback
Addressed in response to review: the regenerated EVM paywall templates and the added per-network unit tests have been dropped. This PR now touches source, docs, and changelog entries only. The paywall source change is the Sei Testnet faucet entry in `faucetUrls.ts`, so the bundles can be regenerated at release time.

## Test plan
- [x] `pnpm --filter @x402/evm test` — 878 tests
- [x] `pnpm --filter @x402/paywall test` — 55 tests
- [x] `go test ./test/unit -run TestEVMDefaultAssets -count=1`
- [x] `go test ./mechanisms/evm/...`
- [x] Python EVM unit suite
- [x] TypeScript ESLint, Python Ruff, Go formatting, and changeset validation

## AI assistance
This PR was prepared with significant Cursor agent assistance and reviewed by the author. Token metadata and EIP-712 domains were independently checked against live Sei RPCs before submission.

Made with [Cursor](https://cursor.com)

## Tracking
- [PLT-1046](https://linear.app/seilabs/issue/PLT-1046/add-sei-default-stablecoins-to-upstream-x402-sdks)