### PR TITLE
docs(ts): align contributor prerequisites with workspace

### DIFF
--- a/typescript/CONTRIBUTING.md
+++ b/typescript/CONTRIBUTING.md
@@ -52,8 +52,8 @@ The core package provides transport-agnostic primitives. Mechanism packages (`ev
 
 ### Prerequisites
 
-- Node.js >= 18.0.0
-- pnpm >= 10.7.0
+- Node.js >= 22.0.0
+- pnpm >= 11.1.1
 
 ### Installation
 


### PR DESCRIPTION
## Description

Updates the TypeScript contributing guide to match the workspace engine requirements declared in `typescript/package.json`.

The requirements were raised in #2287, but `typescript/CONTRIBUTING.md:55-56` retained the previous Node.js and pnpm versions. This aligns the guide with the workspace source of truth.

Closes #3253.

## Tests

None applicable — documentation only. Ran `git diff --check` and verified both versions against `typescript/package.json`.

## Checklist

- [x] I have formatted and linted my code (documentation-only diff checked)
- [x] All new and existing tests pass (n/a — docs only)
- [x] My commits are signed
- [x] Changelog fragment not required — docs-only change

---

Disclosure: drafted with AI assistance; the version requirements were verified against `typescript/package.json` and PR #2287.
