### PR TITLE
fix(mcp-ts): handle facilitator failure before resource delivery

### DIFF
--- a/typescript/.changeset/mcp-withhold-content-on-settle-failure.md
+++ b/typescript/.changeset/mcp-withhold-content-on-settle-failure.md
@@ -1,0 +1,5 @@
+---
+'@x402/mcp': minor
+---
+
+Withhold MCP tool content when after-handler settlement returns `{ success: false }`.

--- a/typescript/packages/mcp/src/server/paymentWrapper.ts
+++ b/typescript/packages/mcp/src/server/paymentWrapper.ts
@@ -590,6 +590,16 @@ async function settlePaymentResult(
       "after-handler",
     );
 
+    if (!settleResult.success) {
+      return createSettlementFailedResult(
+        resourceServer,
+        toolName,
+        config,
+        settleResult.errorReason || settleResult.errorMessage || "Settlement failed",
+        transportContext,
+      );
+    }
+
     if (config.hooks?.onAfterSettlement) {
       const settlementContext: SettlementContext = {
         ...hookContext,

--- a/typescript/packages/mcp/test/unit/server.test.ts
+++ b/typescript/packages/mcp/test/unit/server.test.ts
@@ -1203,6 +1203,50 @@ describe("createPaymentWrapper", () => {
       expect(result.isError).toBe(true); // But error returned due to settlement failure
       expect(result.structuredContent).toBeDefined();
     });
+
+    it("should withhold tool output when settlement returns success false", async () => {
+      mockResourceServer.settlePayment.mockResolvedValueOnce({
+        success: false,
+        errorReason: "AuthorizationAlreadyUsed",
+        transaction: "",
+        network: "eip155:84532",
+      });
+
+      const settlementHook = vi.fn();
+      const paid = createPaymentWrapper(
+        mockResourceServer as unknown as Parameters<typeof createPaymentWrapper>[0],
+        {
+          accepts: [mockPaymentRequirements],
+          hooks: {
+            onAfterSettlement: settlementHook,
+          },
+        },
+      );
+
+      const handler = vi.fn().mockResolvedValue({
+        content: [{ type: "text", text: "should-not-be-returned" }],
+      });
+
+      const wrappedHandler = paid(handler);
+      const result = await wrappedHandler(
+        { test: "arg" },
+        { _meta: { "x402/payment": mockPaymentPayload } },
+      );
+
+      expect(handler).toHaveBeenCalled();
+      expect(result.isError).toBe(true);
+      expect(JSON.stringify(result.content)).not.toContain("should-not-be-returned");
+      expect(JSON.stringify(result.structuredContent)).not.toContain("should-not-be-returned");
+      expect(mockResourceServer.createPaymentRequiredResponse).toHaveBeenCalledWith(
+        [mockPaymentRequirements],
+        expect.any(Object),
+        "Payment settlement failed: AuthorizationAlreadyUsed",
+        undefined,
+        expect.any(Object),
+        undefined,
+      );
+      expect(settlementHook).not.toHaveBeenCalled();
+    });
   });
 
   describe("unexpected errors", () => {


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

Withhold MCP tool output when after-handler settlement returns { success: false }. Previously only thrown settlement errors were handled

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 