### PR TITLE
fix(python): resolve Context across mcp 1.x and 2.x

### DIFF
--- a/python/x402/mcp/server.py
+++ b/python/x402/mcp/server.py
@@ -88,8 +88,12 @@ def create_payment_wrapper(
     Returns:
         A decorator to apply to a FastMCP tool handler function.
     """
-    # Lazy import mcp types so the module can be imported without mcp installed
-    from mcp.server.fastmcp import Context
+    # Lazy import mcp types so the module can be imported without mcp installed.
+    # mcp 2.x moved FastMCP to mcp.server.mcpserver and re-exports Context from there.
+    try:
+        from mcp.server.fastmcp import Context  # mcp 1.x
+    except ImportError:
+        from mcp.server.mcpserver import Context  # mcp >= 2.0
 
     from mcp.types import CallToolResult, TextContent
 


### PR DESCRIPTION
Fixes #3261.

`x402[mcp]` declares `mcp>=1.0.0` with no upper bound, so a clean install resolves `mcp` 2.x. `create_payment_wrapper` then does a runtime import of `mcp.server.fastmcp`, which 2.x removed, and every server-side paid tool fails at declaration time.

`mcp` 2.x moved `FastMCP` to `mcp.server.mcpserver.MCPServer` and re-exports `Context` from the same module, so resolving across both layouts is a four-line change at the one runtime import site. The only other reference to `mcp.server.fastmcp` in this package is inside the module docstring example, which never executes.

I chose this over pinning `mcp<2` in the extra because pinning would hold users on the 1.x layout for a break that only affects one import.

## Verified

On a clean venv with `mcp` 2.1.0 and `x402` 2.20.0, with this patch applied:

- `create_payment_wrapper(...)` builds without error
- a wrapped tool registers on `MCPServer` and appears in `list_tools()`
- the synthetic `ctx` parameter is injected and correctly absent from the public input schema
- calling the tool with no payment returns the x402 challenge, `{"x402Version": 2, "accepts": [...]}`, rather than executing the handler

Before the patch the same script fails at `ModuleNotFoundError: No module named 'mcp.server.fastmcp'`.

I did not run the package's own MCP tests against 2.x; they are written for the 1.x layout and would need separate work.

## Note on the failure mode

The import is lazy, so nothing breaks until the first paid tool is declared. If that happens during server construction, the process dies before binding, and the visible symptom in a client is `Connection closed` with no cause, while free tools on the same server keep working. That reads as a payment configuration problem rather than an import one, which is what cost me the time.

## AI disclosure

Diagnosis and this patch were produced with an AI coding agent. I reviewed the change and ran the verification above myself before opening this PR.
