### PR TITLE
fix(extensions): validate Bazaar schema formats

### DIFF
--- a/typescript/.changeset/validate-bazaar-schema-formats.md
+++ b/typescript/.changeset/validate-bazaar-schema-formats.md
@@ -1,0 +1,5 @@
+---
+"@x402/extensions": patch
+---
+
+Validate standard JSON Schema formats in Bazaar discovery declarations.

--- a/typescript/packages/extensions/package.json
+++ b/typescript/packages/extensions/package.json
@@ -47,6 +47,7 @@
     "@scure/base": "^1.2.6",
     "@x402/core": "workspace:~",
     "ajv": "^8.17.1",
+    "ajv-formats": "^3.0.1",
     "jose": "^5.9.6",
     "@signinwithethereum/siwe": "^4.1.0",
     "tweetnacl": "^1.0.3",

--- a/typescript/packages/extensions/src/bazaar/facilitator.ts
+++ b/typescript/packages/extensions/src/bazaar/facilitator.ts
@@ -9,6 +9,7 @@
 
 import { domainToASCII } from "node:url";
 import Ajv from "ajv/dist/2020.js";
+import addFormats from "ajv-formats";
 import type {
   PaymentPayload,
   PaymentRequirements,
@@ -354,6 +355,7 @@ export function validateDiscoveryExtension(extension: DiscoveryExtension): Valid
     }
 
     const ajv = new Ajv({ strict: false, allErrors: true });
+    addFormats(ajv, ["uri", "date-time"]);
     const validate = ajv.compile(extension.schema);
 
     // The schema describes the structure of info directly

--- a/typescript/packages/extensions/test/bazaar.test.ts
+++ b/typescript/packages/extensions/test/bazaar.test.ts
@@ -260,6 +260,111 @@ describe("Bazaar Discovery Extension", () => {
       expect(result.errors).toBeDefined();
       expect(result.errors!.length).toBeGreaterThan(0);
     });
+
+    it("should reject an invalid URI format", () => {
+      const declared = declareDiscoveryExtension({
+        method: "GET",
+        input: { source: "not a uri" },
+        inputSchema: {
+          properties: {
+            source: { type: "string", format: "uri" },
+          },
+          required: ["source"],
+        },
+        output: {
+          example: { updatedAt: "2026-08-12T22:00:00Z" },
+          schema: {
+            properties: {
+              updatedAt: { type: "string", format: "date-time" },
+            },
+            required: ["updatedAt"],
+          },
+        },
+      });
+
+      const result = validateDiscoveryExtension(declared.bazaar);
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('/input/queryParams/source: must match format "uri"');
+    });
+
+    it("should reject an invalid date-time format", () => {
+      const declared = declareDiscoveryExtension({
+        method: "GET",
+        input: { source: "https://example.com/data" },
+        inputSchema: {
+          properties: {
+            source: { type: "string", format: "uri" },
+          },
+          required: ["source"],
+        },
+        output: {
+          example: { updatedAt: "not a date" },
+          schema: {
+            properties: {
+              updatedAt: { type: "string", format: "date-time" },
+            },
+            required: ["updatedAt"],
+          },
+        },
+      });
+
+      const result = validateDiscoveryExtension(declared.bazaar);
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('/output/example/updatedAt: must match format "date-time"');
+    });
+
+    it("should accept valid URI and date-time formats", () => {
+      const declared = declareDiscoveryExtension({
+        method: "GET",
+        input: { source: "https://example.com/data" },
+        inputSchema: {
+          properties: {
+            source: { type: "string", format: "uri" },
+          },
+          required: ["source"],
+        },
+        output: {
+          example: { updatedAt: "2026-08-12T22:00:00Z" },
+          schema: {
+            properties: {
+              updatedAt: { type: "string", format: "date-time" },
+            },
+            required: ["updatedAt"],
+          },
+        },
+      });
+
+      expect(validateDiscoveryExtension(declared.bazaar)).toEqual({ valid: true });
+    });
+
+    it("should not activate ajv-formats comparison keywords", () => {
+      const declared = declareDiscoveryExtension({
+        method: "GET",
+        input: { source: "https://example.com/data" },
+        inputSchema: {
+          properties: {
+            source: { type: "string", format: "uri" },
+          },
+          required: ["source"],
+        },
+        output: {
+          example: { updatedAt: "2026-08-12T22:00:00Z" },
+          schema: {
+            properties: {
+              updatedAt: {
+                type: "string",
+                format: "date-time",
+                formatMinimum: "2027-01-01T00:00:00Z",
+                formatMaximum: "2025-01-01T00:00:00Z",
+              },
+            },
+            required: ["updatedAt"],
+          },
+        },
+      });
+
+      expect(validateDiscoveryExtension(declared.bazaar)).toEqual({ valid: true });
+    });
   });
 
   describe("extractDiscoveryInfoFromExtension", () => {

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       ajv:
         specifier: ^8.17.1
         version: 8.17.1
+      ajv-formats:
+        specifier: ^3.0.1
+        version: 3.0.1(ajv@8.17.1)
       jose:
         specifier: ^5.9.6
         version: 5.10.0


### PR DESCRIPTION
## Summary

- register standard JSON Schema format validators in Bazaar validation
- reject invalid `uri` and `date-time` values declared by discovery schemas
- add focused valid and invalid regression cases

AJV otherwise ignores these standard formats when `strict: false`, allowing malformed discovery metadata to pass facilitator validation.

## Verification

- focused URI and date-time assertions added
- dependency and lockfile use `ajv-formats@3.0.1` with AJV 8
- full isolated TypeScript gates and independent review are in progress; this PR remains draft until they pass

Implementation and tests were AI-assisted, then reviewed against the exact diff and upstream contribution rules.
