### PR TITLE
fix(fetch): preserve original errors as cause in wrapFetchWithPayment

### DIFF
--- a/typescript/packages/http/fetch/src/index.test.ts
+++ b/typescript/packages/http/fetch/src/index.test.ts
@@ -230,6 +230,57 @@ describe("wrapFetchWithPayment()", () => {
     );
   });
 
+  it("should preserve the original typed error as `cause` when payment payload creation fails (#2394)", async () => {
+    // A structured, caller-defined error carrying fields beyond `message`.
+    const original = Object.assign(new Error("guardrail blocked payment"), {
+      name: "PolicyError",
+      code: "SPEND_LIMIT_EXCEEDED",
+    });
+    (mockClient.createPaymentPayload as ReturnType<typeof vi.fn>).mockRejectedValue(original);
+
+    mockFetch.mockResolvedValue(createResponse(402, validPaymentRequired));
+
+    const caught = await wrappedFetch("https://api.example.com", { method: "GET" }).catch(e => e);
+
+    // The descriptive wrapper message is retained for existing callers...
+    expect(caught).toBeInstanceOf(Error);
+    expect(caught.message).toBe("Failed to create payment payload: guardrail blocked payment");
+    // ...and the original error, with its structured fields, is reachable via `cause`.
+    expect(caught.cause).toBe(original);
+    expect((caught.cause as { code?: string }).code).toBe("SPEND_LIMIT_EXCEEDED");
+  });
+
+  it("should preserve a non-Error thrown value as `cause` when payment payload creation fails", async () => {
+    (mockClient.createPaymentPayload as ReturnType<typeof vi.fn>).mockRejectedValue("String error");
+
+    mockFetch.mockResolvedValue(createResponse(402, validPaymentRequired));
+
+    const caught = await wrappedFetch("https://api.example.com", { method: "GET" }).catch(e => e);
+
+    expect(caught.message).toBe("Failed to create payment payload: Unknown error");
+    expect(caught.cause).toBe("String error");
+  });
+
+  it("should preserve the original error as `cause` when payment requirements parsing fails", async () => {
+    const { x402HTTPClient: MockX402HTTPClient } = await import("@x402/core/client");
+    const original = new TypeError("Invalid payment header format");
+    (
+      MockX402HTTPClient.prototype.getPaymentRequiredResponse as ReturnType<typeof vi.fn>
+    ).mockImplementation(() => {
+      throw original;
+    });
+
+    mockFetch.mockResolvedValue(createResponse(402, undefined));
+
+    const caught = await wrappedFetch("https://api.example.com", { method: "GET" }).catch(e => e);
+
+    expect(caught.message).toBe(
+      "Failed to parse payment requirements: Invalid payment header format",
+    );
+    expect(caught.cause).toBe(original);
+    expect(caught.cause).toBeInstanceOf(TypeError);
+  });
+
   it("should handle v1 payment responses from body", async () => {
     const { x402HTTPClient: MockX402HTTPClient } = await import("@x402/core/client");
     const successResponse = createResponse(200, { data: "success" });

--- a/typescript/packages/http/fetch/src/index.ts
+++ b/typescript/packages/http/fetch/src/index.ts
@@ -72,8 +72,11 @@ export function wrapFetchWithPayment(
 
       paymentRequired = httpClient.getPaymentRequiredResponse(getHeader, body);
     } catch (error) {
-      throw new Error(
-        `Failed to parse payment requirements: ${error instanceof Error ? error.message : "Unknown error"}`,
+      throw Object.assign(
+        new Error(
+          `Failed to parse payment requirements: ${error instanceof Error ? error.message : "Unknown error"}`,
+        ),
+        { cause: error },
       );
     }
 
@@ -97,8 +100,11 @@ export function wrapFetchWithPayment(
     try {
       paymentPayload = await client.createPaymentPayload(paymentRequired);
     } catch (error) {
-      throw new Error(
-        `Failed to create payment payload: ${error instanceof Error ? error.message : "Unknown error"}`,
+      throw Object.assign(
+        new Error(
+          `Failed to create payment payload: ${error instanceof Error ? error.message : "Unknown error"}`,
+        ),
+        { cause: error },
       );
     }
 


### PR DESCRIPTION
## Summary

Closes #2394.

`wrapFetchWithPayment` in `@x402/fetch` caught errors thrown by `client.createPaymentPayload(...)` and rethrew a fresh generic `Error`, discarding the original error type and any structured fields. As the issue notes, that makes it impossible for callers to distinguish policy or guardrail failures from generic payment construction failures without parsing error message strings. The identical pattern also sat two blocks up, on the payment requirements parse step.

## Fix

Attach the original thrown value as the `cause` of the wrapper error, using the `Object.assign(new Error(...), { cause })` form already established in the repo (for example `packages/mechanisms/tvm/src/exact/codec.ts`). This keeps the ES2020 target and the package `lib: ["DOM"]` override happy without relying on the two argument `Error` constructor overload.

The descriptive wrapper message is unchanged, so existing callers and existing tests that assert on it are unaffected. The original error, with its structured fields, is now reachable via `error.cause`.

Both wrap sites in `wrapFetchWithPayment` get the same treatment for consistency: payment payload creation, which the issue reports, plus the sibling payment requirements parse.

## Tests

Added three cases to `src/index.test.ts`:

- a structured caller error survives on `cause` (message retained, `cause.code` reachable),
- a non-Error thrown value is preserved verbatim on `cause`,
- the payment requirements parse path preserves its original error on `cause`.

## Validation

- `pnpm --filter @x402/fetch test` (via `turbo run test`) passes 24 tests (21 existing plus 3 new)
- `tsc --noEmit`, `eslint`, and `prettier --check` are clean on the changed files
- `pnpm run format:check` passes across the workspace
- `tsup` build succeeds

No behaviour change for existing callers. The wrapper `Error` and its message are the same, with the original now preserved on `.cause`.
