### PR TITLE
docs: scope offer-receipt evidence claims to signed payload

### DIFF
--- a/docs/extensions/offer-receipt.mdx
+++ b/docs/extensions/offer-receipt.mdx
@@ -3,14 +3,14 @@ title: "Signed Offers & Receipts"
 description: "Sign offers on 402 responses and receipts on 200 responses, producing cryptographic proof-of-interaction artifacts that clients can use for reputation, auditing, or dispute resolution."
 ---
 
-The Offer & Receipt extension adds cryptographic proof-of-interaction to x402 payment flows. When enabled, your server automatically signs an **offer** on every `402` response (committing to payment terms) and a **receipt** on every `200` response (confirming service delivery). No changes to your business logic.
+The Offer & Receipt extension adds cryptographic proof-of-interaction to x402 payment flows. When enabled, your server automatically signs an **offer** on every `402` response (committing to payment terms) and a **receipt** on every `200` response (attesting to service delivery). No changes to your business logic.
 
 ## Why Enable Offer & Receipt Signing?
 
 Signed offers and receipts are portable, verifiable artifacts that any third party can check. They enable:
 
 * **Reputation systems** — Clients can attach receipts to onchain attestations as proof they actually paid for and received a service. This is the "Verified Purchase" equivalent for the open web.
-* **Dispute resolution** — Offers prove the server committed to specific terms; receipts prove delivery. If either party disputes a transaction, the signed artifacts provide evidence.
+* **Dispute resolution** — Offers prove the server committed to specific terms; receipts prove the server attested to delivery. If either party disputes a transaction, the signed artifacts evidence what was offered and that the interaction happened. The receipt payload carries no amount or usage fields, so for usage-priced schemes (e.g., `upto`) the artifacts do not by themselves evidence the amount settled.
 * **Auditing** — Receipts create a verifiable trail of service delivery without exposing transaction details (the transaction hash is optional).
 * **Client confidence** — Services with verifiable proof-of-interaction build stronger trust signals, making new clients more likely to use the service.
 
@@ -411,13 +411,15 @@ const verified = verifyReceiptMatchesOffer(
 - `payer` matches one of your wallet addresses
 - `issuedAt` is recent (within 1 hour by default)
 
+It performs no amount comparison; the receipt payload carries no amount field (spec §5.2).
+
 ### What Can Clients Do with These Artifacts?
 
 Signed offers and receipts are portable, verifiable artifacts. Clients can:
 
 - **Attach them to reputation attestations** as proof-of-interaction (e.g., "Verified Purchase" reviews)
 - **Store them for auditing** — receipts create a verifiable trail of service delivery
-- **Use them in dispute resolution** — offers prove the server committed to terms; receipts prove delivery
+- **Use them in dispute resolution** — offers prove the server committed to terms; receipts prove the server attested to delivery
 - **Share them with aggregators** — trust scoring engines can verify the signatures independently
 - **Submit them to trust providers** — services like [OMATrust](https://docs.omatrust.org/integrations/x402/overview) can embed receipts into user reviews, and [PEAC Protocol](https://x402.peacprotocol.org) can record them as payment evidence attestation chains
 

--- a/specs/extensions/extension-offer-and-receipt.md
+++ b/specs/extensions/extension-offer-and-receipt.md
@@ -260,7 +260,7 @@ This allows servers to limit how long they commit to specific pricing or terms. 
 
 **5. Receipt**
 
-A receipt is a signed statement returned by the resource server **only on success**, confirming that payment was received and service was delivered.
+A receipt is a signed statement returned by the resource server **only on success**, in which the server attests that payment was received and service was delivered.
 
 **5.1 Placement**
 
@@ -855,11 +855,11 @@ This extension defines signed offers and signed receipts that can be carried alo
 
 - **Attestation-backed discovery and trust for paid endpoints**: Signed offers and receipts can be embedded as evidence in attestations (e.g., user reviews). Those attestations can support discovery, filtering, and reputation scoring for paid API/service endpoints — an area that typically lacks the trust provided by user reviews in app stores and ecommerce sites.
 
-- **Auditability and dispute/feedback evidence**: Signed artifacts provide verifiable evidence of what terms were presented and, when applicable, that service was delivered. This supports auditing, customer support, and dispute workflows, including scenarios involving automated purchasers (agents) and enterprise procurement.
+- **Auditability and dispute/feedback evidence**: Signed artifacts provide verifiable evidence of what terms were presented and, when applicable, that the server attested to delivery. This supports auditing, customer support, and dispute workflows, including scenarios involving automated purchasers (agents) and enterprise procurement.
 
-- **Agent-to-agent commerce**: Autonomous agents making purchasing decisions need machine-verifiable proof of terms and delivery. Signed offers let an agent's principal (human or system) audit what deals the agent accepted; receipts prove the agent received the promised service.
+- **Agent-to-agent commerce**: Autonomous agents making purchasing decisions need machine-verifiable proof of terms and delivery. Signed offers let an agent's principal (human or system) audit what deals the agent accepted; receipts prove the server attested that the agent received the promised service.
 
-- **Why offers matter even without receipts**: A signed offer can be used as evidence even when no receipt is available (e.g., the user did not complete payment, the service did not return a receipt, or the user wants to provide feedback about pricing/terms). Offers prove the server's stated terms at a point in time; receipts prove successful service delivery.
+- **Why offers matter even without receipts**: A signed offer can be used as evidence even when no receipt is available (e.g., the user did not complete payment, the service did not return a receipt, or the user wants to provide feedback about pricing/terms). Offers prove the server's stated terms at a point in time; receipts prove the server attested, at a point in time, that service was delivered.
 
 **9. Integration with Proof Systems**
 
@@ -871,6 +871,7 @@ The `offer` and `receipt` objects defined in this extension are designed to be u
 - Servers MUST NOT include the `signature` field in the payload being signed to avoid circularity.
 - Servers should consider replay implications of long-lived signed offers; including `validUntil` can reduce risk.
 - Receipts and offers are transferable artifacts; possession of a valid server signature is sufficient for verification. Transport-layer security (HTTPS) is essential.
+- **Evidence scope**: A receipt binds `resourceUrl`, `payer`, and `issuedAt` under the server's signature; the payload carries no amount and no usage fields (see §5.2). A valid receipt therefore proves the server attested to a successful interaction. It does not prove what amount was settled or what usage occurred. For schemes where the settled amount is determined by the server after authorization (e.g., the `upto` scheme; see its Server Trust consideration), offers and receipts together evidence the terms offered and that an interaction occurred; they do not by themselves evidence the amount ultimately charged.
 
 **11. Privacy Considerations**
 
@@ -884,6 +885,7 @@ The `offer` and `receipt` objects defined in this extension are designed to be u
 
 | Version | Date       | Changes                                                        | Author     |
 | ------- | ---------- | -------------------------------------------------------------- | ---------- |
+| 0.7     | 2026-08-23 | Scope evidence claims to the signed payload (§5, §8); add Evidence scope to §10. | David Ngene |
 | 0.6     | 2026-02-04 | Make EIP-712 chain-agnostic: chainId=1, payTo type=string.     | Alfred Tom |
 | 0.5     | 2026-01-29 | First approved release.                                        | Alfred Tom |
 | 0.4     | 2026-01-26 | Add acceptIndex as unsigned envelope field.                    | Alfred Tom |


### PR DESCRIPTION
The extension docs say receipts "prove delivery" (§8 twice, docs page twice). The receipt payload (§5.2) is five required fields plus an optional transaction hash, server-signed. What a verifier can establish is that the server attested to delivery at a time. The spec already draws this distinction for keys in §4.5.1 ("A valid signature proves that a specific key signed the artifact. It does not prove that the key was authorized"); this PR applies the same discipline to receipt content.

Why it matters: offer-receipt is documented as the dispute-resolution answer while `upto`'s Server Trust consideration concedes servers could charge up to `amount` regardless of usage, and the receipt carries no amount or usage field (#3001). A reader today can reasonably conclude the evidence question is already solved. These edits scope the claims to what the payload supports. No schema, wire-format, or verification changes, and deliberately no new fields; whether the receipt should carry `settledAmount`/`usage` is the #3001/#3220 discussion, not this PR.

Disclosure: I build recordation infrastructure for usage-based billing (pacspace.io). Prepared with AI assistance, reviewed and verified by me.
