### PR TITLE
docs(facilitators): add AlgoVoi chain-agnostic multi-chain facilitator

### DIFF
--- a/docs/dev-tools/facilitators.md
+++ b/docs/dev-tools/facilitators.md
@@ -19,7 +19,7 @@ If you are evaluating a mainnet EVM route, decide on your production facilitator
 
 | Name | Description |
 | ---- | ----------- | 
-| [AlgoVoi](https://algovoi.co.uk/payment-gateway.html) | Chain-agnostic x402 facilitator across 7 mainnet chains (Algorand, Base, Solana, Stellar, Hedera, Voi, Tempo); hosted or self-hosted, with post-quantum signed, offline-verifiable settlement receipts. Tenant-free pay-per-call rail at pay.algovoi.co.uk (no account, no API key). |
+| [AlgoVoi](https://pay.algovoi.co.uk) | Chain-agnostic x402 facilitator across 7 mainnet chains (Algorand, Base, Solana, Stellar, Hedera, Voi, Tempo), hosted or self-hosted. Tenant-free pay-per-call rail at pay.algovoi.co.uk (no account, no API key) with signed, offline-verifiable Ed25519 receipts; post-quantum receipts where the self-hosted estate is deployed. |
 | [Built on Stellar](https://developers.stellar.org/docs/build/apps/x402/built-on-stellar) | Free, public x402 facilitator for Stellar |
 | [CDP Facilitator](https://docs.cdp.coinbase.com/x402/docs/quickstart-sellers) | Coinbase-hosted facilitator with KYT/OFAC checks on every transaction |
 | [Celo Facilitator](https://docs.celo.org/build-on-celo/build-with-ai/x402) | Gasless x402 facilitator for Celo Mainnet, accepting USDC and USD₮ via EIP-3009 |

--- a/docs/dev-tools/facilitators.md
+++ b/docs/dev-tools/facilitators.md
@@ -19,6 +19,7 @@ If you are evaluating a mainnet EVM route, decide on your production facilitator
 
 | Name | Description |
 | ---- | ----------- | 
+| [AlgoVoi](https://algovoi.co.uk/payment-gateway.html) | Chain-agnostic x402 facilitator across 7 mainnet chains (Algorand, Base, Solana, Stellar, Hedera, Voi, Tempo); hosted or self-hosted, with post-quantum signed, offline-verifiable settlement receipts. Tenant-free pay-per-call rail at pay.algovoi.co.uk (no account, no API key). |
 | [Built on Stellar](https://developers.stellar.org/docs/build/apps/x402/built-on-stellar) | Free, public x402 facilitator for Stellar |
 | [CDP Facilitator](https://docs.cdp.coinbase.com/x402/docs/quickstart-sellers) | Coinbase-hosted facilitator with KYT/OFAC checks on every transaction |
 | [Celo Facilitator](https://docs.celo.org/build-on-celo/build-with-ai/x402) | Gasless x402 facilitator for Celo Mainnet, accepting USDC and USD₮ via EIP-3009 |


### PR DESCRIPTION
Adds AlgoVoi to the facilitators list.

AlgoVoi runs a chain-agnostic x402 facilitator across seven mainnet chains (Algorand, Base, Solana, Stellar, Hedera, Voi, Tempo), available hosted or self-hosted. A tenant-free pay-per-call rail is live at https://pay.algovoi.co.uk (no account, no API key), returning signed, offline-verifiable Ed25519 settlement receipts; post-quantum receipts apply where the self-hosted estate is deployed.

Single-row docs addition, alphabetically placed. DCO signed.
