### PR TITLE
docs(specs): refresh the contributing guide and impl template

### DIFF
--- a/specs/CONTRIBUTING.md
+++ b/specs/CONTRIBUTING.md
@@ -16,14 +16,18 @@ The `specs/` directory contains the formal specifications for the x402 protocol.
 
 ```
 specs/
-├── x402-specification.md      # Core protocol specification
+├── x402-specification-v2.md   # Core protocol specification (v1 kept alongside)
 ├── schemes/
-│   └── exact/
-│       ├── scheme_exact.md    # Scheme overview
-│       ├── scheme_exact_evm.md
-│       ├── scheme_exact_svm.md
-│       └── scheme_exact_sui.md
-├── transports/
+│   ├── exact/
+│   │   ├── scheme_exact.md    # Scheme overview
+│   │   ├── scheme_exact_evm.md
+│   │   ├── scheme_exact_svm.md
+│   │   └── …                  # one file per network
+│   ├── upto/
+│   ├── auth-capture/
+│   └── batch-settlement/
+├── extensions/                # optional functionality beyond core payment mechanics
+├── transports-v2/             # (transports-v1/ kept alongside)
 │   ├── http.md
 │   ├── mcp.md
 │   └── a2a.md
@@ -43,6 +47,9 @@ Schemes define how funds are transferred from client to server. Each scheme has:
 
 Current schemes:
 - `exact` - Transfers a specific amount for resource access
+- `upto` - Authorizes a maximum and settles the amount actually used
+- `auth-capture` - Holds funds, then captures, voids or refunds
+- `batch-settlement` - Grants access immediately and settles later, in batches
 
 ### Transports
 
@@ -54,7 +61,7 @@ Transports define how x402 messages are transmitted over different protocols:
 
 ### Core Specification
 
-`x402-specification.md` defines the protocol fundamentals:
+`x402-specification-v2.md` defines the protocol fundamentals:
 - Core types (`PaymentRequirements`, `PaymentPayload`, `SettlementResponse`)
 - Facilitator interface
 - Security considerations
@@ -83,7 +90,7 @@ Use the appropriate template:
 
 1. Create the spec file in the appropriate directory
 2. For schemes: `specs/schemes/<scheme_name>/scheme_<name>.md`
-3. For transports: `specs/transports/<name>.md`
+3. For transports: `specs/transports-v2/<name>.md`
 4. Reference the core spec for shared types
 
 ## Templates
@@ -176,7 +183,7 @@ Every section should include concrete examples:
 
 Don't redefine types from the core spec. Reference them:
 
-> See `PaymentRequirements` in [x402-specification.md](x402-specification.md#5-types)
+> See `PaymentRequirements` in [x402-specification-v2.md](x402-specification-v2.md#5-types)
 
 ### Document Security Considerations
 

--- a/specs/scheme_impl_template.md
+++ b/specs/scheme_impl_template.md
@@ -4,9 +4,14 @@
 
 Summarize the purpose and behavior of your scheme here. Include example use cases.
 
-## `X-Payment` header payload
+## Payment payload
 
-Document how to construct the `X-Payment` header payload for your scheme, based on `paymentRequirements` returned in a `402` response.
+Document how to construct the `PaymentPayload` for your scheme, based on the
+`PaymentRequirements` returned in the `402` response.
+
+Over the HTTP transport the client sends it in the `PAYMENT-SIGNATURE` header and the
+server advertises requirements in `PAYMENT-REQUIRED`; see
+[transports-v2/http.md](transports-v2/http.md).
 
 ## Verification
 


### PR DESCRIPTION
## Description

Two documents in `specs/` have drifted from the repo they describe, both on the path a new contributor follows.

**`specs/scheme_impl_template.md`** still asks for an `` `X-Payment` header payload ``. That is v1. A contributor who follows the official template today documents a header the v2 transport does not use — the real names are `PAYMENT-REQUIRED` and `PAYMENT-SIGNATURE` (`specs/transports-v2/http.md`). Replaced with a transport-neutral "Payment payload" section that points at the HTTP transport for header names.

**`specs/CONTRIBUTING.md`**:
- the directory diagram names `x402-specification.md` and `transports/`; the real paths are `x402-specification-v1.md` / `-v2.md` and `transports-v1/` / `transports-v2/`
- `extensions/` is missing from the diagram
- "Current schemes:" lists only `exact`, but `upto`, `auth-capture` and `batch-settlement` have since merged
- two inline references to `x402-specification.md` and one to `specs/transports/<name>.md` follow the same drift

Docs only. No normative change, no behaviour change, nothing under `specs/schemes/` touched.

## Tests

None applicable — documentation. I verified every path and scheme name against the tree at `main` rather than from memory, and the header names against `specs/transports-v2/http.md`.

## Checklist

- [x] Formatted and linted
- [x] All tests pass (n/a — docs only)
- [x] Commits are signed
- [ ] Changelog fragment — docs-only, skipped per the template

---

Found these while writing a scheme spec against the template, so the fix is first-hand rather than a drive-by. For context on what led me here: #3182 — not something I'm asking about in this PR.

*Disclosure per CONTRIBUTING.md: drafted with AI assistance; every path, header name and scheme name above was checked against the tree before submitting.*
