### PR TITLE
fix(e2e): scope EVM/SVM client signer derivation to selected families

### DIFF
--- a/e2e/clients/typescript/client.ts
+++ b/e2e/clients/typescript/client.ts
@@ -76,61 +76,104 @@ export type E2EClientContext = {
    * setup instead of duplicating it.
    */
   schemes: SchemeRegistration[];
-  batchSettlementScheme: BatchSettlementEvmScheme;
+  batchSettlementScheme: BatchSettlementEvmScheme | undefined;
   batchSettlementPhase: BatchSettlementPhase | undefined;
 };
 
 /**
  * Builds the shared x402 client with all e2e scheme registrations.
+ *
+ * EVM and SVM signer derivation is conditional on their own client
+ * credential (`CLIENT_EVM_PRIVATE_KEY`/`CLIENT_SVM_PRIVATE_KEY`), same as
+ * every other family below (Aptos, Hedera, Keeta, Stellar, AVM, TVM, Near,
+ * XRPL). Both used to be derived unconditionally at the top of this
+ * function, ahead of any family-scoping logic, so a run scoped to a single
+ * non-EVM/SVM family via `--families` still crashed here unless unrelated
+ * EVM/SVM credentials happened to be set too (x402-foundation/x402#3187).
  */
 export async function createE2EClient(): Promise<E2EClientContext> {
   const baseURL = process.env.RESOURCE_SERVER_URL as string;
   const endpointPath = process.env.ENDPOINT_PATH as string;
   const url = `${baseURL}${endpointPath}`;
-  const evmAccount = privateKeyToAccount(process.env.CLIENT_EVM_PRIVATE_KEY as `0x${string}`);
-  const svmSigner = await createKeyPairSignerFromBytes(
-    base58.decode(process.env.CLIENT_SVM_PRIVATE_KEY as string),
-  );
 
-  const evmNetwork = resolveNetworkCaip2("evm");
-  const evmRpcUrl = process.env.EVM_RPC_URL;
-  const evmChain = evmNetwork === "eip155:8453" ? base : baseSepolia;
+  const schemes: SchemeRegistration[] = [];
+  let batchSettlementScheme: BatchSettlementEvmScheme | undefined;
 
-  const publicClient = createPublicClient({
-    chain: evmChain,
-    transport: http(evmRpcUrl),
-  });
+  if (process.env.CLIENT_EVM_PRIVATE_KEY) {
+    const evmAccount = privateKeyToAccount(process.env.CLIENT_EVM_PRIVATE_KEY as `0x${string}`);
 
-  const evmSigner = toClientEvmSigner(evmAccount, publicClient);
+    const evmNetwork = resolveNetworkCaip2("evm");
+    const evmRpcUrl = process.env.EVM_RPC_URL;
+    const evmChain = evmNetwork === "eip155:8453" ? base : baseSepolia;
 
-  const evmSchemeOptions = process.env.EVM_RPC_URL
-    ? { rpcUrl: process.env.EVM_RPC_URL }
-    : undefined;
+    const publicClient = createPublicClient({
+      chain: evmChain,
+      transport: http(evmRpcUrl),
+    });
 
-  const uptoSchemeOptions: UptoEvmSchemeOptions | undefined = process.env.EVM_RPC_URL
-    ? { rpcUrl: process.env.EVM_RPC_URL }
-    : undefined;
-  const svmSchemeOptions = process.env.SVM_RPC_URL ? { rpcUrl: process.env.SVM_RPC_URL } : undefined;
+    const evmSigner = toClientEvmSigner(evmAccount, publicClient);
+
+    const evmSchemeOptions = evmRpcUrl ? { rpcUrl: evmRpcUrl } : undefined;
+
+    const uptoSchemeOptions: UptoEvmSchemeOptions | undefined = evmRpcUrl
+      ? { rpcUrl: evmRpcUrl }
+      : undefined;
+
+    // Batch-settlement scheme uses a per-scenario salt (EVM_BATCH_SETTLEMENT_CHANNEL) so
+    // concurrent e2e runs don't collide on the same on-chain channel id. An optional
+    // voucher signer (CLIENT_EVM_BATCH_SETTLEMENT_VOUCHER_SIGNER_PRIVATE_KEY) exercises
+    // the alt-EOA voucher branch while deposits keep using the main client signer.
+    const channelSalt = process.env.EVM_BATCH_SETTLEMENT_CHANNEL as `0x${string}` | undefined;
+    const voucherSignerKey = process.env.CLIENT_EVM_BATCH_SETTLEMENT_VOUCHER_SIGNER_PRIVATE_KEY as
+      | `0x${string}`
+      | undefined;
+    const voucherSigner = voucherSignerKey
+      ? toClientEvmSigner(privateKeyToAccount(voucherSignerKey), publicClient)
+      : undefined;
+    const batchSettlementOptions =
+      channelSalt || voucherSigner
+        ? { ...(channelSalt ? { salt: channelSalt } : {}), ...(voucherSigner ? { voucherSigner } : {}) }
+        : undefined;
+    batchSettlementScheme = new BatchSettlementEvmScheme(evmSigner, batchSettlementOptions);
+
+    schemes.push(
+      { network: networkCaip2Pattern("evm"), client: new ExactEvmScheme(evmSigner, evmSchemeOptions) },
+      {
+        network: networkCaip2Pattern("evm"),
+        client: new UptoEvmClientScheme(evmSigner, uptoSchemeOptions),
+      },
+      { network: networkCaip2Pattern("evm"), client: batchSettlementScheme },
+      { network: "base-sepolia", client: new ExactEvmSchemeV1(evmSigner), x402Version: 1 },
+      { network: "base", client: new ExactEvmSchemeV1(evmSigner), x402Version: 1 },
+    );
+  }
+
+  if (process.env.CLIENT_SVM_PRIVATE_KEY) {
+    const svmSigner = await createKeyPairSignerFromBytes(
+      base58.decode(process.env.CLIENT_SVM_PRIVATE_KEY),
+    );
+    const svmSchemeOptions = process.env.SVM_RPC_URL ? { rpcUrl: process.env.SVM_RPC_URL } : undefined;
+
+    schemes.push(
+      {
+        network: networkCaip2Pattern("svm"),
+        client: new ExactSvmScheme(svmSigner, svmSchemeOptions),
+      },
+      {
+        network: networkCaip2Pattern("svm"),
+        client: new UptoSvmScheme(svmSigner, svmSchemeOptions),
+      },
+      {
+        network: "solana-devnet",
+        client: new ExactSvmSchemeV1(svmSigner, svmSchemeOptions),
+        x402Version: 1,
+      },
+      { network: "solana", client: new ExactSvmSchemeV1(svmSigner, svmSchemeOptions), x402Version: 1 },
+    );
+  }
 
   const ccdPrivateKey = process.env.CLIENT_CCD_PRIVATE_KEY;
   const ccdAddress = process.env.CLIENT_CCD_ADDRESS;
-
-  // Batch-settlement scheme uses a per-scenario salt (EVM_BATCH_SETTLEMENT_CHANNEL) so
-  // concurrent e2e runs don't collide on the same on-chain channel id. An optional
-  // voucher signer (CLIENT_EVM_BATCH_SETTLEMENT_VOUCHER_SIGNER_PRIVATE_KEY) exercises
-  // the alt-EOA voucher branch while deposits keep using the main client signer.
-  const channelSalt = process.env.EVM_BATCH_SETTLEMENT_CHANNEL as `0x${string}` | undefined;
-  const voucherSignerKey = process.env.CLIENT_EVM_BATCH_SETTLEMENT_VOUCHER_SIGNER_PRIVATE_KEY as
-    | `0x${string}`
-    | undefined;
-  const voucherSigner = voucherSignerKey
-    ? toClientEvmSigner(privateKeyToAccount(voucherSignerKey), publicClient)
-    : undefined;
-  const batchSettlementOptions =
-    channelSalt || voucherSigner
-      ? { ...(channelSalt ? { salt: channelSalt } : {}), ...(voucherSigner ? { voucherSigner } : {}) }
-      : undefined;
-  const batchSettlementScheme = new BatchSettlementEvmScheme(evmSigner, batchSettlementOptions);
 
   let aptosAccount: Account | undefined;
   if (process.env.CLIENT_APTOS_PRIVATE_KEY) {
@@ -190,30 +233,6 @@ export async function createE2EClient(): Promise<E2EClientContext> {
       )
     : undefined;
 
-  const schemes: SchemeRegistration[] = [
-    { network: networkCaip2Pattern("evm"), client: new ExactEvmScheme(evmSigner, evmSchemeOptions) },
-    {
-      network: networkCaip2Pattern("evm"),
-      client: new UptoEvmClientScheme(evmSigner, uptoSchemeOptions),
-    },
-    { network: networkCaip2Pattern("evm"), client: batchSettlementScheme },
-    { network: "base-sepolia", client: new ExactEvmSchemeV1(evmSigner), x402Version: 1 },
-    { network: "base", client: new ExactEvmSchemeV1(evmSigner), x402Version: 1 },
-    {
-      network: networkCaip2Pattern("svm"),
-      client: new ExactSvmScheme(svmSigner, svmSchemeOptions),
-    },
-    {
-      network: networkCaip2Pattern("svm"),
-      client: new UptoSvmScheme(svmSigner, svmSchemeOptions),
-    },
-    {
-      network: "solana-devnet",
-      client: new ExactSvmSchemeV1(svmSigner, svmSchemeOptions),
-      x402Version: 1,
-    },
-    { network: "solana", client: new ExactSvmSchemeV1(svmSigner, svmSchemeOptions), x402Version: 1 },
-  ];
   if (ccdPrivateKey && ccdAddress) {
     schemes.push({
       network: networkCaip2Pattern("ccd"),
@@ -319,7 +338,12 @@ function aggregateBatchResult(
 export type ClientScenarioDeps = {
   url: string;
   batchSettlementPhase: BatchSettlementPhase | undefined;
-  batchSettlementScheme: BatchSettlementEvmScheme;
+  /**
+   * `undefined` whenever `createE2EClient()` had no `CLIENT_EVM_PRIVATE_KEY`
+   * to derive it from (batch-settlement is EVM-only). Checked below before
+   * `batchSettlementPhase` can ever cause it to be used.
+   */
+  batchSettlementScheme: BatchSettlementEvmScheme | undefined;
   issueRequest: () => Promise<RequestResult>;
   /**
    * Overrides how the cooperative refund request is sent. Defaults to
@@ -334,7 +358,19 @@ export type ClientScenarioDeps = {
  */
 export async function runClientScenario(deps: ClientScenarioDeps): Promise<void> {
   const { url, batchSettlementPhase, batchSettlementScheme, issueRequest } = deps;
-  const sendRefund = deps.refund ?? (() => batchSettlementScheme.refund(url));
+  // A batch-settlement phase only makes sense for EVM, so this only fires
+  // when a scenario's own config is inconsistent (EVM_BATCH_SETTLEMENT_PHASE
+  // set without CLIENT_EVM_PRIVATE_KEY), not from ordinary family scoping,
+  // where batchSettlementPhase is simply left unset. Failing fast here with a
+  // clear message beats a bare "Cannot read properties of undefined" once
+  // sendRefund is actually invoked below.
+  if (batchSettlementPhase && !batchSettlementScheme) {
+    throw new Error(
+      "EVM_BATCH_SETTLEMENT_PHASE is set but no CLIENT_EVM_PRIVATE_KEY was provided to build a " +
+        "batch-settlement scheme from.",
+    );
+  }
+  const sendRefund = deps.refund ?? (() => batchSettlementScheme!.refund(url));
 
   if (!batchSettlementPhase) {
     const result = await issueRequest();

--- a/e2e/clients/typescript/mcp/index.ts
+++ b/e2e/clients/typescript/mcp/index.ts
@@ -115,7 +115,11 @@ try {
     batchSettlementPhase,
     batchSettlementScheme,
     issueRequest,
-    refund: () => batchSettlementScheme.refund(toolResourceUrl, { fetch: mcpRefundFetch }),
+    // Same as runClientScenario's own sendRefund fallback: this closure only
+    // ever runs once batchSettlementPhase has already been confirmed truthy,
+    // and runClientScenario throws before that point if batchSettlementScheme
+    // (EVM-only) is missing, so the assertion here is safe, not a bypass.
+    refund: () => batchSettlementScheme!.refund(toolResourceUrl, { fetch: mcpRefundFetch }),
   });
 } catch (error: unknown) {
   console.log(

--- a/e2e/test.ts
+++ b/e2e/test.ts
@@ -992,51 +992,68 @@ async function runTest() {
     log('');
   }
 
-  // Collect unique facilitators and servers
+  // Collect unique facilitators, servers, and clients
   const uniqueFacilitators = new Map<string, any>();
   const uniqueServers = new Map<string, any>();
+  const uniqueClients = new Map<string, any>();
 
   filteredScenarios.forEach(scenario => {
     if (scenario.facilitator) {
       uniqueFacilitators.set(scenario.facilitator.name, scenario.facilitator);
     }
     uniqueServers.set(scenario.server.name, scenario.server);
+    uniqueClients.set(scenario.client.name, scenario.client);
   });
 
-  // Validate environment variables for all selected facilitators
-  log('\n🔍 Validating facilitator environment variables...\n');
-  const missingEnvVars: { facilitatorName: string; missingVars: string[] }[] = [];
+  // Validate environment variables for all selected facilitators and clients.
+  // Clients used to be silently skipped here: this loop printed "✅ All
+  // required environment variables are present" having checked only
+  // facilitators, then a family-scoped run could still crash deep inside a
+  // client (e.g. e2e/clients/typescript/client.ts's createE2EClient(), see
+  // x402-foundation/x402#3187) over a missing CLIENT_* credential this check
+  // never looked at. Each component type keeps its own catalog-declared
+  // `config.environment.required` list (client requirements can be more
+  // specific than the generic per-family baseline already enforced above,
+  // same reason the facilitator-specific check existed in the first place),
+  // so this validates every component type against its own list rather than
+  // assuming the earlier, family-generic check already covers it.
+  log('\n🔍 Validating facilitator and client environment variables...\n');
+  const missingEnvVars: { componentName: string; missingVars: string[] }[] = [];
 
-  for (const [facilitatorName, facilitator] of uniqueFacilitators) {
-    const requiredVars = facilitator.config.environment?.required || [];
-    const missing: string[] = [];
+  const componentsToValidate: Map<string, any>[] = [uniqueFacilitators, uniqueClients];
 
-    for (const envVar of requiredVars) {
-      // Skip env keys the harness assigns itself (e.g. PORT), never operator-supplied
-      if (FACILITATOR_ENV_PREFLIGHT_ALLOWLIST.has(envVar)) {
-        continue;
+  for (const components of componentsToValidate) {
+    for (const [componentName, component] of components) {
+      const requiredVars = component.config.environment?.required || [];
+      const missing: string[] = [];
+
+      for (const envVar of requiredVars) {
+        // Skip env keys the harness assigns itself (e.g. PORT), never operator-supplied
+        if (FACILITATOR_ENV_PREFLIGHT_ALLOWLIST.has(envVar)) {
+          continue;
+        }
+        // Skip credentials for families not in this run (catalog marks all wallet
+        // keys required per family; only selected families need them present).
+        const family = protocolFamilyForCredentialKey(envVar);
+        if (family && !selectedProtocolFamilies.has(family)) {
+          continue;
+        }
+
+        if (!process.env[envVar]) {
+          missing.push(envVar);
+        }
       }
-      // Skip credentials for families not in this run (catalog marks all wallet
-      // keys required per family; only selected families need them present).
-      const family = protocolFamilyForCredentialKey(envVar);
-      if (family && !selectedProtocolFamilies.has(family)) {
-        continue;
-      }
 
-      if (!process.env[envVar]) {
-        missing.push(envVar);
+      if (missing.length > 0) {
+        missingEnvVars.push({ componentName, missingVars: missing });
       }
-    }
-
-    if (missing.length > 0) {
-      missingEnvVars.push({ facilitatorName, missingVars: missing });
     }
   }
 
   if (missingEnvVars.length > 0) {
-    errorLog('❌ Missing required environment variables for selected facilitators:\n');
-    for (const { facilitatorName, missingVars } of missingEnvVars) {
-      errorLog(`   ${facilitatorName}:`);
+    errorLog('❌ Missing required environment variables for selected facilitators/clients:\n');
+    for (const { componentName, missingVars } of missingEnvVars) {
+      errorLog(`   ${componentName}:`);
       missingVars.forEach(varName => errorLog(` - ${varName}`));
     }
     errorLog('\n💡 Please set the required environment variables and try again.\n');


### PR DESCRIPTION
Fixes #3187.

`createE2EClient()` derived EVM (`viem`'s `privateKeyToAccount`) and SVM (`@solana/kit`'s `createKeyPairSignerFromBytes`) signers unconditionally at the top of the function, ahead of any `--families` scoping, while every other family below it (Aptos, Hedera, Keeta, Stellar, AVM, TVM, Near, XRPL) already only derives its signer when that family's own `CLIENT_*` credential is actually set. A single-family run against a non-EVM/SVM network crashed here regardless of `--families`, unless unrelated EVM/SVM credentials happened to be set too — the exact scenario in #3187, hit running the real conformance suite against a live Stellar facilitator with no EVM/SVM credentials configured at all.

## What changed

- EVM and SVM signer derivation is now conditional on their own `CLIENT_EVM_PRIVATE_KEY`/`CLIENT_SVM_PRIVATE_KEY`, matching the pattern every other family already follows.
- `batchSettlementScheme` (EVM-only) is now `BatchSettlementEvmScheme | undefined`. `runClientScenario` throws a clear config error if `EVM_BATCH_SETTLEMENT_PHASE` is set without EVM creds, instead of a bare `Cannot read properties of undefined` once the refund path is actually reached.
- Second, separate gap found running this: the harness's own preflight validation (`e2e/test.ts`) only ever checked facilitator env vars, printing "✅ All required environment variables are present" without having looked at client env at all. A family-scoped run could pass that check cleanly and still crash deep inside a client for exactly this reason. Extended the same validation loop to also cover clients against each client's own catalog-declared `config.environment.required`.

## Verified with real code, not just reasoning

Built the full `typescript/` workspace and the `e2e/` workspace on top of current `main`, then called the actual `createE2EClient()`/`runClientScenario()` under five scenarios: no client creds (the exact reported crash), EVM-only (a real random 32-byte key), SVM-only (a real generated Ed25519 keypair, base58-encoded, matching what `createKeyPairSignerFromBytes` expects), both, and the batch-settlement-without-EVM-creds guard (checked against `runClientScenario`, where that guard actually lives, not `createE2EClient` itself). All five pass:

```
PASS [no client creds (the reported #3187 crash)]: 0 scheme(s) registered, no crash
PASS [EVM-only]: 5 scheme(s) registered, no crash
PASS [SVM-only]: 4 scheme(s) registered, no crash
PASS [EVM + SVM]: 9 scheme(s) registered, no crash
PASS [EVM_BATCH_SETTLEMENT_PHASE set without EVM creds (guard)]: threw as expected: EVM_BATCH_SETTLEMENT_PHASE is set but no CLIENT_EVM_PRIVATE_KEY was provided to build a batch-settlement scheme from.
```

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
