### PR TITLE
fix: require PaymentRequired.resource.url on v2 emit

### DIFF
--- a/go/extensions/signinwithx/client_test.go
+++ b/go/extensions/signinwithx/client_test.go
@@ -278,6 +278,7 @@ func TestCreateClientHookReturnsSIWXHeader(t *testing.T) {
 	hook := CreateClientHook(signer)
 	result, err := hook(context.Background(), types.PaymentRequired{
 		X402Version: 2,
+		Resource:    &types.ResourceInfo{URL: "https://example.com/resource"},
 		Extensions: map[string]interface{}{
 			ExtensionKey: Extension{
 				Info: Info{
@@ -321,6 +322,7 @@ func TestCreateClientHookWithSignersReturnsSolanaHeader(t *testing.T) {
 	hook := CreateClientHookWithSigners(NewSolanaSIWXSigner(signer))
 	result, err := hook(context.Background(), types.PaymentRequired{
 		X402Version: 2,
+		Resource:    &types.ResourceInfo{URL: "https://example.com/resource"},
 		Extensions: map[string]interface{}{
 			ExtensionKey: Extension{
 				Info: Info{
@@ -540,6 +542,7 @@ func TestCreateClientHookDoesNotSignWhenOriginMismatched(t *testing.T) {
 	hook := CreateClientHook(signer)
 	result, err := hook(context.Background(), types.PaymentRequired{
 		X402Version: 2,
+		Resource:    &types.ResourceInfo{URL: "https://example.com/resource"},
 		Accepts:     []types.PaymentRequirements{{Network: "eip155:1"}},
 		Extensions: map[string]interface{}{
 			ExtensionKey: Extension{

--- a/go/http/client_test.go
+++ b/go/http/client_test.go
@@ -169,6 +169,7 @@ func TestPaymentRoundTripper_RejectsOversizedInitial402(t *testing.T) {
 func TestPaymentRoundTripper_RejectsOversizedAuthRetry402(t *testing.T) {
 	required := types.PaymentRequired{
 		X402Version: 2,
+		Resource:    &types.ResourceInfo{URL: "https://example.com/resource"},
 		Extensions: map[string]interface{}{
 			"sign-in-with-x": map[string]interface{}{"info": map[string]interface{}{"nonce": "abc"}},
 		},

--- a/go/http/client_test.go
+++ b/go/http/client_test.go
@@ -30,6 +30,7 @@ func TestNewx402HTTPClient(t *testing.T) {
 func TestPaymentRoundTripper_OnPaymentRequiredHeaderRetry(t *testing.T) {
 	required := types.PaymentRequired{
 		X402Version: 2,
+		Resource:    &types.ResourceInfo{URL: "https://example.com/resource"},
 		Extensions: map[string]interface{}{
 			"sign-in-with-x": map[string]interface{}{"info": map[string]interface{}{"nonce": "abc"}},
 		},
@@ -225,6 +226,7 @@ func TestPaymentRoundTripper_RejectsOversizedAuthRetry402(t *testing.T) {
 func TestPaymentRoundTripper_OnPaymentRequiredHookSkippedWithoutHeaders(t *testing.T) {
 	required := types.PaymentRequired{
 		X402Version: 2,
+		Resource:    &types.ResourceInfo{URL: "https://example.com/resource"},
 		Accepts: []types.PaymentRequirements{
 			{Scheme: "unsupported", Network: "eip155:1"},
 		},
@@ -269,6 +271,7 @@ func TestPaymentRoundTripper_OnPaymentRequiredHookSkippedWithoutHeaders(t *testi
 func TestPaymentRoundTripper_OnPaymentRequiredPassesRequestURL(t *testing.T) {
 	required := types.PaymentRequired{
 		X402Version: 2,
+		Resource:    &types.ResourceInfo{URL: "https://example.com/resource"},
 		Accepts: []types.PaymentRequirements{
 			{Scheme: "unsupported", Network: "eip155:1"},
 		},
@@ -318,6 +321,7 @@ func TestPaymentRoundTripper_OnPaymentRequiredPassesRequestURL(t *testing.T) {
 func TestPaymentRoundTripper_RegisteredExtensionHookRetry(t *testing.T) {
 	required := types.PaymentRequired{
 		X402Version: 2,
+		Resource:    &types.ResourceInfo{URL: "https://example.com/resource"},
 		Extensions: map[string]interface{}{
 			"test-extension": map[string]interface{}{"info": map[string]interface{}{"nonce": "abc"}},
 		},
@@ -378,6 +382,7 @@ func TestPaymentRoundTripper_RegisteredExtensionHookRetry(t *testing.T) {
 func TestPaymentRoundTripper_RegisteredExtensionHookSkippedWithoutDeclaration(t *testing.T) {
 	required := types.PaymentRequired{
 		X402Version: 2,
+		Resource:    &types.ResourceInfo{URL: "https://example.com/resource"},
 		Extensions: map[string]interface{}{
 			"other-extension": map[string]interface{}{},
 		},
@@ -595,6 +600,7 @@ func TestGetPaymentRequiredResponse(t *testing.T) {
 	// Test v2 header format
 	requirements := x402.PaymentRequired{
 		X402Version: 2,
+		Resource:    &x402.ResourceInfo{URL: "https://example.com/resource"},
 		Error:       "Payment required",
 		Accepts: []x402.PaymentRequirements{
 			{
@@ -789,6 +795,7 @@ func TestPaymentRoundTripper(t *testing.T) {
 			// First call - return 402
 			requirements := x402.PaymentRequired{
 				X402Version: 2,
+				Resource:    &x402.ResourceInfo{URL: "https://example.com/resource"},
 				Error:       "Payment required",
 				Accepts: []x402.PaymentRequirements{
 					{
@@ -869,6 +876,7 @@ func TestPaymentRoundTripper_ReplaysOneShotBody(t *testing.T) {
 			var bodies []string
 			required := types.PaymentRequired{
 				X402Version: 2,
+				Resource:    &types.ResourceInfo{URL: "https://example.com/resource"},
 				Extensions: map[string]interface{}{
 					"sign-in-with-x": map[string]interface{}{"info": map[string]interface{}{"nonce": "abc"}},
 				},
@@ -1220,7 +1228,7 @@ func (m *hookSchemeClient) OnPaymentResponse(ctx context.Context, prCtx x402.Pay
 
 func paymentRequiredHeader(t *testing.T, accepts []types.PaymentRequirements) string {
 	t.Helper()
-	pr := types.PaymentRequired{X402Version: 2, Accepts: accepts}
+	pr := types.PaymentRequired{X402Version: 2, Resource: &types.ResourceInfo{URL: "https://example.com/resource"}, Accepts: accepts}
 	encoded, err := encodePaymentRequiredHeader(pr)
 	if err != nil {
 		t.Fatalf("encodePaymentRequired: %v", err)

--- a/go/mcp/client_test.go
+++ b/go/mcp/client_test.go
@@ -92,6 +92,7 @@ func TestX402MCPClient_CallTool_FreeTool(t *testing.T) {
 func TestX402MCPClient_CallTool_PaymentRequired(t *testing.T) {
 	paymentRequired := types.PaymentRequired{
 		X402Version: 2,
+		Resource:    &types.ResourceInfo{URL: "https://example.com/resource"},
 		Accepts: []types.PaymentRequirements{
 			{
 				Scheme:            "exact",
@@ -371,6 +372,7 @@ func TestX402MCPClient_CallToolWithPayment_AfterPaymentHook(t *testing.T) {
 func TestX402MCPClient_GetToolPaymentRequirements(t *testing.T) {
 	paymentRequired := types.PaymentRequired{
 		X402Version: 2,
+		Resource:    &types.ResourceInfo{URL: "https://example.com/resource"},
 		Accepts: []types.PaymentRequirements{
 			{
 				Scheme:  "exact",
@@ -436,6 +438,7 @@ func TestX402MCPClient_CallTool_AutoPaymentE2E(t *testing.T) {
 	// First call returns 402 payment required, second call returns success
 	paymentRequired := types.PaymentRequired{
 		X402Version: 2,
+		Resource:    &types.ResourceInfo{URL: "https://example.com/resource"},
 		Accepts: []types.PaymentRequirements{
 			{
 				Scheme:            "exact",
@@ -510,6 +513,7 @@ func TestX402MCPClient_CallTool_SelectsSupportedNonFirstAccept(t *testing.T) {
 	// otherwise CreatePaymentPayload fails for the unregistered first network.
 	paymentRequired := types.PaymentRequired{
 		X402Version: 2,
+		Resource:    &types.ResourceInfo{URL: "https://example.com/resource"},
 		Accepts: []types.PaymentRequirements{
 			{Scheme: "exact", Network: "eip155:1", Amount: "1000", Asset: "USDC", PayTo: "0xrecipient", MaxTimeoutSeconds: 300},
 			{Scheme: "exact", Network: "eip155:84532", Amount: "1000", Asset: "USDC", PayTo: "0xrecipient", MaxTimeoutSeconds: 300},
@@ -564,6 +568,7 @@ func TestX402MCPClient_CallTool_SelectsSupportedNonFirstAccept(t *testing.T) {
 func TestX402MCPClient_CallTool_HookAbort(t *testing.T) {
 	paymentRequired := types.PaymentRequired{
 		X402Version: 2,
+		Resource:    &types.ResourceInfo{URL: "https://example.com/resource"},
 		Accepts: []types.PaymentRequirements{
 			{
 				Scheme:  "exact",
@@ -616,6 +621,7 @@ func TestX402MCPClient_CallTool_HookAbort(t *testing.T) {
 func TestX402MCPClient_CallTool_HookCustomPayment(t *testing.T) {
 	paymentRequired := types.PaymentRequired{
 		X402Version: 2,
+		Resource:    &types.ResourceInfo{URL: "https://example.com/resource"},
 		Accepts: []types.PaymentRequirements{
 			{
 				Scheme:  "exact",
@@ -693,6 +699,7 @@ func TestX402MCPClient_CallTool_HookCustomPayment(t *testing.T) {
 func TestX402MCPClient_CallTool_OnPaymentRequestedApproved(t *testing.T) {
 	paymentRequired := types.PaymentRequired{
 		X402Version: 2,
+		Resource:    &types.ResourceInfo{URL: "https://example.com/resource"},
 		Accepts: []types.PaymentRequirements{
 			{
 				Scheme:  "exact",
@@ -752,6 +759,7 @@ func TestX402MCPClient_CallTool_OnPaymentRequestedApproved(t *testing.T) {
 func TestX402MCPClient_CallTool_OnPaymentRequestedDenied(t *testing.T) {
 	paymentRequired := types.PaymentRequired{
 		X402Version: 2,
+		Resource:    &types.ResourceInfo{URL: "https://example.com/resource"},
 		Accepts: []types.PaymentRequirements{
 			{
 				Scheme:  "exact",
@@ -802,6 +810,7 @@ func TestX402MCPClient_CallTool_OnPaymentRequestedDenied(t *testing.T) {
 func TestX402MCPClient_CallTool_BeforePaymentHookCalled(t *testing.T) {
 	paymentRequired := types.PaymentRequired{
 		X402Version: 2,
+		Resource:    &types.ResourceInfo{URL: "https://example.com/resource"},
 		Accepts: []types.PaymentRequirements{
 			{
 				Scheme:  "exact",
@@ -865,6 +874,7 @@ func TestX402MCPClient_CallTool_BeforePaymentHookCalled(t *testing.T) {
 func TestX402MCPClient_CallTool_BeforePaymentHookError(t *testing.T) {
 	paymentRequired := types.PaymentRequired{
 		X402Version: 2,
+		Resource:    &types.ResourceInfo{URL: "https://example.com/resource"},
 		Accepts: []types.PaymentRequirements{
 			{
 				Scheme:  "exact",
@@ -960,6 +970,7 @@ func TestX402MCPClientFromConfig_SpendControlsDefaultRejectsOverCap(t *testing.T
 		callToolResults: []MCPToolResult{
 			mcp402Result(t, types.PaymentRequired{
 				X402Version: 2,
+				Resource:    &types.ResourceInfo{URL: "https://example.com/resource"},
 				Accepts: []types.PaymentRequirements{{
 					Scheme: "exact", Network: "eip155:84532",
 					Asset: "0xCustomUnknownToken", Amount: "2000000",
@@ -983,6 +994,7 @@ func TestX402MCPClient_WrapExistingClientHonoursSpendControlsWhenUnset(t *testin
 		callToolResults: []MCPToolResult{
 			mcp402Result(t, types.PaymentRequired{
 				X402Version: 2,
+				Resource:    &types.ResourceInfo{URL: "https://example.com/resource"},
 				Accepts: []types.PaymentRequirements{{
 					Scheme: "exact", Network: "eip155:84532",
 					Asset: "0xCustomUnknownToken", Amount: "1",
@@ -1007,6 +1019,7 @@ func TestX402MCPClient_WrapUsesPaymentClientDisableSpendControls(t *testing.T) {
 		callToolResults: []MCPToolResult{
 			mcp402Result(t, types.PaymentRequired{
 				X402Version: 2,
+				Resource:    &types.ResourceInfo{URL: "https://example.com/resource"},
 				Accepts: []types.PaymentRequirements{{
 					Scheme: "exact", Network: "eip155:84532",
 					Asset: "0xCustomUnknownToken", Amount: "2000000",
@@ -1035,6 +1048,7 @@ func TestX402MCPClient_WrapUsesPaymentClientSpendControls(t *testing.T) {
 		callToolResults: []MCPToolResult{
 			mcp402Result(t, types.PaymentRequired{
 				X402Version: 2,
+				Resource:    &types.ResourceInfo{URL: "https://example.com/resource"},
 				Accepts: []types.PaymentRequirements{{
 					Scheme: "exact", Network: "eip155:84532",
 					Asset: "0xCustomUnknownToken", Amount: "1",

--- a/go/mcp/utils_test.go
+++ b/go/mcp/utils_test.go
@@ -95,6 +95,7 @@ func TestAttachPaymentToMeta(t *testing.T) {
 func TestExtractPaymentRequiredFromResult(t *testing.T) {
 	paymentRequired := types.PaymentRequired{
 		X402Version: 2,
+		Resource:    &types.ResourceInfo{URL: "https://example.com/resource"},
 		Accepts: []types.PaymentRequirements{
 			{
 				Scheme:  "exact",
@@ -152,6 +153,7 @@ func TestExtractPaymentRequiredFromResult(t *testing.T) {
 func TestCreatePaymentRequiredError(t *testing.T) {
 	paymentRequired := &types.PaymentRequired{
 		X402Version: 2,
+		Resource:    &types.ResourceInfo{URL: "https://example.com/resource"},
 		Accepts: []types.PaymentRequirements{
 			{Scheme: "exact", Network: "eip155:84532", Amount: "1000"},
 		},
@@ -179,6 +181,7 @@ func TestCreatePaymentRequiredError(t *testing.T) {
 func TestIsPaymentRequiredError(t *testing.T) {
 	paymentRequired := &types.PaymentRequired{
 		X402Version: 2,
+		Resource:    &types.ResourceInfo{URL: "https://example.com/resource"},
 		Accepts: []types.PaymentRequirements{
 			{Scheme: "exact", Network: "eip155:84532", Amount: "1000"},
 		},
@@ -204,6 +207,7 @@ func TestIsPaymentRequiredError(t *testing.T) {
 func TestExtractPaymentRequiredFromError(t *testing.T) {
 	_ = types.PaymentRequired{
 		X402Version: 2,
+		Resource:    &types.ResourceInfo{URL: "https://example.com/resource"},
 		Accepts: []types.PaymentRequirements{
 			{Scheme: "exact", Network: "eip155:84532", Amount: "1000"},
 		},

--- a/go/mechanisms/evm/batch-settlement/client/refund_test.go
+++ b/go/mechanisms/evm/batch-settlement/client/refund_test.go
@@ -78,6 +78,7 @@ func TestEncodePaymentSignatureHeader_RoundTrip(t *testing.T) {
 func TestDecodePaymentRequiredHeader(t *testing.T) {
 	pr := x402.PaymentRequired{
 		X402Version: 2,
+		Resource:    &x402.ResourceInfo{URL: "https://example.com/resource"},
 		Error:       "boom",
 		Accepts:     []types.PaymentRequirements{{Scheme: "batch-settlement"}},
 	}
@@ -211,7 +212,7 @@ func TestProbeRefundRequirements_MissingHeader(t *testing.T) {
 }
 
 func TestProbeRefundRequirements_NoBatchedScheme(t *testing.T) {
-	pr := x402.PaymentRequired{Accepts: []types.PaymentRequirements{{Scheme: "exact"}}}
+	pr := x402.PaymentRequired{X402Version: 2, Resource: &x402.ResourceInfo{URL: "https://example.com/resource"}, Accepts: []types.PaymentRequirements{{Scheme: "exact"}}}
 	raw, _ := json.Marshal(pr)
 	header := base64.StdEncoding.EncodeToString(raw)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -225,7 +226,7 @@ func TestProbeRefundRequirements_NoBatchedScheme(t *testing.T) {
 }
 
 func TestProbeRefundRequirements_MissingReceiverAuthorizer(t *testing.T) {
-	pr := x402.PaymentRequired{Accepts: []types.PaymentRequirements{{Scheme: batchsettlement.SchemeBatched}}}
+	pr := x402.PaymentRequired{X402Version: 2, Resource: &x402.ResourceInfo{URL: "https://example.com/resource"}, Accepts: []types.PaymentRequirements{{Scheme: batchsettlement.SchemeBatched}}}
 	raw, _ := json.Marshal(pr)
 	header := base64.StdEncoding.EncodeToString(raw)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -240,6 +241,8 @@ func TestProbeRefundRequirements_MissingReceiverAuthorizer(t *testing.T) {
 
 func TestProbeRefundRequirements_OK(t *testing.T) {
 	pr := x402.PaymentRequired{
+		X402Version: 2,
+		Resource:    &x402.ResourceInfo{URL: "https://example.com/resource"},
 		Accepts: []types.PaymentRequirements{{
 			Scheme: batchsettlement.SchemeBatched,
 			Extra:  map[string]interface{}{"receiverAuthorizer": "0x1"},
@@ -615,7 +618,7 @@ func TestExecuteRefund_402WithBadPaymentResponseHeader(t *testing.T) {
 
 func TestExecuteRefund_NonRecoverableErrorFailsFast(t *testing.T) {
 	// Verify-side abort with a known non-recoverable error code: don't retry.
-	pr := x402.PaymentRequired{Error: batchsettlement.ErrRefundAmountInvalid}
+	pr := x402.PaymentRequired{X402Version: 2, Resource: &x402.ResourceInfo{URL: "https://example.com/resource"}, Error: batchsettlement.ErrRefundAmountInvalid}
 	prBytes, _ := json.Marshal(pr)
 	prHeader := base64.StdEncoding.EncodeToString(prBytes)
 
@@ -641,7 +644,7 @@ func TestExecuteRefund_NonRecoverableErrorFailsFast(t *testing.T) {
 
 func TestExecuteRefund_RecoverableErrorRetriesAndExhausts(t *testing.T) {
 	// Recoverable error code (not in non-recoverable set) but recovery returns false → fail with reason.
-	pr := x402.PaymentRequired{Error: "some_recoverable_thing"}
+	pr := x402.PaymentRequired{X402Version: 2, Resource: &x402.ResourceInfo{URL: "https://example.com/resource"}, Error: "some_recoverable_thing"}
 	prBytes, _ := json.Marshal(pr)
 	prHeader := base64.StdEncoding.EncodeToString(prBytes)
 

--- a/go/mechanisms/evm/batch-settlement/client/scheme_test.go
+++ b/go/mechanisms/evm/batch-settlement/client/scheme_test.go
@@ -1206,6 +1206,7 @@ func TestOnPaymentResponse_CorrectiveMismatchSignalsRecovered(t *testing.T) {
 		Requirements: defaultRequirements(),
 		PaymentRequired: &types.PaymentRequired{
 			X402Version: 2,
+			Resource:    &types.ResourceInfo{URL: "https://example.com/resource"},
 			Error:       batchsettlement.ErrCumulativeAmountMismatch,
 			Accepts:     []types.PaymentRequirements{defaultRequirements()},
 		},
@@ -1224,6 +1225,7 @@ func TestOnPaymentResponse_CorrectiveUnknownErrorDoesNotRecover(t *testing.T) {
 		Requirements: defaultRequirements(),
 		PaymentRequired: &types.PaymentRequired{
 			X402Version: 2,
+			Resource:    &types.ResourceInfo{URL: "https://example.com/resource"},
 			Error:       "some_other_error",
 			Accepts:     []types.PaymentRequirements{defaultRequirements()},
 		},

--- a/go/test/integration/evm_batch_settlement_test.go
+++ b/go/test/integration/evm_batch_settlement_test.go
@@ -957,6 +957,7 @@ func alwaysStaleRefundHandler(t *testing.T, pipe *batchedPipeline, price string)
 
 		paymentRequired := x402.PaymentRequired{
 			X402Version: 2,
+			Resource:    &x402.ResourceInfo{URL: "https://example.com/resource"},
 			Accepts:     []types.PaymentRequirements{req},
 		}
 		if r.Header.Get("PAYMENT-SIGNATURE") != "" {

--- a/go/types/payment_required_resource_test.go
+++ b/go/types/payment_required_resource_test.go
@@ -1,0 +1,32 @@
+package types
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestPaymentRequiredMarshalRequiresResourceURL(t *testing.T) {
+	if _, err := json.Marshal(PaymentRequired{X402Version: 1}); err != nil {
+		t.Fatalf("v1 must still marshal without resource: %v", err)
+	}
+	_, err := json.Marshal(PaymentRequired{X402Version: 2})
+	if err == nil {
+		t.Fatal("expected marshal error when resource is missing")
+	}
+	if !strings.Contains(err.Error(), "resource.url") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := json.Marshal(PaymentRequired{
+		X402Version: 2,
+		Resource:    &ResourceInfo{URL: "https://example.com/paid"},
+		Accepts:     []PaymentRequirements{{Scheme: "exact", Network: "eip155:1"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"resource"`) {
+		t.Fatalf("expected resource key on wire: %s", data)
+	}
+}

--- a/go/types/v2.go
+++ b/go/types/v2.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"encoding/json"
+	"fmt"
 )
 
 // PaymentPayload represents a v2 payment payload structure
@@ -40,13 +41,26 @@ func (r PaymentRequirements) GetPayTo() string                 { return r.PayTo 
 func (r PaymentRequirements) GetMaxTimeoutSeconds() int        { return r.MaxTimeoutSeconds }
 func (r PaymentRequirements) GetExtra() map[string]interface{} { return r.Extra }
 
-// PaymentRequired represents a v2 402 response structure
+// PaymentRequired represents a v2 402 response structure.
+// Spec section 5.1.2 requires resource on the wire. Keep Resource as a pointer
+// so inbound JSON can still be decoded, but MarshalJSON refuses a missing or
+// empty URL so Go servers cannot emit the v1-shaped envelope TypeScript rejects.
 type PaymentRequired struct {
 	X402Version int                    `json:"x402Version"`
 	Error       string                 `json:"error,omitempty"`
 	Resource    *ResourceInfo          `json:"resource,omitempty"`
 	Accepts     []PaymentRequirements  `json:"accepts"`
 	Extensions  map[string]interface{} `json:"extensions,omitempty"`
+}
+
+// MarshalJSON requires a non-empty resource.url (spec 5.1.2 / TS PaymentRequiredV2Schema).
+func (p PaymentRequired) MarshalJSON() ([]byte, error) {
+	// v1 bodies reused this struct in tests/clients and do not require resource.
+	if p.X402Version != 1 && (p.Resource == nil || p.Resource.URL == "") {
+		return nil, fmt.Errorf("PaymentRequired.resource.url is required")
+	}
+	type alias PaymentRequired
+	return json.Marshal(alias(p))
 }
 
 // ResourceInfo describes the resource being accessed.

--- a/python/x402/http/utils.py
+++ b/python/x402/http/utils.py
@@ -48,6 +48,8 @@ def encode_payment_required_header(
     payment_required: PaymentRequired | PaymentRequiredV1,
 ) -> str:
     """Encode a PaymentRequired object as a base64 header value."""
+    if isinstance(payment_required, PaymentRequired):
+        payment_required.validate_resource()
     return safe_base64_encode(payment_required.model_dump_json(by_alias=True, exclude_none=True))
 
 

--- a/python/x402/http/x402_http_server_base.py
+++ b/python/x402/http/x402_http_server_base.py
@@ -1331,6 +1331,7 @@ class x402HTTPServerBase:
         if not current_url and payment_required.resource:
             current_url = payment_required.resource.url or ""
 
+        payment_required.validate_resource()
         payment_data = payment_required.model_dump(by_alias=True, exclude_none=True)
 
         x402_config = {
@@ -1366,6 +1367,7 @@ class x402HTTPServerBase:
                 app_logo = f'<img src="{html.escape(config.app_logo)}" alt="{html.escape(config.app_name or "")}" style="max-width: 200px;">'
             app_name = config.app_name or ""
 
+        payment_required.validate_resource()
         payment_data = payment_required.model_dump_json(by_alias=True, exclude_none=True)
 
         title = f"{html.escape(app_name)} - Payment Required" if app_name else "Payment Required"

--- a/python/x402/schemas/payments.py
+++ b/python/x402/schemas/payments.py
@@ -66,7 +66,8 @@ class PaymentRequired(BaseX402Model):
     Attributes:
         x402_version: Protocol version (always 2 for V2).
         error: Optional error message.
-        resource: Optional resource information.
+        resource: Resource being accessed. Required on the wire (spec 5.1.2);
+            construction may leave it unset until serialize/validate.
         accepts: List of accepted payment requirements.
         extensions: Optional extension data.
     """
@@ -76,6 +77,10 @@ class PaymentRequired(BaseX402Model):
     resource: ResourceInfo | None = None
     accepts: list[PaymentRequirements]
     extensions: dict[str, Any] | None = None
+
+    def validate_resource(self) -> None:
+        if self.resource is None or not (self.resource.url or "").strip():
+            raise ValueError("PaymentRequired.resource.url is required")
 
 
 class PaymentPayload(BaseX402Model):

--- a/python/x402/tests/unit/core/test_extension_echo_validation.py
+++ b/python/x402/tests/unit/core/test_extension_echo_validation.py
@@ -11,6 +11,7 @@ from x402.schemas import (
     PaymentPayloadV1,
     PaymentRequired,
     PaymentRequirements,
+    ResourceInfo,
 )
 from x402.server_base import ERR_EXTENSION_ECHO_MISMATCH
 
@@ -30,7 +31,11 @@ def _requirements() -> PaymentRequirements:
 
 
 def _payment_required(extensions: dict | None) -> PaymentRequired:
-    return PaymentRequired(accepts=[_requirements()], extensions=extensions)
+    return PaymentRequired(
+        resource=ResourceInfo(url="https://example.com/resource"),
+        accepts=[_requirements()],
+        extensions=extensions,
+    )
 
 
 def _payment_payload(extensions: dict | None) -> PaymentPayload:

--- a/python/x402/tests/unit/extensions/builder_code/test_client.py
+++ b/python/x402/tests/unit/extensions/builder_code/test_client.py
@@ -9,7 +9,7 @@ from x402.extensions.builder_code import (
     BuilderCodeClientExtension,
     declare_builder_code_extension,
 )
-from x402.schemas import PaymentPayload, PaymentRequired, PaymentRequirements
+from x402.schemas import PaymentPayload, PaymentRequired, PaymentRequirements, ResourceInfo
 from x402.server_base import ERR_EXTENSION_ECHO_MISMATCH
 
 APP = "bc_my_app"
@@ -33,7 +33,9 @@ def _base_payload(extensions: dict | None = None) -> PaymentPayload:
 
 def _payment_required(app_code: str | None = None) -> PaymentRequired:
     extensions = {BUILDER_CODE: declare_builder_code_extension(app_code)} if app_code else None
-    return PaymentRequired(accepts=[], extensions=extensions)
+    return PaymentRequired(
+        resource=ResourceInfo(url="https://example.com/resource"), accepts=[], extensions=extensions
+    )
 
 
 class TestConstructorValidation:
@@ -97,6 +99,7 @@ class TestBuilderCodeClientIntegration:
         client.register_extension(BuilderCodeClientExtension(SERVICE))
 
         payment_required = PaymentRequired(
+            resource=ResourceInfo(url="https://example.com/resource"),
             x402_version=2,
             accepts=[
                 PaymentRequirements(
@@ -120,6 +123,7 @@ class TestBuilderCodeClientIntegration:
         client.register_extension(BuilderCodeClientExtension(SERVICE))
 
         payment_required = PaymentRequired(
+            resource=ResourceInfo(url="https://example.com/resource"),
             x402_version=2,
             accepts=[
                 PaymentRequirements(
@@ -150,6 +154,7 @@ class TestBuilderCodeClientIntegration:
         server = x402ResourceServer()
 
         payment_required = PaymentRequired(
+            resource=ResourceInfo(url="https://example.com/resource"),
             x402_version=2,
             accepts=[
                 PaymentRequirements(

--- a/python/x402/tests/unit/http/clients/test_httpx.py
+++ b/python/x402/tests/unit/http/clients/test_httpx.py
@@ -17,7 +17,13 @@ from x402.http.clients.httpx import (
 )
 from x402.http.utils import encode_payment_required_header, encode_payment_response_header
 from x402.http.x402_http_client import x402HTTPClient
-from x402.schemas import PaymentPayload, PaymentRequired, PaymentRequirements, SettleResponse
+from x402.schemas import (
+    PaymentPayload,
+    PaymentRequired,
+    PaymentRequirements,
+    ResourceInfo,
+    SettleResponse,
+)
 from x402.schemas.hooks import PaymentRequiredHeadersResult, RecoveredResponseResult
 
 # Skip tests if httpx not installed
@@ -129,6 +135,7 @@ class TestX402AsyncTransport:
 
         # Create payment required response
         payment_required = PaymentRequired(
+            resource=ResourceInfo(url="https://example.com/resource"),
             x402_version=2,
             accepts=[make_payment_requirements()],
         )
@@ -163,6 +170,7 @@ class TestX402AsyncTransport:
         """Streaming request bodies are identical on the initial send and retry."""
         mock_client = MockX402Client()
         payment_required = PaymentRequired(
+            resource=ResourceInfo(url="https://example.com/resource"),
             x402_version=2,
             accepts=[make_payment_requirements()],
         )
@@ -202,6 +210,7 @@ class TestX402AsyncTransport:
         mock_client = MockX402Client()
 
         payment_required = PaymentRequired(
+            resource=ResourceInfo(url="https://example.com/resource"),
             x402_version=2,
             accepts=[make_payment_requirements()],
         )
@@ -253,6 +262,7 @@ class TestX402AsyncTransport:
         mock_client = MockX402Client()
 
         payment_required = PaymentRequired(
+            resource=ResourceInfo(url="https://example.com/resource"),
             x402_version=2,
             accepts=[make_payment_requirements()],
         )
@@ -303,6 +313,7 @@ class TestX402AsyncTransport:
         )
 
         payment_required = PaymentRequired(
+            resource=ResourceInfo(url="https://example.com/resource"),
             x402_version=2,
             accepts=[make_payment_requirements()],
         )
@@ -343,6 +354,7 @@ class TestX402AsyncTransport:
         http_client.on_payment_required(capture_url)
 
         payment_required = PaymentRequired(
+            resource=ResourceInfo(url="https://example.com/resource"),
             x402_version=2,
             accepts=[make_payment_requirements()],
         )
@@ -371,6 +383,7 @@ class TestX402AsyncTransport:
         """Recovery retry creates a fresh payload after hook signals recovered."""
         mock_client = MockRecoveringClient()
         payment_required = PaymentRequired(
+            resource=ResourceInfo(url="https://example.com/resource"),
             x402_version=2,
             accepts=[make_payment_requirements()],
         )
@@ -633,6 +646,7 @@ class TestConsecutivePayments:
         mock_client = MockX402ClientWithCounter()
 
         payment_required = PaymentRequired(
+            resource=ResourceInfo(url="https://example.com/resource"),
             x402_version=2,
             accepts=[make_payment_requirements()],
         )
@@ -669,6 +683,7 @@ class TestConsecutivePayments:
         mock_client = MockX402ClientWithCounter()
 
         payment_required = PaymentRequired(
+            resource=ResourceInfo(url="https://example.com/resource"),
             x402_version=2,
             accepts=[make_payment_requirements()],
         )
@@ -700,6 +715,7 @@ class TestConsecutivePayments:
         mock_client = MockX402ClientWithCounter()
 
         payment_required = PaymentRequired(
+            resource=ResourceInfo(url="https://example.com/resource"),
             x402_version=2,
             accepts=[make_payment_requirements()],
         )
@@ -729,6 +745,7 @@ class TestConsecutivePayments:
         mock_client = MockX402ClientWithCounter()
 
         payment_required = PaymentRequired(
+            resource=ResourceInfo(url="https://example.com/resource"),
             x402_version=2,
             accepts=[make_payment_requirements()],
         )
@@ -848,6 +865,7 @@ class TestErrorHandlingTransport:
         mock_client.create_payment_payload = AsyncMock(side_effect=Exception("Client error"))
 
         payment_required = PaymentRequired(
+            resource=ResourceInfo(url="https://example.com/resource"),
             x402_version=2,
             accepts=[make_payment_requirements()],
         )
@@ -873,6 +891,7 @@ class TestErrorHandlingTransport:
         )
 
         payment_required = PaymentRequired(
+            resource=ResourceInfo(url="https://example.com/resource"),
             x402_version=2,
             accepts=[make_payment_requirements()],
         )

--- a/python/x402/tests/unit/http/clients/test_requests.py
+++ b/python/x402/tests/unit/http/clients/test_requests.py
@@ -16,7 +16,13 @@ from x402.http.clients.requests import (
 from x402.http.utils import encode_payment_required_header, encode_payment_response_header
 from x402.http.x402_http_client import x402HTTPClientSync
 from x402.http.x402_http_client_base import ProcessPaymentResult
-from x402.schemas import PaymentPayload, PaymentRequired, PaymentRequirements, SettleResponse
+from x402.schemas import (
+    PaymentPayload,
+    PaymentRequired,
+    PaymentRequirements,
+    ResourceInfo,
+    SettleResponse,
+)
 from x402.schemas.hooks import PaymentRequiredHeadersResult, RecoveredResponseResult
 
 # Skip tests if requests not installed
@@ -138,6 +144,7 @@ class TestX402HTTPAdapter:
 
         # Create payment required
         payment_required = PaymentRequired(
+            resource=ResourceInfo(url="https://example.com/resource"),
             x402_version=2,
             accepts=[make_payment_requirements()],
         )
@@ -182,6 +189,7 @@ class TestX402HTTPAdapter:
         adapter = x402HTTPAdapter(mock_client)
 
         payment_required = PaymentRequired(
+            resource=ResourceInfo(url="https://example.com/resource"),
             x402_version=2,
             accepts=[make_payment_requirements()],
         )
@@ -303,6 +311,7 @@ class TestX402HTTPAdapter:
         adapter = x402HTTPAdapter(http_client)
 
         payment_required = PaymentRequired(
+            resource=ResourceInfo(url="https://example.com/resource"),
             x402_version=2,
             accepts=[make_payment_requirements()],
         )
@@ -344,6 +353,7 @@ class TestX402HTTPAdapter:
         adapter = x402HTTPAdapter(mock_client)
 
         payment_required = PaymentRequired(
+            resource=ResourceInfo(url="https://example.com/resource"),
             x402_version=2,
             accepts=[make_payment_requirements()],
         )

--- a/python/x402/tests/unit/http/test_extension_transport_hooks.py
+++ b/python/x402/tests/unit/http/test_extension_transport_hooks.py
@@ -10,7 +10,7 @@ import pytest
 from x402.http.types import HTTPRequestContext, PaymentOption, RouteConfig
 from x402.http.x402_http_client import x402HTTPClient
 from x402.http.x402_http_server_base import x402HTTPServerBase
-from x402.schemas import PaymentRequired, PaymentRequirements
+from x402.schemas import PaymentRequired, PaymentRequirements, ResourceInfo
 from x402.schemas.hooks import (
     GrantAccessResult,
     PaymentRequiredContext,
@@ -168,6 +168,7 @@ async def test_client_extension_on_payment_required_runs_after_manual():
         max_timeout_seconds=300,
     )
     payment_required = PaymentRequired(
+        resource=ResourceInfo(url="https://example.com/resource"),
         x402_version=2,
         accepts=[requirements],
         extensions={"cli-ext": {}},

--- a/python/x402/tests/unit/http/test_http_hooks.py
+++ b/python/x402/tests/unit/http/test_http_hooks.py
@@ -15,7 +15,13 @@ from x402.http.types import (
 )
 from x402.http.utils import encode_payment_signature_header
 from x402.http.x402_http_server import x402HTTPResourceServer
-from x402.schemas import PaymentPayload, PaymentRequirements, SettleResponse, VerifyResponse
+from x402.schemas import (
+    PaymentPayload,
+    PaymentRequirements,
+    ResourceInfo,
+    SettleResponse,
+    VerifyResponse,
+)
 from x402.schemas.hooks import (
     AbortProtectedRequestResult,
     GrantAccessResult,
@@ -128,6 +134,7 @@ class TestOnProtectedRequest:
             _requirements, _resource, error, _extensions, **_kwargs
         ):
             return PaymentRequired(
+                resource=ResourceInfo(url="https://example.com/resource"),
                 x402_version=2,
                 error=error,
                 accepts=requirements,

--- a/python/x402/tests/unit/http/test_utils.py
+++ b/python/x402/tests/unit/http/test_utils.py
@@ -21,6 +21,7 @@ from x402.schemas import (
     PaymentPayload,
     PaymentRequired,
     PaymentRequirements,
+    ResourceInfo,
     SettleResponse,
 )
 from x402.schemas.v1 import PaymentPayloadV1, PaymentRequiredV1
@@ -72,6 +73,7 @@ class TestCamelCaseSerialization:
         """PaymentRequired should serialize as camelCase."""
         payment_required = PaymentRequired(
             x402_version=2,
+            resource=ResourceInfo(url="https://example.com/paid"),
             accepts=[make_payment_requirements()],
         )
         data = json.loads(payment_required.model_dump_json())
@@ -174,6 +176,7 @@ class TestPaymentRequiredHeader:
         requirements = make_payment_requirements()
         payment_required = PaymentRequired(
             x402_version=2,
+            resource=ResourceInfo(url="https://example.com/paid"),
             accepts=[requirements],
             error=None,
         )
@@ -190,6 +193,7 @@ class TestPaymentRequiredHeader:
         requirements = make_payment_requirements()
         payment_required = PaymentRequired(
             x402_version=2,
+            resource=ResourceInfo(url="https://example.com/paid"),
             accepts=[requirements],
         )
         encoded = encode_payment_required_header(payment_required)
@@ -406,3 +410,13 @@ class TestHtmlsafeJsonDumps:
         result = htmlsafe_json_dumps(data)
         decoded = json.loads(result)
         assert decoded == data
+
+
+class TestPaymentRequiredResourceRequired:
+    def test_encode_rejects_missing_resource(self):
+        payment_required = PaymentRequired(
+            x402_version=2,
+            accepts=[make_payment_requirements()],
+        )
+        with pytest.raises(ValueError, match="resource.url"):
+            encode_payment_required_header(payment_required)

--- a/python/x402/tests/unit/http/test_x402_http_client.py
+++ b/python/x402/tests/unit/http/test_x402_http_client.py
@@ -25,6 +25,7 @@ from x402.schemas import (
     PaymentPayload,
     PaymentRequired,
     PaymentRequirements,
+    ResourceInfo,
     SettleResponse,
 )
 from x402.schemas.hooks import RecoveredResponseResult
@@ -138,7 +139,11 @@ class TestX402HTTPClientBase:
         """Test extracting PaymentRequired from V2 header."""
         base = x402HTTPClientBase()
         requirements = make_payment_requirements()
-        payment_required = PaymentRequired(x402_version=2, accepts=[requirements])
+        payment_required = PaymentRequired(
+            resource=ResourceInfo(url="https://example.com/resource"),
+            x402_version=2,
+            accepts=[requirements],
+        )
         encoded = encode_payment_required_header(payment_required)
 
         def get_header(name: str) -> str | None:
@@ -286,6 +291,7 @@ class TestX402HTTPClient:
         http_client = x402HTTPClient(mock_client)
 
         payment_required = PaymentRequired(
+            resource=ResourceInfo(url="https://example.com/resource"),
             x402_version=2,
             accepts=[make_payment_requirements()],
         )
@@ -304,6 +310,7 @@ class TestX402HTTPClient:
 
         # Create encoded payment required header
         payment_required = PaymentRequired(
+            resource=ResourceInfo(url="https://example.com/resource"),
             x402_version=2,
             accepts=[make_payment_requirements()],
         )
@@ -332,6 +339,7 @@ class TestX402HTTPClientSync:
         http_client = x402HTTPClientSync(mock_client)
 
         payment_required = PaymentRequired(
+            resource=ResourceInfo(url="https://example.com/resource"),
             x402_version=2,
             accepts=[make_payment_requirements()],
         )
@@ -347,6 +355,7 @@ class TestX402HTTPClientSync:
         http_client = x402HTTPClientSync(mock_client)
 
         payment_required = PaymentRequired(
+            resource=ResourceInfo(url="https://example.com/resource"),
             x402_version=2,
             accepts=[make_payment_requirements()],
         )
@@ -418,6 +427,7 @@ class TestProcessPaymentResult:
         http_client = x402HTTPClient(mock_client)
         payload = make_v2_payload()
         payment_required = PaymentRequired(
+            resource=ResourceInfo(url="https://example.com/resource"),
             x402_version=2,
             accepts=[make_payment_requirements()],
         )
@@ -502,6 +512,7 @@ class TestPaymentRoundTripper:
         tripper = PaymentRoundTripper(http_client)
 
         payment_required = PaymentRequired(
+            resource=ResourceInfo(url="https://example.com/resource"),
             x402_version=2,
             accepts=[make_payment_requirements()],
         )
@@ -534,6 +545,7 @@ class TestPaymentRoundTripper:
         tripper = PaymentRoundTripper(http_client)
 
         payment_required = PaymentRequired(
+            resource=ResourceInfo(url="https://example.com/resource"),
             x402_version=2,
             accepts=[make_payment_requirements()],
         )

--- a/python/x402/tests/unit/http/test_x402_http_client_hooks.py
+++ b/python/x402/tests/unit/http/test_x402_http_client_hooks.py
@@ -6,7 +6,7 @@ import pytest
 
 from x402 import x402Client, x402ClientSync
 from x402.http.x402_http_client import x402HTTPClient, x402HTTPClientSync
-from x402.schemas import PaymentRequired, PaymentRequirements
+from x402.schemas import PaymentRequired, PaymentRequirements, ResourceInfo
 from x402.schemas.hooks import PaymentRequiredContext, PaymentRequiredHeadersResult
 
 
@@ -22,7 +22,11 @@ def make_payment_requirements() -> PaymentRequirements:
 
 
 def make_payment_required() -> PaymentRequired:
-    return PaymentRequired(x402_version=2, accepts=[make_payment_requirements()])
+    return PaymentRequired(
+        resource=ResourceInfo(url="https://example.com/resource"),
+        x402_version=2,
+        accepts=[make_payment_requirements()],
+    )
 
 
 class TestOnPaymentRequiredRegistration:

--- a/python/x402/tests/unit/mechanisms/evm/batch_settlement/client/test_refund.py
+++ b/python/x402/tests/unit/mechanisms/evm/batch_settlement/client/test_refund.py
@@ -30,7 +30,7 @@ try:
     from x402.mechanisms.evm.batch_settlement.types import ChannelConfig
     from x402.mechanisms.evm.batch_settlement.utils import compute_channel_id
     from x402.mechanisms.evm.signers import EthAccountSigner
-    from x402.schemas import PaymentRequired, PaymentRequirements, SettleResponse
+    from x402.schemas import PaymentRequired, PaymentRequirements, ResourceInfo, SettleResponse
 except ImportError:
     pytest.skip("batch_settlement requires evm extras", allow_module_level=True)
 
@@ -67,7 +67,11 @@ def _requirements() -> PaymentRequirements:
 
 
 def _payment_required() -> PaymentRequired:
-    return PaymentRequired(x402_version=2, accepts=[_requirements()])
+    return PaymentRequired(
+        resource=ResourceInfo(url="https://example.com/resource"),
+        x402_version=2,
+        accepts=[_requirements()],
+    )
 
 
 def _channel_id_for_signer(signer: EthAccountSigner) -> str:
@@ -177,6 +181,7 @@ class TestRefundChannel:
     def test_probe_without_batch_settlement_raises(self):
         deps = _deps()
         pr = PaymentRequired(
+            resource=ResourceInfo(url="https://example.com/resource"),
             x402_version=2,
             accepts=[
                 PaymentRequirements(
@@ -210,7 +215,9 @@ class TestRefundChannel:
             max_timeout_seconds=60,
             extra={},
         )
-        pr = PaymentRequired(x402_version=2, accepts=[req])
+        pr = PaymentRequired(
+            resource=ResourceInfo(url="https://example.com/resource"), x402_version=2, accepts=[req]
+        )
         fetch = _FakeFetch(
             _RefundResponse(
                 status=402,


### PR DESCRIPTION
Fixes #3211.

v2 Go/Python servers could omit `resource`; TypeScript clients reject that. Marshal/encode now requires a non-empty `resource.url` (v1 unchanged).

Majority-AI assisted; human-reviewed. Commit unsigned (local gpg lock); can re-sign if needed.

Tested: `go test ./types ./http`; `pytest python/x402/tests/unit/http/test_utils.py`.