### PR TITLE
docs: add vet402 to Third-Party Extensions

### DIFF
--- a/docs/dev-tools/third-party-extensions.md
+++ b/docs/dev-tools/third-party-extensions.md
@@ -8,5 +8,6 @@ description: "Packages built by ecosystem partners that extend x402 beyond the c
 | [World AgentKit](https://docs.world.org/agents/agent-kit/integrate) | Verify human-backed agents | TypeScript | [GitHub](https://github.com/worldcoin/agentkit) · [npm](https://www.npmjs.com/package/@worldcoin/agentkit) |
 | [OMATrust](https://www.omatrust.org/x402) | Key authorizations for Signed Offers and Receipts | TypeScript | [GitHub](https://github.com/oma3dao/omatrust-sdk) · [npm](https://www.npmjs.com/package/@oma3/omatrust) |
 | [PEAC Protocol](https://x402.peacprotocol.org) | Verifiable receipts for x402 payments | TypeScript | [GitHub](https://github.com/peacprotocol/peac) · [npm](https://www.npmjs.com/package/@peac/adapter-x402) |
+| [vet402](https://vet402.com) | Payee verification before paying — trust scores backed by real, on-chain-verified purchases | TypeScript, Python | [GitHub](https://github.com/kzmttkc/vet402) · [npm](https://www.npmjs.com/package/@vouchscore/sdk) |
 | [x402r](https://x402r.org) | Non-custodial refund and arbitration protocol | Typescript | [GitHub](https://github.com/BackTrackCo/x402r-sdk) · [npm](https://www.npmjs.com/package/@x402r/sdk ) |
 | [zauth](https://zauthx402.com) | Monitoring, verification, and refund SDK | TypeScript | [GitHub](https://github.com/zauthofficial/zauthSDK) · [npm](https://www.npmjs.com/package/@zauthx402/sdk) |


### PR DESCRIPTION
Adds vet402 to Third-Party Extensions.

vet402 is an independent verification layer for the x402 economy: it makes real purchases against listed endpoints (daily, under a hard budget), re-reads each claimed settlement on-chain (recipient, amount, token, chain, confirmations), and publishes every outcome — failures included — with tx hashes. Agents check a payee before paying via SDK / Express middleware / MCP server; the default policy is fail-closed.

- Site: https://vet402.com — live ledger, per-endpoint receipt pages, methodology
- Data: free JSON/CSV (`/api/v1/observatory/state`, `/export.csv`), daily hash-chained roots (`/anchors`)
- Packages: `@vouchscore/sdk`, `@vouchscore/middleware`, `@vouchscore/mcp-server` (npm), Python SDK in-repo
- MIT licensed

Placed between PEAC Protocol and x402r (alphabetical). One row, no other changes.

Note: an earlier version of this listing was opened against the coinbase/x402 fork as PR coinbase/x402#290 before we realized this repo is the canonical home — happy to close that one.
