### PR TITLE
docs: add sui-x402 to third-party SDKs

### DIFF
--- a/docs/dev-tools/third-party-sdks.md
+++ b/docs/dev-tools/third-party-sdks.md
@@ -8,3 +8,4 @@ description: "Community-maintained x402 SDKs."
 | [Mogami](https://mogami.gitbook.io/mogami) | Java x402 stack | Java | [GitHub](https://github.com/mogami-tech/) |
 | [x402-rs](https://github.com/x402-rs/x402-rs/blob/main/README.md) | Rust toolkit for x402 | Rust | [GitHub](https://github.com/x402-rs/x402-rs) |
 | [x402-rails](https://github.com/quiknode-labs/x402-rails/blob/main/README.md) | x402 for Rails applications by Quicknode | Ruby | [GitHub](https://github.com/quiknode-labs/x402-rails) |
+| [sui-x402](https://github.com/yannickrocks/sui-x402/blob/master/README.md) | TypeScript SDK and middleware (Hono, Express, Next.js) for x402 on Sui | TypeScript | [GitHub](https://github.com/yannickrocks/sui-x402) |


### PR DESCRIPTION
## Description

Adds sui-x402 to the third-party SDKs table.

Sui has an exact scheme in this repo (specs/schemes/exact/scheme_exact_sui.md) and a live open-source reference facilitator (DrVelvetFog/sui-x402-facilitator), but no standards-track client SDK or server middleware spoke the v2 wire format on Sui until now. sui-x402 is five TypeScript packages, v0.1.0 on npm: protocol schemas and a framework-agnostic seller core (core), a payer with coin discovery, tx construction and a fetch that handles the 402 itself (payer-sui), and Hono, Express and Next.js middleware certified by one shared conformance suite. It settles through the existing reference facilitator, unmodified and self-hosted, and never takes custody.

It is testnet only for now, Apache-2.0, 349 tests, and more than ten payments have settled end to end on chain (digests in the repo's docs/status.md).

## Tests

Docs-only change: one row added to the markdown table in `docs/dev-tools/third-party-sdks.md`. No code touched; verified the table renders correctly and all links resolve. The SDK itself is tested in its own repo (349 tests, CI settles a live testnet payment on every push).

## Checklist

- [x] I have formatted and linted my code (docs-only, table row matches existing formatting)
- [x] All new and existing tests pass (no code changed)
- [x] My commits are signed (required for merge)
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

## AI disclosure

Drafted with AI assistance (Claude Code); reviewed and verified by the maintainer. The linked SDK, its test suite, and the on-chain settlement digests it cites are human-reviewed and independently verifiable.