### PR TITLE
fix(ts/go): refactor svm upto rpc config

### DIFF
--- a/e2e/facilitators/go/main.go
+++ b/e2e/facilitators/go/main.go
@@ -795,6 +795,72 @@ func (s *realFacilitatorSvmSigner) ConfirmTransaction(ctx context.Context, signa
 	return fmt.Errorf("transaction confirmation timed out after %d attempts", svmmech.MaxConfirmAttempts)
 }
 
+func (s *realFacilitatorSvmSigner) GetAccountInfo(
+	ctx context.Context,
+	account solana.PublicKey,
+	network string,
+	opts *rpc.GetAccountInfoOpts,
+) (*rpc.GetAccountInfoResult, error) {
+	rpcClient, err := s.getRPC(ctx, network)
+	if err != nil {
+		return nil, err
+	}
+	return rpcClient.GetAccountInfoWithOpts(ctx, account, opts)
+}
+
+func (s *realFacilitatorSvmSigner) GetLatestBlockhash(ctx context.Context, network string) (solana.Hash, uint64, error) {
+	rpcClient, err := s.getRPC(ctx, network)
+	if err != nil {
+		return solana.Hash{}, 0, err
+	}
+	latest, err := rpcClient.GetLatestBlockhash(ctx, rpc.CommitmentFinalized)
+	if err != nil {
+		return solana.Hash{}, 0, err
+	}
+	return latest.Value.Blockhash, latest.Value.LastValidBlockHeight, nil
+}
+
+func (s *realFacilitatorSvmSigner) GetSlot(ctx context.Context, network string, commitment rpc.CommitmentType) (uint64, error) {
+	rpcClient, err := s.getRPC(ctx, network)
+	if err != nil {
+		return 0, err
+	}
+	return rpcClient.GetSlot(ctx, commitment)
+}
+
+func (s *realFacilitatorSvmSigner) SimulateTransactionWithOpts(
+	ctx context.Context,
+	tx *solana.Transaction,
+	network string,
+	opts *rpc.SimulateTransactionOpts,
+) error {
+	rpcClient, err := s.getRPC(ctx, network)
+	if err != nil {
+		return err
+	}
+	result, err := rpcClient.SimulateTransactionWithOpts(ctx, tx, opts)
+	if err != nil {
+		return fmt.Errorf("simulation failed: %w", err)
+	}
+	if result != nil && result.Value != nil && result.Value.Err != nil {
+		return fmt.Errorf("simulation failed: transaction would fail on-chain")
+	}
+	return nil
+}
+
+func (s *realFacilitatorSvmSigner) GetProgramAccounts(
+	ctx context.Context,
+	network string,
+	programID solana.PublicKey,
+	opts *rpc.GetProgramAccountsOpts,
+) (rpc.GetProgramAccountsResult, error) {
+	rpcClient, err := s.getRPC(ctx, network)
+	if err != nil {
+		return nil, err
+	}
+	return rpcClient.GetProgramAccountsWithOpts(ctx, programID, opts)
+}
+
 func (s *realFacilitatorSvmSigner) SimulateTransactionWithInnerInstructions(ctx context.Context, tx *solana.Transaction, network string) ([]rpc.InnerInstruction, error) {
 	rpcClient, err := s.getRPC(ctx, network)
 	if err != nil {
@@ -1030,7 +1096,7 @@ func main() {
 		)
 		facilitator.Register(
 			[]x402.Network{x402.Network(svmNetwork)},
-			uptosvm.NewUptoSvmScheme(svmSigner, &uptosvm.Config{RPCURL: svmRpcUrl}),
+			uptosvm.NewUptoSvmScheme(svmSigner, nil),
 		)
 		facilitator.RegisterV1(
 			[]x402.Network{x402.Network(getV1SvmNetwork(svmNetwork))},

--- a/e2e/facilitators/typescript/index.ts
+++ b/e2e/facilitators/typescript/index.ts
@@ -563,7 +563,7 @@ if (svmSigner) {
     )
     .register(
       SVM_NETWORK as Network,
-      new UptoSvmScheme(svmSigner, { rpcUrl: SVM_RPC_URL }),
+      new UptoSvmScheme(svmSigner),
     )
     .registerV1(SVM_V1_NETWORKS as Network[], new ExactSvmSchemeV1(svmSigner));
 }

--- a/examples/go/facilitator/upto/main.go
+++ b/examples/go/facilitator/upto/main.go
@@ -50,7 +50,6 @@ func main() {
 	// one in production so cleanup survives restarts and works across replicas.
 	maxChannelLifetimeSecs := envInt("MAX_CHANNEL_LIFETIME_SECS", uptosvm.DefaultMaxChannelLifetimeSecs)
 	scheme := uptosvm.NewUptoSvmScheme(signer, &uptosvm.Config{
-		RPCURL:                 rpcURL,
 		MaxChannelLifetimeSecs: &maxChannelLifetimeSecs,
 	})
 

--- a/examples/go/facilitator/upto/signer.go
+++ b/examples/go/facilitator/upto/signer.go
@@ -131,6 +131,52 @@ func (s *facilitatorSvmSigner) ConfirmTransaction(
 	return fmt.Errorf("transaction %s was not confirmed in time", signature)
 }
 
+func (s *facilitatorSvmSigner) GetAccountInfo(
+	ctx context.Context,
+	account solana.PublicKey,
+	_ string,
+	opts *rpc.GetAccountInfoOpts,
+) (*rpc.GetAccountInfoResult, error) {
+	return s.rpcClient.GetAccountInfoWithOpts(ctx, account, opts)
+}
+
+func (s *facilitatorSvmSigner) GetLatestBlockhash(ctx context.Context, _ string) (solana.Hash, uint64, error) {
+	latest, err := s.rpcClient.GetLatestBlockhash(ctx, rpc.CommitmentFinalized)
+	if err != nil {
+		return solana.Hash{}, 0, err
+	}
+	return latest.Value.Blockhash, latest.Value.LastValidBlockHeight, nil
+}
+
+func (s *facilitatorSvmSigner) GetSlot(ctx context.Context, _ string, commitment rpc.CommitmentType) (uint64, error) {
+	return s.rpcClient.GetSlot(ctx, commitment)
+}
+
+func (s *facilitatorSvmSigner) SimulateTransactionWithOpts(
+	ctx context.Context,
+	tx *solana.Transaction,
+	_ string,
+	opts *rpc.SimulateTransactionOpts,
+) error {
+	result, err := s.rpcClient.SimulateTransactionWithOpts(ctx, tx, opts)
+	if err != nil {
+		return fmt.Errorf("simulation failed: %w", err)
+	}
+	if result != nil && result.Value != nil && result.Value.Err != nil {
+		return fmt.Errorf("simulation failed: %v", result.Value.Err)
+	}
+	return nil
+}
+
+func (s *facilitatorSvmSigner) GetProgramAccounts(
+	ctx context.Context,
+	_ string,
+	programID solana.PublicKey,
+	opts *rpc.GetProgramAccountsOpts,
+) (rpc.GetProgramAccountsResult, error) {
+	return s.rpcClient.GetProgramAccountsWithOpts(ctx, programID, opts)
+}
+
 func (s *facilitatorSvmSigner) SimulateTransactionWithInnerInstructions(ctx context.Context, tx *solana.Transaction, _ string) ([]rpc.InnerInstruction, error) {
 	return svmmech.SimulateWithInnerInstructions(ctx, s.rpcClient, tx)
 }

--- a/examples/typescript/facilitator/basic/index.ts
+++ b/examples/typescript/facilitator/basic/index.ts
@@ -94,7 +94,11 @@ const evmSigner = toFacilitatorEvmSigner({
 });
 
 // Facilitator can now handle all Solana networks with automatic RPC creation
-const svmSigner = toFacilitatorSvmSigner(svmAccount);
+const svmRpcUrl = process.env.SVM_RPC_URL;
+const svmSigner = toFacilitatorSvmSigner(
+  svmAccount,
+  svmRpcUrl ? { defaultRpcUrl: svmRpcUrl } : undefined,
+);
 
 const facilitator = new x402Facilitator()
   .onBeforeVerify(async (context) => {

--- a/examples/typescript/facilitator/upto/index.ts
+++ b/examples/typescript/facilitator/upto/index.ts
@@ -148,11 +148,13 @@ if (svmPrivateKey) {
   );
   console.info(`SVM Facilitator account: ${svmAccount.address}`);
 
-  const svmSigner = toFacilitatorSvmSigner(svmAccount);
+  const svmSigner = toFacilitatorSvmSigner(
+    svmAccount,
+    svmRpcUrl ? { defaultRpcUrl: svmRpcUrl } : undefined,
+  );
   const svmUptoScheme = new UptoSvmScheme(svmSigner, {
     channelStorage,
     maxChannelLifetimeSecs,
-    rpcUrl: svmRpcUrl,
   });
   facilitator.register(SVM_NETWORK, svmUptoScheme);
 

--- a/go/.changes/unreleased/change-svm-upto-signer-rpc.yaml
+++ b/go/.changes/unreleased/change-svm-upto-signer-rpc.yaml
@@ -1,0 +1,2 @@
+type: changed
+body: Route SVM upto facilitator RPC through the signer instead of scheme Config.RPC/RPCURL — claim settlement simulates before send, deposit composite sim uses a placeholder blockhash with replaceRecentBlockhash, and claim overlaps channel read with blockhash prefetch

--- a/go/mechanisms/svm/paymentchannels/discovery.go
+++ b/go/mechanisms/svm/paymentchannels/discovery.go
@@ -16,6 +16,12 @@ type DiscoveredChannel struct {
 	Channel   Channel
 }
 
+// ProgramAccountsQuerier lists onchain program accounts. Facilitator signers
+// implement this via a thin adapter at the call site.
+type ProgramAccountsQuerier interface {
+	GetProgramAccounts(ctx context.Context, opts *rpc.GetProgramAccountsOpts) (rpc.GetProgramAccountsResult, error)
+}
+
 // DiscoverChannelsByRentPayer finds every payment-channels account this
 // facilitator key fronted rent for, per spec §6. It filters onchain by
 // rent_payer and account size, then rejects any match that fails full
@@ -26,11 +32,11 @@ type DiscoveredChannel struct {
 // time ChannelStorage record, which also carries the distribution recipient.
 func DiscoverChannelsByRentPayer(
 	ctx context.Context,
-	rpcClient *rpc.Client,
+	querier ProgramAccountsQuerier,
 	rentPayer solana.PublicKey,
 ) ([]DiscoveredChannel, error) {
 	accountSize := uint64(ChannelAccountSize)
-	results, err := rpcClient.GetProgramAccountsWithOpts(ctx, ProgramID, &rpc.GetProgramAccountsOpts{
+	results, err := querier.GetProgramAccounts(ctx, &rpc.GetProgramAccountsOpts{
 		Encoding:   solana.EncodingBase64,
 		Commitment: rpc.CommitmentConfirmed,
 		DataSlice:  nil,

--- a/go/mechanisms/svm/paymentchannels/discovery_test.go
+++ b/go/mechanisms/svm/paymentchannels/discovery_test.go
@@ -1,6 +1,7 @@
 package paymentchannels
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"net/http"
@@ -94,6 +95,17 @@ func validDiscoveryChannel(t *testing.T, rentPayer solana.PublicKey) (solana.Pub
 	return pda, data
 }
 
+type rpcProgramAccountsQuerier struct {
+	client *rpc.Client
+}
+
+func (q rpcProgramAccountsQuerier) GetProgramAccounts(
+	ctx context.Context,
+	opts *rpc.GetProgramAccountsOpts,
+) (rpc.GetProgramAccountsResult, error) {
+	return q.client.GetProgramAccountsWithOpts(ctx, ProgramID, opts)
+}
+
 func TestDiscoverChannelsByRentPayer_AcceptsValidatedAccount(t *testing.T) {
 	rentPayer := testKeypair(t).PublicKey()
 	pda, data := validDiscoveryChannel(t, rentPayer)
@@ -102,7 +114,7 @@ func TestDiscoverChannelsByRentPayer_AcceptsValidatedAccount(t *testing.T) {
 		{pubkey: pda, owner: ProgramID, data: data},
 	})
 
-	discovered, err := DiscoverChannelsByRentPayer(t.Context(), client, rentPayer)
+	discovered, err := DiscoverChannelsByRentPayer(t.Context(), rpcProgramAccountsQuerier{client: client}, rentPayer)
 	require.NoError(t, err)
 	require.Len(t, discovered, 1)
 	assert.Equal(t, pda, discovered[0].ChannelID)
@@ -123,7 +135,7 @@ func TestDiscoverChannelsByRentPayer_RejectsWrongOwner(t *testing.T) {
 		{pubkey: pda, owner: testKeypair(t).PublicKey(), data: data},
 	})
 
-	discovered, err := DiscoverChannelsByRentPayer(t.Context(), client, rentPayer)
+	discovered, err := DiscoverChannelsByRentPayer(t.Context(), rpcProgramAccountsQuerier{client: client}, rentPayer)
 	require.NoError(t, err)
 	assert.Empty(t, discovered)
 }
@@ -139,7 +151,7 @@ func TestDiscoverChannelsByRentPayer_RejectsPDAMismatch(t *testing.T) {
 		{pubkey: wrongPubkey, owner: ProgramID, data: data},
 	})
 
-	discovered, err := DiscoverChannelsByRentPayer(t.Context(), client, rentPayer)
+	discovered, err := DiscoverChannelsByRentPayer(t.Context(), rpcProgramAccountsQuerier{client: client}, rentPayer)
 	require.NoError(t, err)
 	assert.Empty(t, discovered)
 }
@@ -152,7 +164,7 @@ func TestDiscoverChannelsByRentPayer_RejectsMalformedAccount(t *testing.T) {
 		{pubkey: pda, owner: ProgramID, data: []byte{0x01, 0x02}},
 	})
 
-	discovered, err := DiscoverChannelsByRentPayer(t.Context(), client, rentPayer)
+	discovered, err := DiscoverChannelsByRentPayer(t.Context(), rpcProgramAccountsQuerier{client: client}, rentPayer)
 	require.NoError(t, err)
 	assert.Empty(t, discovered)
 }

--- a/go/mechanisms/svm/types.go
+++ b/go/mechanisms/svm/types.go
@@ -20,6 +20,9 @@ type ExactSvmPayloadV1 = ExactSvmPayload
 // ExactSvmPayloadV2 - alias for v2 (currently identical, reserved for future)
 type ExactSvmPayloadV2 = ExactSvmPayload
 
+// UptoSvmPayloadV2 is an alias for v2 compatibility.
+type UptoSvmPayloadV2 = UptoSvmPayload
+
 // UptoSvmPayload is the SVM `upto` payment payload: the client-signed channel
 // `open` plus the channel facts the facilitator rebinds it against.
 type UptoSvmPayload struct {
@@ -117,7 +120,32 @@ func IsUptoSvmPayload(payload map[string]interface{}) bool {
 			return false
 		}
 	}
+	if !jsonNumberIsInt64(payload["expiresAt"]) {
+		return false
+	}
+	if !jsonNumberIsInt64(payload["validAfter"]) {
+		return false
+	}
+	if voucher, present := payload[UptoVoucherSignatureField]; present {
+		if _, ok := voucher.(string); !ok {
+			return false
+		}
+	}
 	return true
+}
+
+func jsonNumberIsInt64(value interface{}) bool {
+	switch v := value.(type) {
+	case float64:
+		return v == float64(int64(v))
+	case int64, int:
+		return true
+	case json.Number:
+		_, err := v.Int64()
+		return err == nil
+	default:
+		return false
+	}
 }
 
 // HasUptoVoucherSignature reports whether the payload carries the voucher key
@@ -162,6 +190,29 @@ type FacilitatorSvmSigner interface {
 	// ConfirmTransaction waits for transaction confirmation
 	// Returns error if confirmation fails or times out
 	ConfirmTransaction(ctx context.Context, signature solana.Signature, network string) error
+}
+
+// FacilitatorSimulateTransactionOptions configures facilitator transaction
+// simulation. Nil pointer fields use RPC defaults (sigVerify off,
+// replaceRecentBlockhash off).
+type FacilitatorSimulateTransactionOptions struct {
+	SigVerify              *bool
+	ReplaceRecentBlockhash *bool
+	Commitment             rpc.CommitmentType
+}
+
+// FacilitatorAccountInfo is the account shape returned by GetAccountInfo on
+// facilitator signers that expose read RPC.
+type FacilitatorAccountInfo struct {
+	Data     solana.Data
+	Owner    solana.PublicKey
+	Lamports uint64
+}
+
+// FacilitatorProgramAccount is one row from GetProgramAccounts.
+type FacilitatorProgramAccount struct {
+	Pubkey  solana.PublicKey
+	Account FacilitatorAccountInfo
 }
 
 // SmartWalletRPCCapabilities is the extra read-only RPC surface a

--- a/go/mechanisms/svm/types_test.go
+++ b/go/mechanisms/svm/types_test.go
@@ -1,0 +1,77 @@
+package svm
+
+import (
+	"testing"
+)
+
+func TestExactSvmPayloadV1Structure(t *testing.T) {
+	payload := ExactSvmPayloadV1{Transaction: "base64encodedtransaction=="}
+	if payload.Transaction == "" {
+		t.Fatal("expected transaction field")
+	}
+}
+
+func TestExactSvmPayloadV2CompatibleWithV1(t *testing.T) {
+	payload := ExactSvmPayloadV2{Transaction: "base64encodedtransaction=="}
+	v1 := ExactSvmPayloadV1(payload)
+	if v1.Transaction != payload.Transaction {
+		t.Fatalf("expected V2 to be assignable to V1")
+	}
+}
+
+func TestUptoSvmPayloadV2Alias(t *testing.T) {
+	payload := UptoSvmPayloadV2{
+		From:             "From1111111111111111111111111111111111111",
+		MaxAmount:        "1000",
+		ExpiresAt:        1_700_000_000,
+		ValidAfter:       1_699_999_000,
+		Nonce:            "1",
+		OpenSlot:         "341000000",
+		ChannelId:        "Channel111111111111111111111111111111111111",
+		Deposit:          "1000",
+		AuthorizedSigner: "Auth1111111111111111111111111111111111111",
+		OpenTransaction:  "dGVzdA==",
+	}
+	if payload.From == "" {
+		t.Fatal("expected from field on UptoSvmPayloadV2 alias")
+	}
+}
+
+func TestIsUptoSvmPayload(t *testing.T) {
+	valid := map[string]interface{}{
+		"from":             "From1111111111111111111111111111111111111",
+		"maxAmount":        "1000",
+		"deposit":          "1000",
+		"channelId":        "Channel111111111111111111111111111111111111",
+		"authorizedSigner": "Auth1111111111111111111111111111111111111",
+		"openTransaction":  "dGVzdA==",
+		"openSlot":         "341000000",
+		"nonce":            "1",
+		"expiresAt":        float64(1_700_000_000),
+		"validAfter":       float64(1_699_999_000),
+	}
+	if !IsUptoSvmPayload(valid) {
+		t.Fatal("expected valid upto payload")
+	}
+
+	missingExpires := map[string]interface{}{}
+	for k, v := range valid {
+		missingExpires[k] = v
+	}
+	delete(missingExpires, "expiresAt")
+	if IsUptoSvmPayload(missingExpires) {
+		t.Fatal("expected missing expiresAt to fail the guard")
+	}
+}
+
+func TestPayloadFromMapRequiresTransaction(t *testing.T) {
+	if _, err := PayloadFromMap(map[string]interface{}{}); err == nil {
+		t.Fatal("expected error for missing transaction")
+	}
+}
+
+func TestUptoPayloadFromMapRequiresFields(t *testing.T) {
+	if _, err := UptoPayloadFromMap(map[string]interface{}{"from": "x"}); err == nil {
+		t.Fatal("expected error for incomplete upto payload")
+	}
+}

--- a/go/mechanisms/svm/upto/facilitator/channel.go
+++ b/go/mechanisms/svm/upto/facilitator/channel.go
@@ -15,6 +15,10 @@ import (
 	"github.com/x402-foundation/x402/go/v2/mechanisms/svm/upto"
 )
 
+// simPlaceholderBlockhash is compiled into deposit composite sims; the RPC
+// replaces it before simulation.
+var simPlaceholderBlockhash = solana.Hash{}
+
 // simComputeUnitLimit is the Solana per-transaction compute maximum. Only used
 // for facilitator-built simulations: the composite open + settle + distribute
 // exceeds the 400,000 CU ceiling the client open is capped at.
@@ -109,10 +113,11 @@ func (c *verifiedOpenChannel) settlement(tokenProgram solana.PublicKey, network 
 // value reports whether the account exists at all.
 func fetchChannelAccount(
 	ctx context.Context,
-	rpcClient *rpc.Client,
+	signer UptoFacilitatorSigner,
+	network string,
 	channelID solana.PublicKey,
 ) (*paymentchannels.Channel, bool, error) {
-	account, err := getChannelAccount(ctx, rpcClient, channelID)
+	account, err := getChannelAccount(ctx, signer, network, channelID)
 	if err != nil {
 		if errors.Is(err, rpc.ErrNotFound) {
 			return nil, false, nil
@@ -135,18 +140,24 @@ func fetchChannelAccount(
 // is visible to this one.
 func getChannelAccount(
 	ctx context.Context,
-	rpcClient *rpc.Client,
+	signer UptoFacilitatorSigner,
+	network string,
 	channelID solana.PublicKey,
 ) (*rpc.GetAccountInfoResult, error) {
-	return rpcClient.GetAccountInfoWithOpts(ctx, channelID, &rpc.GetAccountInfoOpts{
+	return signer.GetAccountInfo(ctx, channelID, network, &rpc.GetAccountInfoOpts{
 		Encoding:   solana.EncodingBase64,
 		Commitment: upto.StateCommitment,
 	})
 }
 
 // channelExists reports whether the channel PDA is already allocated onchain.
-func channelExists(ctx context.Context, rpcClient *rpc.Client, channelID solana.PublicKey) (bool, error) {
-	account, err := getChannelAccount(ctx, rpcClient, channelID)
+func channelExists(
+	ctx context.Context,
+	signer UptoFacilitatorSigner,
+	network string,
+	channelID solana.PublicKey,
+) (bool, error) {
+	account, err := getChannelAccount(ctx, signer, network, channelID)
 	if err != nil {
 		if errors.Is(err, rpc.ErrNotFound) {
 			return false, nil
@@ -160,12 +171,13 @@ func channelExists(ctx context.Context, rpcClient *rpc.Client, channelID solana.
 // the challenge terms before the facilitator settles against it.
 func fetchAndVerifyOpenChannel(
 	ctx context.Context,
-	rpcClient *rpc.Client,
+	signer UptoFacilitatorSigner,
+	network string,
 	channelID solana.PublicKey,
 	expected expectedOpenChannel,
 ) (*verifiedOpenChannel, error) {
 	for attempt := 1; attempt <= channelReadMaxAttempts; attempt++ {
-		channel, exists, err := fetchChannelAccount(ctx, rpcClient, channelID)
+		channel, exists, err := fetchChannelAccount(ctx, signer, network, channelID)
 		if err != nil {
 			return nil, err
 		}
@@ -305,8 +317,7 @@ type settlementChannel struct {
 // with signature verification off).
 func simulateOpenSettleDistribute(
 	ctx context.Context,
-	rpcClient *rpc.Client,
-	signer svm.FacilitatorSvmSigner,
+	signer UptoFacilitatorSigner,
 	feePayer solana.PublicKey,
 	openTransactionBase64 string,
 	channel settlementChannel,
@@ -347,7 +358,7 @@ func simulateOpenSettleDistribute(
 	}
 	instructions = append(instructions, settleInstructions...)
 
-	return simulateInstructions(ctx, rpcClient, signer, feePayer, channel.Network, instructions)
+	return simulateInstructions(ctx, signer, feePayer, channel.Network, instructions)
 }
 
 // voucherArgs carry a signed voucher into settle_and_seal via the Ed25519
@@ -407,22 +418,17 @@ func buildSettleAndDistribute(
 }
 
 // buildSignedTransaction compiles instructions into a fee-payer-signed
-// transaction anchored to a fresh blockhash.
+// transaction anchored to blockhash.
 func buildSignedTransaction(
 	ctx context.Context,
-	rpcClient *rpc.Client,
 	signer svm.FacilitatorSvmSigner,
 	feePayer solana.PublicKey,
 	network string,
+	blockhash solana.Hash,
 	instructions []solana.Instruction,
 ) (*solana.Transaction, error) {
-	latest, err := rpcClient.GetLatestBlockhash(ctx, upto.BlockhashCommitment)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch latest blockhash: %w", err)
-	}
-
 	builder := solana.NewTransactionBuilder().
-		SetRecentBlockHash(latest.Value.Blockhash).
+		SetRecentBlockHash(blockhash).
 		SetFeePayer(feePayer)
 	for _, instruction := range instructions {
 		builder = builder.AddInstruction(instruction)
@@ -448,29 +454,38 @@ func buildSignedTransaction(
 // are never landed and the composite open simulation carries an unsigned payer.
 func simulateInstructions(
 	ctx context.Context,
-	rpcClient *rpc.Client,
-	signer svm.FacilitatorSvmSigner,
+	signer UptoFacilitatorSigner,
 	feePayer solana.PublicKey,
 	network string,
 	instructions []solana.Instruction,
 ) error {
-	tx, err := buildSignedTransaction(ctx, rpcClient, signer, feePayer, network, instructions)
+	tx, err := buildSignedTransaction(ctx, signer, feePayer, network, simPlaceholderBlockhash, instructions)
 	if err != nil {
 		return err
 	}
 
-	result, err := rpcClient.SimulateTransactionWithOpts(ctx, tx, &rpc.SimulateTransactionOpts{
+	return signer.SimulateTransactionWithOpts(ctx, tx, network, &rpc.SimulateTransactionOpts{
 		SigVerify:              false,
 		ReplaceRecentBlockhash: true,
 		Commitment:             upto.StateCommitment,
 	})
-	if err != nil {
-		return fmt.Errorf("settlement simulation failed: %w", err)
+}
+
+// SettlementSimulationError is returned when explicit settlement simulation
+// fails. The transaction is never broadcast.
+type SettlementSimulationError struct {
+	Err error
+}
+
+func (e *SettlementSimulationError) Error() string {
+	if e.Err != nil {
+		return e.Err.Error()
 	}
-	if result != nil && result.Value != nil && result.Value.Err != nil {
-		return fmt.Errorf("settlement simulation failed: %v", result.Value.Err)
-	}
-	return nil
+	return "settlement simulation failed"
+}
+
+func (e *SettlementSimulationError) Unwrap() error {
+	return e.Err
 }
 
 // submitSettleOptions configures the ComputeBudget prefix submitSettle
@@ -484,6 +499,9 @@ type submitSettleOptions struct {
 	// ComputeUnitPriceMicroLamports overrides SetComputeUnitPrice; 0 omits
 	// the instruction. Defaults to svm.DefaultComputeUnitPriceMicrolamports.
 	ComputeUnitPriceMicroLamports *uint64
+	// LatestBlockhash, when set, skips a blockhash fetch (e.g. prefetched in
+	// parallel with a channel read during claim settle).
+	LatestBlockhash *solana.Hash
 }
 
 // buildSettleComputeBudget builds the ComputeBudget prefix submitSettle
@@ -523,8 +541,7 @@ func buildSettleComputeBudget(opts submitSettleOptions) ([]solana.Instruction, e
 // ComputeBudget SetComputeUnitLimit and optional SetComputeUnitPrice.
 func submitSettle(
 	ctx context.Context,
-	rpcClient *rpc.Client,
-	signer svm.FacilitatorSvmSigner,
+	signer UptoFacilitatorSigner,
 	feePayer solana.PublicKey,
 	network string,
 	instructions []solana.Instruction,
@@ -535,11 +552,26 @@ func submitSettle(
 		return "", err
 	}
 
+	var blockhash solana.Hash
+	if opts.LatestBlockhash != nil {
+		blockhash = *opts.LatestBlockhash
+	} else {
+		latest, _, err := signer.GetLatestBlockhash(ctx, network)
+		if err != nil {
+			return "", fmt.Errorf("failed to fetch latest blockhash: %w", err)
+		}
+		blockhash = latest
+	}
+
 	tx, err := buildSignedTransaction(
-		ctx, rpcClient, signer, feePayer, network, append(computeBudget, instructions...),
+		ctx, signer, feePayer, network, blockhash, append(computeBudget, instructions...),
 	)
 	if err != nil {
 		return "", err
+	}
+
+	if err := signer.SimulateTransaction(ctx, tx, network); err != nil {
+		return "", &SettlementSimulationError{Err: err}
 	}
 
 	signature, err := signer.SendTransaction(ctx, tx, network)

--- a/go/mechanisms/svm/upto/facilitator/channel_test.go
+++ b/go/mechanisms/svm/upto/facilitator/channel_test.go
@@ -32,12 +32,14 @@ func TestFetchAndVerifyOpenChannelRetriesMissingAccount(t *testing.T) {
 	signer := newMockSigner(t, 1)
 	fixture := newPaymentFixture(t, signer)
 	rpcStub := newStubRPC(t)
+	signer.attachRPC(rpc.New(rpcStub.url))
 	rpcStub.setAccount(fixture.channelID.String(), fixture.openChannel().encode(t))
 	rpcStub.hideAccountForReads(fixture.channelID.String(), 1)
 
 	verified, err := fetchAndVerifyOpenChannel(
 		context.Background(),
-		rpc.New(rpcStub.url),
+		signer,
+		testNetwork,
 		fixture.channelID,
 		expectedFrom(fixture),
 	)
@@ -50,12 +52,14 @@ func TestFetchAndVerifyOpenChannelStopsRetryingWhenContextEnds(t *testing.T) {
 	signer := newMockSigner(t, 1)
 	fixture := newPaymentFixture(t, signer)
 	rpcStub := newStubRPC(t)
+	signer.attachRPC(rpc.New(rpcStub.url))
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 	defer cancel()
 
 	_, err := fetchAndVerifyOpenChannel(
 		ctx,
-		rpc.New(rpcStub.url),
+		signer,
+		testNetwork,
 		fixture.channelID,
 		expectedFrom(fixture),
 	)

--- a/go/mechanisms/svm/upto/facilitator/rent_cleanup.go
+++ b/go/mechanisms/svm/upto/facilitator/rent_cleanup.go
@@ -444,7 +444,10 @@ func (m *RentCleanupManager) Discover(ctx context.Context, opts DiscoveryOptions
 	m.passMu.Lock()
 	defer m.passMu.Unlock()
 
-	assertProgramAccountsSigner(m.signer, "RentCleanupManager.Discover")
+	querier := programAccountsQuerier{
+		signer:  assertProgramAccountsSigner(m.signer, "RentCleanupManager.Discover"),
+		network: m.network,
+	}
 	records, err := m.storage.List(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to list stored channels: %w", err)
@@ -462,7 +465,7 @@ func (m *RentCleanupManager) Discover(ctx context.Context, opts DiscoveryOptions
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
-		found, err := paymentchannels.DiscoverChannelsByRentPayer(ctx, programAccountsQuerier{m.signer, m.network}, managed)
+		found, err := paymentchannels.DiscoverChannelsByRentPayer(ctx, querier, managed)
 		if err != nil {
 			opts.reportError(fmt.Errorf("discovery failed for rent payer %s: %w", managed, err), "")
 			continue

--- a/go/mechanisms/svm/upto/facilitator/rent_cleanup.go
+++ b/go/mechanisms/svm/upto/facilitator/rent_cleanup.go
@@ -10,9 +10,7 @@ import (
 	"time"
 
 	solana "github.com/gagliardetto/solana-go"
-	"github.com/gagliardetto/solana-go/rpc"
 
-	"github.com/x402-foundation/x402/go/v2/mechanisms/svm"
 	"github.com/x402-foundation/x402/go/v2/mechanisms/svm/paymentchannels"
 	"github.com/x402-foundation/x402/go/v2/mechanisms/svm/upto"
 )
@@ -163,14 +161,9 @@ func (c StartConfig) discoveryOptions() DiscoveryOptions {
 
 // RentCleanupConfig configures a rent cleanup manager for one network.
 type RentCleanupConfig struct {
-	Signer  svm.FacilitatorSvmSigner
+	Signer  UptoFacilitatorSigner
 	Storage ChannelStorage
 	Network string
-	RPCURL  string
-
-	// RPC is a prebuilt client used instead of building one from RPCURL, for
-	// callers that need custom headers, transport, or rate limiting.
-	RPC *rpc.Client
 
 	// ComputeUnitPriceMicroLamports is the SetComputeUnitPrice (microlamports
 	// per compute unit) attached to cleanup transactions; 0 omits the
@@ -193,11 +186,9 @@ type RentCleanupConfig struct {
 // refunds the unsettled remainder to the client, so cleanup only kicks in
 // after the voucher deadline plus a grace period.
 type RentCleanupManager struct {
-	signer                        svm.FacilitatorSvmSigner
+	signer                        UptoFacilitatorSigner
 	storage                       ChannelStorage
 	network                       string
-	rpcURL                        string
-	rpc                           *rpc.Client
 	computeUnitPriceMicroLamports *uint64
 	settleComputeUnitLimit        *uint32
 
@@ -221,24 +212,17 @@ type RentCleanupManager struct {
 // NewRentCleanupManager creates a rent cleanup manager. It does not start
 // automatically; the facilitator scheme never runs cleanup on its own.
 func NewRentCleanupManager(config RentCleanupConfig) *RentCleanupManager {
+	signer := config.Signer
+	if signer == nil {
+		panic("upto svm rent cleanup: signer is required")
+	}
 	return &RentCleanupManager{
-		signer:                        config.Signer,
+		signer:                        signer,
 		storage:                       config.Storage,
 		network:                       config.Network,
-		rpcURL:                        config.RPCURL,
-		rpc:                           config.RPC,
 		computeUnitPriceMicroLamports: config.ComputeUnitPriceMicroLamports,
 		settleComputeUnitLimit:        config.SettleComputeUnitLimit,
 	}
-}
-
-// rpcClient returns the injected client when there is one, otherwise builds
-// one for the network.
-func (m *RentCleanupManager) rpcClient() (*rpc.Client, error) {
-	if m.rpc != nil {
-		return m.rpc, nil
-	}
-	return upto.NewRPCClient(m.network, m.rpcURL)
 }
 
 // Start runs Cleanup on an interval, and Discover on its own longer interval
@@ -331,10 +315,6 @@ func (m *RentCleanupManager) Cleanup(ctx context.Context, opts CleanupOptions) e
 
 	opts = opts.withDefaults()
 
-	rpcClient, err := m.rpcClient()
-	if err != nil {
-		return err
-	}
 	records, err := m.storage.List(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to list stored channels: %w", err)
@@ -367,7 +347,7 @@ func (m *RentCleanupManager) Cleanup(ctx context.Context, opts CleanupOptions) e
 			opts.reportError(err, record.ChannelID)
 			continue
 		}
-		channel, exists, err := fetchChannelAccount(ctx, rpcClient, channelID)
+		channel, exists, err := fetchChannelAccount(ctx, m.signer, m.network, channelID)
 		if err != nil {
 			opts.reportError(err, record.ChannelID)
 			continue
@@ -399,7 +379,7 @@ func (m *RentCleanupManager) Cleanup(ctx context.Context, opts CleanupOptions) e
 				)
 				continue
 			}
-			signature, err := m.submitCloseOrDistribute(ctx, rpcClient, record, channel, channelID)
+			signature, err := m.submitCloseOrDistribute(ctx, record, channel, channelID)
 			if err != nil {
 				opts.reportError(err, record.ChannelID)
 				continue
@@ -417,10 +397,10 @@ func (m *RentCleanupManager) Cleanup(ctx context.Context, opts CleanupOptions) e
 					Action:      action,
 				})
 			}
-			m.deleteIfGone(ctx, rpcClient, channelID, record.ChannelID, opts)
+			m.deleteIfGone(ctx, channelID, record.ChannelID, opts)
 
 		case paymentchannels.StatusDistributed:
-			slot, err := m.currentSlot(ctx, rpcClient, &currentSlot)
+			slot, err := m.currentSlot(ctx, &currentSlot)
 			if err != nil {
 				opts.reportError(err, record.ChannelID)
 				continue
@@ -442,7 +422,7 @@ func (m *RentCleanupManager) Cleanup(ctx context.Context, opts CleanupOptions) e
 		}
 	}
 
-	m.submitReclaimBatches(ctx, rpcClient, reclaimCandidates, opts)
+	m.submitReclaimBatches(ctx, reclaimCandidates, opts)
 	return nil
 }
 
@@ -464,10 +444,7 @@ func (m *RentCleanupManager) Discover(ctx context.Context, opts DiscoveryOptions
 	m.passMu.Lock()
 	defer m.passMu.Unlock()
 
-	rpcClient, err := m.rpcClient()
-	if err != nil {
-		return err
-	}
+	assertProgramAccountsSigner(m.signer, "RentCleanupManager.Discover")
 	records, err := m.storage.List(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to list stored channels: %w", err)
@@ -485,12 +462,12 @@ func (m *RentCleanupManager) Discover(ctx context.Context, opts DiscoveryOptions
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
-		found, err := paymentchannels.DiscoverChannelsByRentPayer(ctx, rpcClient, managed)
+		found, err := paymentchannels.DiscoverChannelsByRentPayer(ctx, programAccountsQuerier{m.signer, m.network}, managed)
 		if err != nil {
 			opts.reportError(fmt.Errorf("discovery failed for rent payer %s: %w", managed, err), "")
 			continue
 		}
-		slot, err := m.currentSlot(ctx, rpcClient, &currentSlot)
+		slot, err := m.currentSlot(ctx, &currentSlot)
 		if err != nil {
 			return err
 		}
@@ -528,11 +505,11 @@ func (m *RentCleanupManager) Discover(ctx context.Context, opts DiscoveryOptions
 
 // currentSlot lazily fetches and caches the slot used to gate reclaims, so a
 // pass with no Distributed records never pays for the RPC round trip.
-func (m *RentCleanupManager) currentSlot(ctx context.Context, rpcClient *rpc.Client, cache **uint64) (uint64, error) {
+func (m *RentCleanupManager) currentSlot(ctx context.Context, cache **uint64) (uint64, error) {
 	if *cache != nil {
 		return **cache, nil
 	}
-	slot, err := rpcClient.GetSlot(ctx, upto.SlotCommitment)
+	slot, err := m.signer.GetSlot(ctx, m.network, upto.SlotCommitment)
 	if err != nil {
 		return 0, fmt.Errorf("failed to fetch the current slot: %w", err)
 	}
@@ -578,7 +555,6 @@ func orderForScan(records []ChannelRecord, cursor string) []ChannelRecord {
 // distributes an already-Sealed one.
 func (m *RentCleanupManager) submitCloseOrDistribute(
 	ctx context.Context,
-	rpcClient *rpc.Client,
 	record ChannelRecord,
 	channel *paymentchannels.Channel,
 	channelID solana.PublicKey,
@@ -618,7 +594,7 @@ func (m *RentCleanupManager) submitCloseOrDistribute(
 		}
 	}
 
-	return submitSettle(ctx, rpcClient, m.signer, feePayer, m.network, instructions, submitSettleOptions{
+	return submitSettle(ctx, m.signer, feePayer, m.network, instructions, submitSettleOptions{
 		ComputeUnitLimit:              m.settleComputeUnitLimit,
 		ComputeUnitPriceMicroLamports: m.computeUnitPriceMicroLamports,
 	})
@@ -634,7 +610,6 @@ func (m *RentCleanupManager) submitCloseOrDistribute(
 // pool.
 func (m *RentCleanupManager) submitReclaimBatches(
 	ctx context.Context,
-	rpcClient *rpc.Client,
 	candidates []reclaimCandidate,
 	opts CleanupOptions,
 ) {
@@ -658,7 +633,7 @@ func (m *RentCleanupManager) submitReclaimBatches(
 		go func(rentPayer solana.PublicKey, group []reclaimCandidate) {
 			defer wg.Done()
 			budget := int64(opts.MaxTxsPerSigner)
-			m.submitReclaimGroup(ctx, rpcClient, rentPayer, group, opts, &budget)
+			m.submitReclaimGroup(ctx, rentPayer, group, opts, &budget)
 		}(rentPayer, group)
 	}
 	wg.Wait()
@@ -669,7 +644,6 @@ func (m *RentCleanupManager) submitReclaimBatches(
 // cannot overrun maxTxs.
 func (m *RentCleanupManager) submitReclaimGroup(
 	ctx context.Context,
-	rpcClient *rpc.Client,
 	rentPayer solana.PublicKey,
 	group []reclaimCandidate,
 	opts CleanupOptions,
@@ -696,7 +670,7 @@ func (m *RentCleanupManager) submitReclaimGroup(
 		if end > len(group) {
 			end = len(group)
 		}
-		batch := m.refreshReclaimBatch(ctx, rpcClient, group[start:end], opts)
+		batch := m.refreshReclaimBatch(ctx, group[start:end], opts)
 		if len(batch) == 0 {
 			continue
 		}
@@ -710,7 +684,7 @@ func (m *RentCleanupManager) submitReclaimGroup(
 		}
 
 		reclaimLimit := ReclaimComputeUnitLimit(len(batch))
-		signature, err := submitSettle(ctx, rpcClient, m.signer, feePayer, m.network, instructions, submitSettleOptions{
+		signature, err := submitSettle(ctx, m.signer, feePayer, m.network, instructions, submitSettleOptions{
 			ComputeUnitLimit:              &reclaimLimit,
 			ComputeUnitPriceMicroLamports: m.computeUnitPriceMicroLamports,
 		})
@@ -737,13 +711,12 @@ func (m *RentCleanupManager) submitReclaimGroup(
 // the whole batch.
 func (m *RentCleanupManager) refreshReclaimBatch(
 	ctx context.Context,
-	rpcClient *rpc.Client,
 	batch []reclaimCandidate,
 	opts CleanupOptions,
 ) []reclaimCandidate {
 	live := make([]reclaimCandidate, 0, len(batch))
 	for _, candidate := range batch {
-		channel, exists, err := fetchChannelAccount(ctx, rpcClient, candidate.channelID)
+		channel, exists, err := fetchChannelAccount(ctx, m.signer, m.network, candidate.channelID)
 		if err != nil {
 			opts.reportError(err, candidate.channelID.String())
 			continue
@@ -765,12 +738,11 @@ func (m *RentCleanupManager) refreshReclaimBatch(
 // deleteIfGone drops the storage entry once the channel account is closed.
 func (m *RentCleanupManager) deleteIfGone(
 	ctx context.Context,
-	rpcClient *rpc.Client,
 	channelID solana.PublicKey,
 	storedID string,
 	opts CleanupOptions,
 ) {
-	exists, err := channelExists(ctx, rpcClient, channelID)
+	exists, err := channelExists(ctx, m.signer, m.network, channelID)
 	if err != nil {
 		opts.reportError(err, storedID)
 		return

--- a/go/mechanisms/svm/upto/facilitator/rent_cleanup_test.go
+++ b/go/mechanisms/svm/upto/facilitator/rent_cleanup_test.go
@@ -55,11 +55,11 @@ func newCleanupHarness(t *testing.T) *cleanupHarness {
 		payer:   payer.PublicKey(),
 		payTo:   payTo.PublicKey(),
 	}
+	harness.signer.attachRPC(rpc.New(harness.stub.url))
 	harness.manager = NewRentCleanupManager(RentCleanupConfig{
 		Signer:  signer,
 		Storage: harness.storage,
 		Network: testNetwork,
-		RPCURL:  harness.stub.url,
 	})
 	return harness
 }
@@ -348,7 +348,6 @@ func TestCleanupUsesTheConfiguredSettleComputeBudget(t *testing.T) {
 		Signer:                        harness.signer,
 		Storage:                       harness.storage,
 		Network:                       testNetwork,
-		RPCURL:                        harness.stub.url,
 		SettleComputeUnitLimit:        &settleLimit,
 		ComputeUnitPriceMicroLamports: &price,
 	})
@@ -822,7 +821,6 @@ func TestCleanupPropagatesAStorageListFailure(t *testing.T) {
 		Signer:  harness.signer,
 		Storage: failingStorage{},
 		Network: testNetwork,
-		RPCURL:  harness.stub.url,
 	})
 
 	err := manager.Cleanup(context.Background(), harness.options(CleanupOptions{}))
@@ -1164,12 +1162,12 @@ func TestDiscoverNeverOverwritesATrackedChannel(t *testing.T) {
 func TestSubmitReclaimBatchesRunsRentPayerGroupsConcurrently(t *testing.T) {
 	harness := newCleanupHarness(t)
 	signer := newMockSigner(t, 2)
+	signer.attachRPC(rpc.New(harness.stub.url))
 	harness.signer = signer
 	harness.manager = NewRentCleanupManager(RentCleanupConfig{
 		Signer:  signer,
 		Storage: harness.storage,
 		Network: testNetwork,
-		RPCURL:  harness.stub.url,
 	})
 
 	openSlot := testSlot - paymentchannels.OpenSlotWindow - 1
@@ -1225,12 +1223,12 @@ func TestSubmitReclaimBatchesRunsRentPayerGroupsConcurrently(t *testing.T) {
 func TestSubmitReclaimBatchesBudgetsEachRentPayerGroupIndependently(t *testing.T) {
 	harness := newCleanupHarness(t)
 	signer := newMockSigner(t, 2)
+	signer.attachRPC(rpc.New(harness.stub.url))
 	harness.signer = signer
 	harness.manager = NewRentCleanupManager(RentCleanupConfig{
 		Signer:  signer,
 		Storage: harness.storage,
 		Network: testNetwork,
-		RPCURL:  harness.stub.url,
 	})
 
 	openSlot := testSlot - paymentchannels.OpenSlotWindow - 1
@@ -1260,8 +1258,6 @@ func TestCleanupAndDiscoverPreferAnInjectedRPCClient(t *testing.T) {
 		Signer:  harness.signer,
 		Storage: harness.storage,
 		Network: testNetwork,
-		RPCURL:  "http://127.0.0.1:1/unreachable",
-		RPC:     rpc.New(harness.stub.url),
 	})
 
 	openSlot := testSlot - paymentchannels.OpenSlotWindow - 1

--- a/go/mechanisms/svm/upto/facilitator/scheme.go
+++ b/go/mechanisms/svm/upto/facilitator/scheme.go
@@ -10,10 +10,10 @@ import (
 	"log"
 	"math/rand/v2"
 	"strconv"
+	"sync"
 	"time"
 
 	solana "github.com/gagliardetto/solana-go"
-	"github.com/gagliardetto/solana-go/rpc"
 
 	x402 "github.com/x402-foundation/x402/go/v2"
 	"github.com/x402-foundation/x402/go/v2/mechanisms/svm"
@@ -40,14 +40,6 @@ const StoragePhaseSettle StoragePhase = "settle"
 
 // Config is the optional configuration of the SVM `upto` facilitator.
 type Config struct {
-	// RPCURL overrides the per-network default RPC endpoint.
-	RPCURL string
-
-	// RPC is a prebuilt client used instead of building one from RPCURL, for
-	// callers that need custom headers, transport, or rate limiting. It is
-	// also threaded into the manager NewRentCleanupManager returns.
-	RPC *rpc.Client
-
 	// ChannelStorage indexes sponsored channels for rent cleanup. Defaults to
 	// in-memory storage; inject a durable one for multi-process facilitators.
 	ChannelStorage ChannelStorage
@@ -107,7 +99,7 @@ type Config struct {
 // abandoned channel to recover its rent, while any nonzero settlement still
 // requires the server's receiver-authorizer voucher.
 type UptoSvmScheme struct {
-	signer          svm.FacilitatorSvmSigner
+	signer          UptoFacilitatorSigner
 	config          Config
 	channelStorage  ChannelStorage
 	settlementCache *svm.SettlementCache
@@ -145,7 +137,7 @@ func NewUptoSvmScheme(signer svm.FacilitatorSvmSigner, config *Config) *UptoSvmS
 		storage = NewInMemoryChannelStorage()
 	}
 	return &UptoSvmScheme{
-		signer:          signer,
+		signer:          assertUptoFacilitatorSigner(signer, "UptoSvmScheme"),
 		config:          cfg,
 		channelStorage:  storage,
 		settlementCache: svm.NewSettlementCache(),
@@ -196,21 +188,9 @@ func (f *UptoSvmScheme) NewRentCleanupManager(network string) *RentCleanupManage
 		Signer:                        f.signer,
 		Storage:                       f.channelStorage,
 		Network:                       network,
-		RPCURL:                        f.config.RPCURL,
-		RPC:                           f.config.RPC,
 		ComputeUnitPriceMicroLamports: f.config.ComputeUnitPriceMicroLamports,
 		SettleComputeUnitLimit:        f.config.SettleComputeUnitLimit,
 	})
-}
-
-// rpcClient returns the injected client when there is one, otherwise builds
-// one for the network. Every RPC entry point in the scheme goes through here
-// so an injected client is never bypassed.
-func (f *UptoSvmScheme) rpcClient(network string) (*rpc.Client, error) {
-	if f.config.RPC != nil {
-		return f.config.RPC, nil
-	}
-	return upto.NewRPCClient(network, f.config.RPCURL)
 }
 
 // GetExtra advertises a randomly selected fee payer for payment-channel opens.
@@ -416,15 +396,12 @@ func (f *UptoSvmScheme) settleDeposit(
 	}
 
 	uptoPayload := auth.payload
-	rpcClient, err := f.rpcClient(string(requirements.Network))
-	if err != nil {
-		return nil, x402.NewSettleError(ErrPaymentRequirements, uptoPayload.From, network, "", err.Error())
-	}
+	networkStr := string(requirements.Network)
 
 	// One authorization opens one channel. An existing PDA is a replay or a
 	// stranded prior open, not a rebind: a handler failure after a successful
 	// deposit refunds through the zero-amount cancel settle instead.
-	exists, err := channelExists(ctx, rpcClient, auth.channelID)
+	exists, err := channelExists(ctx, f.signer, networkStr, auth.channelID)
 	if err != nil {
 		return nil, x402.NewSettleError(ErrChannelState, uptoPayload.From, network, "", err.Error())
 	}
@@ -453,7 +430,7 @@ func (f *UptoSvmScheme) settleDeposit(
 		Splits:       auth.channelConfig.Splits,
 	}
 	if err := simulateOpenSettleDistribute(
-		ctx, rpcClient, f.signer, auth.feePayer, uptoPayload.OpenTransaction, simChannel,
+		ctx, f.signer, auth.feePayer, uptoPayload.OpenTransaction, simChannel,
 	); err != nil {
 		f.settlementCache.Delete(depositKey)
 		return nil, x402.NewSettleError(ErrSettlementSimulation, uptoPayload.From, network, "", err.Error())
@@ -492,7 +469,7 @@ func (f *UptoSvmScheme) settleDeposit(
 		return nil, x402.NewSettleError(ErrChannelBroadcast, uptoPayload.From, network, "", err.Error())
 	}
 
-	if _, err := fetchAndVerifyOpenChannel(ctx, rpcClient, auth.channelID, expectedOpenChannel{
+	if _, err := fetchAndVerifyOpenChannel(ctx, f.signer, networkStr, auth.channelID, expectedOpenChannel{
 		AuthorizedSigner: auth.channelConfig.ReceiverAuthorizer,
 		Mint:             requirements.Asset,
 		Payee:            auth.channelConfig.FeePayer,
@@ -584,12 +561,9 @@ func (f *UptoSvmScheme) settleClaim(
 	if err != nil {
 		return nil, x402.NewSettleError(ErrPaymentRequirements, uptoPayload.From, network, "", err.Error())
 	}
-	rpcClient, err := f.rpcClient(string(requirements.Network))
-	if err != nil {
-		return nil, x402.NewSettleError(ErrPaymentRequirements, uptoPayload.From, network, "", err.Error())
-	}
 
-	channel, err := fetchAndVerifyOpenChannel(ctx, rpcClient, channelID, expectedOpenChannel{
+	networkStr := string(requirements.Network)
+	expected := expectedOpenChannel{
 		AuthorizedSigner: channelConfig.ReceiverAuthorizer,
 		Mint:             requirements.Asset,
 		Payee:            channelConfig.FeePayer,
@@ -598,9 +572,30 @@ func (f *UptoSvmScheme) settleClaim(
 		Deposit:          maxAmount,
 		GracePeriod:      channelConfig.WithdrawDelay,
 		Splits:           channelConfig.Splits,
-	})
-	if err != nil {
-		return nil, x402.NewSettleError(ErrChannelState, uptoPayload.From, network, "", err.Error())
+	}
+
+	var (
+		channel        *verifiedOpenChannel
+		prefetchedHash solana.Hash
+		channelErr     error
+		blockhashErr   error
+		wg             sync.WaitGroup
+	)
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		channel, channelErr = fetchAndVerifyOpenChannel(ctx, f.signer, networkStr, channelID, expected)
+	}()
+	go func() {
+		defer wg.Done()
+		prefetchedHash, _, blockhashErr = f.signer.GetLatestBlockhash(ctx, networkStr)
+	}()
+	wg.Wait()
+	if channelErr != nil {
+		return nil, x402.NewSettleError(ErrChannelState, uptoPayload.From, network, "", channelErr.Error())
+	}
+	if blockhashErr != nil {
+		return nil, x402.NewSettleError(ErrPaymentRequirements, uptoPayload.From, network, "", blockhashErr.Error())
 	}
 
 	// Deduplicate only once the channel is rebound, so replays and concurrent
@@ -611,14 +606,19 @@ func (f *UptoSvmScheme) settleClaim(
 			"a settlement for this channel is already in flight")
 	}
 
-	signature, err := f.submitClaim(ctx, rpcClient, feePayer, channel, claimArgs{
-		Network:          string(requirements.Network),
+	signature, err := f.submitClaim(ctx, feePayer, channel, claimArgs{
+		Network:          networkStr,
 		TokenProgram:     tokenProgram,
 		Actual:           actual,
 		ExpiresAt:        uptoPayload.ExpiresAt,
 		VoucherSignature: uptoPayload.VoucherSignature,
-	})
+	}, &prefetchedHash)
 	if err != nil {
+		var simErr *SettlementSimulationError
+		if errors.As(err, &simErr) {
+			f.settlementCache.Delete(settlementKey)
+			return nil, x402.NewSettleError(ErrSettlementSimulation, uptoPayload.From, network, "", simErr.Error())
+		}
 		// A non-empty signature means settle_and_seal + distribute broadcast
 		// successfully but ConfirmTransaction couldn't observe confirmation
 		// in time: leave the settlement dedup lock in place (a fresh submit
@@ -664,10 +664,10 @@ type claimArgs struct {
 
 func (f *UptoSvmScheme) submitClaim(
 	ctx context.Context,
-	rpcClient *rpc.Client,
 	feePayer solana.PublicKey,
 	channel *verifiedOpenChannel,
 	args claimArgs,
+	prefetchedBlockhash *solana.Hash,
 ) (string, error) {
 	// The program requires settled < cumulative_amount, so a zero charge seals
 	// without a voucher. The zero-amount voucher still authenticated this
@@ -689,10 +689,14 @@ func (f *UptoSvmScheme) submitClaim(
 		return "", err
 	}
 
-	return submitSettle(ctx, rpcClient, f.signer, feePayer, args.Network, instructions, submitSettleOptions{
+	opts := submitSettleOptions{
 		ComputeUnitLimit:              f.config.SettleComputeUnitLimit,
 		ComputeUnitPriceMicroLamports: f.config.ComputeUnitPriceMicroLamports,
-	})
+	}
+	if prefetchedBlockhash != nil {
+		opts.LatestBlockhash = prefetchedBlockhash
+	}
+	return submitSettle(ctx, f.signer, feePayer, args.Network, instructions, opts)
 }
 
 // openAuthorization is the validated open-authorization context shared by
@@ -927,11 +931,7 @@ func (f *UptoSvmScheme) resolveRecentSlot(
 		return slot, nil
 	}
 
-	rpcClient, err := f.rpcClient(string(requirements.Network))
-	if err != nil {
-		return 0, err
-	}
-	slot, err := rpcClient.GetSlot(ctx, upto.SlotCommitment)
+	slot, err := f.signer.GetSlot(ctx, string(requirements.Network), upto.SlotCommitment)
 	if err != nil {
 		return 0, fmt.Errorf("failed to fetch the current slot: %w", err)
 	}

--- a/go/mechanisms/svm/upto/facilitator/scheme_test.go
+++ b/go/mechanisms/svm/upto/facilitator/scheme_test.go
@@ -22,10 +22,7 @@ import (
 
 // newScheme wires a facilitator against the stub RPC.
 func newScheme(signer *mockSigner, stub *stubRPC, config *Config) *UptoSvmScheme {
-	if config == nil {
-		config = &Config{}
-	}
-	config.RPCURL = stub.url
+	signer.attachRPC(rpc.New(stub.url))
 	return NewUptoSvmScheme(signer, config)
 }
 
@@ -583,11 +580,6 @@ func TestSettleReadsEachRPCClassAtThePolicyCommitment(t *testing.T) {
 			method: "getSlot",
 			want:   upto.SlotCommitment,
 			reason: "the openSlot anchor must sit in the frame the client pinned",
-		},
-		{
-			method: "getLatestBlockhash",
-			want:   upto.BlockhashCommitment,
-			reason: "a finalized blockhash cannot be dropped by a fork",
 		},
 		{
 			method: "simulateTransaction",
@@ -1256,38 +1248,6 @@ func TestNewRentCleanupManagerSharesTheSchemeStorage(t *testing.T) {
 	injected := newScheme(signer, stub, &Config{ChannelStorage: storage})
 	assert.Same(t, storage, injected.ChannelStorage())
 	assert.Same(t, storage, injected.NewRentCleanupManager(testNetwork).storage)
-}
-
-// An injected client is how a facilitator routes sends through its own paced
-// or instrumented transport, so it has to win over RPCURL everywhere, not just
-// on the settle path.
-func TestAnInjectedRPCClientIsPreferredOverTheURL(t *testing.T) {
-	signer := newMockSigner(t, 1)
-	stub := newStubRPC(t)
-	fixture := newPaymentFixture(t, signer)
-	scheme := NewUptoSvmScheme(signer, &Config{
-		RPCURL: "http://127.0.0.1:1/unreachable",
-		RPC:    rpc.New(stub.url),
-	})
-	signer.onSend = func(*solana.Transaction) {
-		stub.setAccount(fixture.channelID.String(), fixture.openChannel().encode(t))
-	}
-
-	response, err := scheme.Settle(context.Background(), fixture.payload, fixture.requirements, nil)
-	require.NoError(t, err)
-	assert.True(t, response.Success, "the settle reached the stub, so the unreachable URL was never dialed")
-
-	assert.Same(t, scheme.config.RPC, scheme.NewRentCleanupManager(testNetwork).rpc,
-		"the manager inherits the scheme's client")
-}
-
-func TestTheSchemeBuildsAClientFromTheURLWhenNoneIsInjected(t *testing.T) {
-	scheme := newScheme(newMockSigner(t, 1), newStubRPC(t), nil)
-
-	client, err := scheme.rpcClient(testNetwork)
-	require.NoError(t, err)
-	assert.NotNil(t, client)
-	assert.Nil(t, scheme.NewRentCleanupManager(testNetwork).rpc)
 }
 
 // failingStorage rejects every write so storage-failure paths can be exercised.

--- a/go/mechanisms/svm/upto/facilitator/signer.go
+++ b/go/mechanisms/svm/upto/facilitator/signer.go
@@ -13,7 +13,8 @@ import (
 
 // UptoFacilitatorSigner is FacilitatorSvmSigner narrowed to the read and
 // simulate RPC the `upto` facilitator requires at runtime. Exact-only signers
-// omit the extra methods.
+// omit the extra methods. GetProgramAccounts is optional and only needed for
+// RentCleanupManager.Discover(); assertProgramAccountsSigner checks it.
 type UptoFacilitatorSigner interface {
 	svm.FacilitatorSvmSigner
 
@@ -31,12 +32,6 @@ type UptoFacilitatorSigner interface {
 		network string,
 		opts *rpc.SimulateTransactionOpts,
 	) error
-	GetProgramAccounts(
-		ctx context.Context,
-		network string,
-		programID solana.PublicKey,
-		opts *rpc.GetProgramAccountsOpts,
-	) (rpc.GetProgramAccountsResult, error)
 }
 
 // assertUptoFacilitatorSigner validates that signer exposes every RPC cap the
@@ -71,20 +66,28 @@ func assertUptoFacilitatorSigner(signer svm.FacilitatorSvmSigner, label string) 
 	return signer.(UptoFacilitatorSigner)
 }
 
+// programAccountsGetter is the optional discovery sweep cap. It is not part of
+// UptoFacilitatorSigner so NewUptoSvmScheme can construct without it.
+type programAccountsGetter interface {
+	GetProgramAccounts(
+		context.Context,
+		string,
+		solana.PublicKey,
+		*rpc.GetProgramAccountsOpts,
+	) (rpc.GetProgramAccountsResult, error)
+}
+
 // assertProgramAccountsSigner validates GetProgramAccounts for discovery sweeps.
-func assertProgramAccountsSigner(signer svm.FacilitatorSvmSigner, label string) UptoFacilitatorSigner {
-	uptoSigner := assertUptoFacilitatorSigner(signer, label)
-	type programAccountsGetter interface {
-		GetProgramAccounts(context.Context, string, solana.PublicKey, *rpc.GetProgramAccountsOpts) (rpc.GetProgramAccountsResult, error)
-	}
-	if _, ok := signer.(programAccountsGetter); !ok {
+func assertProgramAccountsSigner(signer svm.FacilitatorSvmSigner, label string) programAccountsGetter {
+	gpa, ok := signer.(programAccountsGetter)
+	if !ok {
 		panic(fmt.Sprintf("%s requires GetProgramAccounts on the signer", label))
 	}
-	return uptoSigner
+	return gpa
 }
 
 type programAccountsQuerier struct {
-	signer  UptoFacilitatorSigner
+	signer  programAccountsGetter
 	network string
 }
 

--- a/go/mechanisms/svm/upto/facilitator/signer.go
+++ b/go/mechanisms/svm/upto/facilitator/signer.go
@@ -1,0 +1,96 @@
+package facilitator
+
+import (
+	"context"
+	"fmt"
+
+	solana "github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/rpc"
+
+	"github.com/x402-foundation/x402/go/v2/mechanisms/svm"
+	"github.com/x402-foundation/x402/go/v2/mechanisms/svm/paymentchannels"
+)
+
+// UptoFacilitatorSigner is FacilitatorSvmSigner narrowed to the read and
+// simulate RPC the `upto` facilitator requires at runtime. Exact-only signers
+// omit the extra methods.
+type UptoFacilitatorSigner interface {
+	svm.FacilitatorSvmSigner
+
+	GetAccountInfo(
+		ctx context.Context,
+		account solana.PublicKey,
+		network string,
+		opts *rpc.GetAccountInfoOpts,
+	) (*rpc.GetAccountInfoResult, error)
+	GetLatestBlockhash(ctx context.Context, network string) (solana.Hash, uint64, error)
+	GetSlot(ctx context.Context, network string, commitment rpc.CommitmentType) (uint64, error)
+	SimulateTransactionWithOpts(
+		ctx context.Context,
+		tx *solana.Transaction,
+		network string,
+		opts *rpc.SimulateTransactionOpts,
+	) error
+	GetProgramAccounts(
+		ctx context.Context,
+		network string,
+		programID solana.PublicKey,
+		opts *rpc.GetProgramAccountsOpts,
+	) (rpc.GetProgramAccountsResult, error)
+}
+
+// assertUptoFacilitatorSigner validates that signer exposes every RPC cap the
+// `upto` facilitator needs at construction. Panics with a clear message when a
+// required method is missing.
+func assertUptoFacilitatorSigner(signer svm.FacilitatorSvmSigner, label string) UptoFacilitatorSigner {
+	type accountInfoGetter interface {
+		GetAccountInfo(context.Context, solana.PublicKey, string, *rpc.GetAccountInfoOpts) (*rpc.GetAccountInfoResult, error)
+	}
+	type blockhashGetter interface {
+		GetLatestBlockhash(context.Context, string) (solana.Hash, uint64, error)
+	}
+	type slotGetter interface {
+		GetSlot(context.Context, string, rpc.CommitmentType) (uint64, error)
+	}
+	type simWithOpts interface {
+		SimulateTransactionWithOpts(context.Context, *solana.Transaction, string, *rpc.SimulateTransactionOpts) error
+	}
+
+	if _, ok := signer.(accountInfoGetter); !ok {
+		panic(fmt.Sprintf("%s requires GetAccountInfo on the signer", label))
+	}
+	if _, ok := signer.(blockhashGetter); !ok {
+		panic(fmt.Sprintf("%s requires GetLatestBlockhash on the signer", label))
+	}
+	if _, ok := signer.(slotGetter); !ok {
+		panic(fmt.Sprintf("%s requires GetSlot on the signer", label))
+	}
+	if _, ok := signer.(simWithOpts); !ok {
+		panic(fmt.Sprintf("%s requires SimulateTransactionWithOpts on the signer", label))
+	}
+	return signer.(UptoFacilitatorSigner)
+}
+
+// assertProgramAccountsSigner validates GetProgramAccounts for discovery sweeps.
+func assertProgramAccountsSigner(signer svm.FacilitatorSvmSigner, label string) UptoFacilitatorSigner {
+	uptoSigner := assertUptoFacilitatorSigner(signer, label)
+	type programAccountsGetter interface {
+		GetProgramAccounts(context.Context, string, solana.PublicKey, *rpc.GetProgramAccountsOpts) (rpc.GetProgramAccountsResult, error)
+	}
+	if _, ok := signer.(programAccountsGetter); !ok {
+		panic(fmt.Sprintf("%s requires GetProgramAccounts on the signer", label))
+	}
+	return uptoSigner
+}
+
+type programAccountsQuerier struct {
+	signer  UptoFacilitatorSigner
+	network string
+}
+
+func (q programAccountsQuerier) GetProgramAccounts(
+	ctx context.Context,
+	opts *rpc.GetProgramAccountsOpts,
+) (rpc.GetProgramAccountsResult, error) {
+	return q.signer.GetProgramAccounts(ctx, q.network, paymentchannels.ProgramID, opts)
+}

--- a/go/mechanisms/svm/upto/facilitator/signer_test.go
+++ b/go/mechanisms/svm/upto/facilitator/signer_test.go
@@ -1,0 +1,74 @@
+package facilitator
+
+import (
+	"context"
+	"testing"
+
+	solana "github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/rpc"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/x402-foundation/x402/go/v2/mechanisms/svm"
+)
+
+// schemeOnlySigner implements every UptoFacilitatorSigner method and omits
+// GetProgramAccounts, so construction succeeds and Discover panics.
+type schemeOnlySigner struct{}
+
+func (schemeOnlySigner) GetAddresses(context.Context, string) []solana.PublicKey {
+	return nil
+}
+
+func (schemeOnlySigner) SignTransaction(context.Context, *solana.Transaction, solana.PublicKey, string) error {
+	return nil
+}
+
+func (schemeOnlySigner) SimulateTransaction(context.Context, *solana.Transaction, string) error {
+	return nil
+}
+
+func (schemeOnlySigner) SendTransaction(context.Context, *solana.Transaction, string) (solana.Signature, error) {
+	return solana.Signature{}, nil
+}
+
+func (schemeOnlySigner) ConfirmTransaction(context.Context, solana.Signature, string) error {
+	return nil
+}
+
+func (schemeOnlySigner) GetAccountInfo(context.Context, solana.PublicKey, string, *rpc.GetAccountInfoOpts) (*rpc.GetAccountInfoResult, error) {
+	return nil, nil
+}
+
+func (schemeOnlySigner) GetLatestBlockhash(context.Context, string) (solana.Hash, uint64, error) {
+	return solana.Hash{}, 0, nil
+}
+
+func (schemeOnlySigner) GetSlot(context.Context, string, rpc.CommitmentType) (uint64, error) {
+	return 0, nil
+}
+
+func (schemeOnlySigner) SimulateTransactionWithOpts(context.Context, *solana.Transaction, string, *rpc.SimulateTransactionOpts) error {
+	return nil
+}
+
+var (
+	_ svm.FacilitatorSvmSigner = schemeOnlySigner{}
+	_ UptoFacilitatorSigner    = schemeOnlySigner{}
+)
+
+func TestNewUptoSvmSchemeAllowsSignerWithoutGetProgramAccounts(t *testing.T) {
+	assert.NotPanics(t, func() {
+		NewUptoSvmScheme(schemeOnlySigner{}, nil)
+	})
+}
+
+func TestDiscoverRequiresGetProgramAccounts(t *testing.T) {
+	manager := NewRentCleanupManager(RentCleanupConfig{
+		Signer:  schemeOnlySigner{},
+		Storage: NewInMemoryChannelStorage(),
+		Network: testNetwork,
+	})
+	assert.PanicsWithValue(t, "RentCleanupManager.Discover requires GetProgramAccounts on the signer", func() {
+		_ = manager.Discover(context.Background(), DiscoveryOptions{})
+	})
+}

--- a/go/mechanisms/svm/upto/facilitator/utils_test.go
+++ b/go/mechanisms/svm/upto/facilitator/utils_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -36,6 +37,7 @@ type mockSigner struct {
 
 	keys []solana.PrivateKey
 	sent []*solana.Transaction
+	rpc  *rpc.Client
 
 	// sendErr, when set, fails every broadcast.
 	sendErr error
@@ -125,6 +127,71 @@ func (s *mockSigner) SendTransaction(
 
 func (s *mockSigner) ConfirmTransaction(_ context.Context, _ solana.Signature, _ string) error {
 	return s.confirmErr
+}
+
+func (s *mockSigner) attachRPC(client *rpc.Client) {
+	s.rpc = client
+}
+
+func (s *mockSigner) GetAccountInfo(
+	ctx context.Context,
+	account solana.PublicKey,
+	_ string,
+	opts *rpc.GetAccountInfoOpts,
+) (*rpc.GetAccountInfoResult, error) {
+	if s.rpc == nil {
+		return nil, errors.New("mock signer has no RPC client")
+	}
+	return s.rpc.GetAccountInfoWithOpts(ctx, account, opts)
+}
+
+func (s *mockSigner) GetLatestBlockhash(ctx context.Context, _ string) (solana.Hash, uint64, error) {
+	if s.rpc == nil {
+		return solana.Hash{}, 0, errors.New("mock signer has no RPC client")
+	}
+	latest, err := s.rpc.GetLatestBlockhash(ctx, upto.BlockhashCommitment)
+	if err != nil {
+		return solana.Hash{}, 0, err
+	}
+	return latest.Value.Blockhash, latest.Value.LastValidBlockHeight, nil
+}
+
+func (s *mockSigner) GetSlot(ctx context.Context, _ string, commitment rpc.CommitmentType) (uint64, error) {
+	if s.rpc == nil {
+		return 0, errors.New("mock signer has no RPC client")
+	}
+	return s.rpc.GetSlot(ctx, commitment)
+}
+
+func (s *mockSigner) SimulateTransactionWithOpts(
+	ctx context.Context,
+	tx *solana.Transaction,
+	_ string,
+	opts *rpc.SimulateTransactionOpts,
+) error {
+	if s.rpc == nil {
+		return errors.New("mock signer has no RPC client")
+	}
+	result, err := s.rpc.SimulateTransactionWithOpts(ctx, tx, opts)
+	if err != nil {
+		return fmt.Errorf("settlement simulation failed: %w", err)
+	}
+	if result != nil && result.Value != nil && result.Value.Err != nil {
+		return fmt.Errorf("settlement simulation failed: %v", result.Value.Err)
+	}
+	return nil
+}
+
+func (s *mockSigner) GetProgramAccounts(
+	ctx context.Context,
+	_ string,
+	programID solana.PublicKey,
+	opts *rpc.GetProgramAccountsOpts,
+) (rpc.GetProgramAccountsResult, error) {
+	if s.rpc == nil {
+		return nil, errors.New("mock signer has no RPC client")
+	}
+	return s.rpc.GetProgramAccountsWithOpts(ctx, programID, opts)
 }
 
 func (s *mockSigner) sentTransactions() []*solana.Transaction {

--- a/go/test/integration/svm_test.go
+++ b/go/test/integration/svm_test.go
@@ -209,6 +209,72 @@ func (s *realFacilitatorSvmSigner) ConfirmTransaction(ctx context.Context, signa
 	return fmt.Errorf("transaction confirmation timed out after %d attempts", svm.MaxConfirmAttempts)
 }
 
+func (s *realFacilitatorSvmSigner) GetAccountInfo(
+	ctx context.Context,
+	account solana.PublicKey,
+	network string,
+	opts *rpc.GetAccountInfoOpts,
+) (*rpc.GetAccountInfoResult, error) {
+	rpcClient, err := s.getRPC(ctx, network)
+	if err != nil {
+		return nil, err
+	}
+	return rpcClient.GetAccountInfoWithOpts(ctx, account, opts)
+}
+
+func (s *realFacilitatorSvmSigner) GetLatestBlockhash(ctx context.Context, network string) (solana.Hash, uint64, error) {
+	rpcClient, err := s.getRPC(ctx, network)
+	if err != nil {
+		return solana.Hash{}, 0, err
+	}
+	latest, err := rpcClient.GetLatestBlockhash(ctx, rpc.CommitmentFinalized)
+	if err != nil {
+		return solana.Hash{}, 0, err
+	}
+	return latest.Value.Blockhash, latest.Value.LastValidBlockHeight, nil
+}
+
+func (s *realFacilitatorSvmSigner) GetSlot(ctx context.Context, network string, commitment rpc.CommitmentType) (uint64, error) {
+	rpcClient, err := s.getRPC(ctx, network)
+	if err != nil {
+		return 0, err
+	}
+	return rpcClient.GetSlot(ctx, commitment)
+}
+
+func (s *realFacilitatorSvmSigner) SimulateTransactionWithOpts(
+	ctx context.Context,
+	tx *solana.Transaction,
+	network string,
+	opts *rpc.SimulateTransactionOpts,
+) error {
+	rpcClient, err := s.getRPC(ctx, network)
+	if err != nil {
+		return err
+	}
+	result, err := rpcClient.SimulateTransactionWithOpts(ctx, tx, opts)
+	if err != nil {
+		return fmt.Errorf("simulation failed: %w", err)
+	}
+	if result != nil && result.Value != nil && result.Value.Err != nil {
+		return fmt.Errorf("simulation failed: transaction would fail on-chain")
+	}
+	return nil
+}
+
+func (s *realFacilitatorSvmSigner) GetProgramAccounts(
+	ctx context.Context,
+	network string,
+	programID solana.PublicKey,
+	opts *rpc.GetProgramAccountsOpts,
+) (rpc.GetProgramAccountsResult, error) {
+	rpcClient, err := s.getRPC(ctx, network)
+	if err != nil {
+		return nil, err
+	}
+	return rpcClient.GetProgramAccountsWithOpts(ctx, programID, opts)
+}
+
 func (s *realFacilitatorSvmSigner) SimulateTransactionWithInnerInstructions(ctx context.Context, tx *solana.Transaction, network string) ([]rpc.InnerInstruction, error) {
 	rpcClient, err := s.getRPC(ctx, network)
 	if err != nil {

--- a/go/test/integration/svm_upto_test.go
+++ b/go/test/integration/svm_upto_test.go
@@ -117,9 +117,7 @@ func newUptoSvmStack(t *testing.T, ctx context.Context) *uptoSvmStack {
 	if err != nil {
 		t.Fatalf("Failed to create facilitator signer: %v", err)
 	}
-	uptoFacilitator := uptosvmfacilitator.NewUptoSvmScheme(facilitatorSigner, &uptosvmfacilitator.Config{
-		RPCURL: uptoSvmRPCURL(),
-	})
+	uptoFacilitator := uptosvmfacilitator.NewUptoSvmScheme(facilitatorSigner, nil)
 	facilitator := x402.Newx402Facilitator()
 	facilitator.Register([]x402.Network{svm.SolanaDevnetCAIP2}, uptoFacilitator)
 
@@ -627,9 +625,7 @@ func newUptoSvmStackWithForcedPendingSigner(t *testing.T, ctx context.Context) (
 		t.Fatalf("Failed to create facilitator signer: %v", err)
 	}
 	facilitatorSigner := &forcedPendingConfirmSigner{FacilitatorSvmSigner: realFacilitatorSigner}
-	uptoFacilitator := uptosvmfacilitator.NewUptoSvmScheme(facilitatorSigner, &uptosvmfacilitator.Config{
-		RPCURL: uptoSvmRPCURL(),
-	})
+	uptoFacilitator := uptosvmfacilitator.NewUptoSvmScheme(facilitatorSigner, nil)
 	facilitator := x402.Newx402Facilitator()
 	facilitator.Register([]x402.Network{svm.SolanaDevnetCAIP2}, uptoFacilitator)
 

--- a/typescript/.changeset/svm-upto-facilitator-perf.md
+++ b/typescript/.changeset/svm-upto-facilitator-perf.md
@@ -1,0 +1,5 @@
+---
+"@x402/svm": minor
+---
+
+Route SVM `upto` facilitator RPC through `toFacilitatorSvmSigner` instead of scheme config: claim settlement simulates before `skipPreflight` send, deposit composite sim uses `replaceRecentBlockhash` without an extra blockhash fetch, and claim overlaps channel read with blockhash prefetch. `UptoSvmFacilitatorConfig.rpc` / `rpcUrl` are removed — pass a paced RPC client or `{ defaultRpcUrl }` to the signer factory (#3183).

--- a/typescript/packages/mechanisms/svm/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/svm/src/exact/facilitator/scheme.ts
@@ -46,10 +46,12 @@ import {
 } from "../../utils";
 import {
   assertSmartWalletLimits,
+  assertSmartWalletVerifySigner,
   resolveAccountKeys,
   verifySmartWalletTransaction,
   verifyPostSettlement,
   type DecodedTransactionView,
+  type SmartWalletVerifySigner,
   type TransferCheckedInfo,
 } from "./smartWalletVerification";
 import { verifyRequiredSignatures } from "./signatureVerification";
@@ -267,25 +269,7 @@ export class ExactSvmScheme implements SchemeNetworkFacilitator {
         maxComputeUnits: this.options.smartWalletMaxComputeUnits,
         maxPriorityFeeMicroLamports: this.options.smartWalletMaxPriorityFeeMicroLamports,
       });
-
-      // fetchAddressLookupTables is required too: assertFeePayerIsolated can't
-      // inspect ALT-resolved accounts without it, so an ALT-using wallet would
-      // otherwise fail at verify time rather than at construction.
-      const required = [
-        "simulateTransactionWithInnerInstructions",
-        "getConfirmedTransactionInnerInstructions",
-        "getTokenAccountBalance",
-        "fetchAddressLookupTables",
-      ] as const;
-
-      for (const method of required) {
-        if (typeof (this.signer as Record<string, unknown>)[method] !== "function") {
-          throw new Error(
-            `enableSmartWalletVerification requires ${method} on the signer. ` +
-              `Use toFacilitatorSvmSigner() which provides all required methods.`,
-          );
-        }
-      }
+      assertSmartWalletVerifySigner(this.signer);
     }
   }
 
@@ -946,7 +930,7 @@ export class ExactSvmScheme implements SchemeNetworkFacilitator {
       const smartWalletResult = await verifySmartWalletTransaction(
         exactSvmPayload.transaction,
         requirements,
-        this.signer,
+        this.signer as SmartWalletVerifySigner,
         feePayer,
         signerAddresses,
         {

--- a/typescript/packages/mechanisms/svm/src/exact/facilitator/smartWalletVerification.ts
+++ b/typescript/packages/mechanisms/svm/src/exact/facilitator/smartWalletVerification.ts
@@ -41,6 +41,47 @@ export type SmartWalletLimits = {
 };
 
 /**
+ * {@link FacilitatorSvmSigner} narrowed to the optional caps Path 2
+ * (simulation-based smart wallet payment verification) requires at runtime.
+ */
+export type SmartWalletVerifySigner = FacilitatorSvmSigner & {
+  simulateTransactionWithInnerInstructions: NonNullable<
+    FacilitatorSvmSigner["simulateTransactionWithInnerInstructions"]
+  >;
+  getConfirmedTransactionInnerInstructions: NonNullable<
+    FacilitatorSvmSigner["getConfirmedTransactionInnerInstructions"]
+  >;
+  getTokenAccountBalance: NonNullable<FacilitatorSvmSigner["getTokenAccountBalance"]>;
+  fetchAddressLookupTables: NonNullable<FacilitatorSvmSigner["fetchAddressLookupTables"]>;
+};
+
+const SMART_WALLET_VERIFY_METHODS = [
+  "simulateTransactionWithInnerInstructions",
+  "getConfirmedTransactionInnerInstructions",
+  "getTokenAccountBalance",
+  "fetchAddressLookupTables",
+] as const satisfies readonly (keyof SmartWalletVerifySigner)[];
+
+/**
+ * Assert a facilitator signer exposes every optional cap smart wallet payment
+ * verification needs.
+ *
+ * @param signer - Facilitator signer to validate
+ * @param label - Scheme or component name for error messages
+ * @throws Error when a required capability is missing
+ */
+export function assertSmartWalletVerifySigner(
+  signer: FacilitatorSvmSigner,
+  label = "ExactSvmScheme",
+): asserts signer is SmartWalletVerifySigner {
+  for (const method of SMART_WALLET_VERIFY_METHODS) {
+    if (typeof signer[method] !== "function") {
+      throw new Error(`${label} requires ${method} on the signer.`);
+    }
+  }
+}
+
+/**
  * Rejects smart-wallet limits that cannot be compared safely.
  *
  * @param limits - Optional operator-provided compute budget caps
@@ -414,7 +455,7 @@ export type SmartWalletVerifyResult = VerifyResponse & {
  *
  * @param transactionBase64 - Base64 encoded transaction
  * @param requirements - Payment requirements to verify against
- * @param signer - Facilitator signer (must implement simulateTransactionWithInnerInstructions)
+ * @param signer - Facilitator signer (must implement simulation verification caps)
  * @param feePayerAddress - Facilitator fee payer address
  * @param signerAddresses - All facilitator signer addresses (for self-spend protection)
  * @param options - Optional operator-configurable limits
@@ -424,7 +465,7 @@ export type SmartWalletVerifyResult = VerifyResponse & {
 export async function verifySmartWalletTransaction(
   transactionBase64: string,
   requirements: PaymentRequirements,
-  signer: FacilitatorSvmSigner,
+  signer: SmartWalletVerifySigner,
   feePayerAddress: string,
   signerAddresses: readonly string[],
   options?: SmartWalletOptions,
@@ -480,14 +521,6 @@ export async function verifySmartWalletTransaction(
   }
 
   // 3. Simulate with inner instructions.
-  if (typeof signer.simulateTransactionWithInnerInstructions !== "function") {
-    return {
-      isValid: false,
-      invalidReason: Errors.ErrSmartWalletVerificationUnavailable,
-      payer: "",
-    };
-  }
-
   let simResult: SvmInnerInstructionsResult;
   try {
     simResult = await signer.simulateTransactionWithInnerInstructions(

--- a/typescript/packages/mechanisms/svm/src/index.ts
+++ b/typescript/packages/mechanisms/svm/src/index.ts
@@ -29,6 +29,9 @@ export { toClientSvmSigner, toFacilitatorSvmSigner } from "./signer";
 export type {
   ClientSvmSigner,
   FacilitatorSvmSigner,
+  FacilitatorAccountInfo,
+  FacilitatorProgramAccount,
+  FacilitatorSimulateTransactionOptions,
   FacilitatorRpcClient,
   FacilitatorRpcConfig,
   ClientSvmConfig,

--- a/typescript/packages/mechanisms/svm/src/payment-channels/discovery.ts
+++ b/typescript/packages/mechanisms/svm/src/payment-channels/discovery.ts
@@ -8,7 +8,7 @@
 
 import { address, type Address, type Base58EncodedBytes } from "@solana/kit";
 
-import type { ChannelRpc } from "../upto/facilitator/channel";
+import type { FacilitatorSvmSigner } from "../signer";
 import type { Channel } from "./generated/accounts/channel";
 import { getChannelDecoder } from "./generated/accounts/channel";
 import { PAYMENT_CHANNELS_PROGRAM_ID } from "./onchain";
@@ -35,33 +35,39 @@ export interface DiscoveredChannel {
  * by `getProgramAccounts` itself, which only lists accounts owned by the
  * program passed to it.
  *
- * @param rpc - RPC client
+ * @param signer - Facilitator signer with {@link FacilitatorSvmSigner.getProgramAccounts}
+ * @param network - CAIP-2 network identifier
  * @param rentPayer - Facilitator key to discover channels for (base58)
  * @param programId - Optional payment-channels program id override
  * @returns Validated discovered channels
  */
 export async function discoverChannelsByRentPayer(
-  rpc: ChannelRpc,
+  signer: Pick<FacilitatorSvmSigner, "getProgramAccounts">,
+  network: string,
   rentPayer: string,
   programId?: string,
 ): Promise<DiscoveredChannel[]> {
+  if (typeof signer.getProgramAccounts !== "function") {
+    throw new Error(
+      "discoverChannelsByRentPayer requires getProgramAccounts on the signer. " +
+        "Use toFacilitatorSvmSigner() which provides all required methods.",
+    );
+  }
   const program = address(programId ?? PAYMENT_CHANNELS_PROGRAM_ID);
-  const results = await rpc
-    .getProgramAccounts(program, {
-      commitment: "confirmed",
-      encoding: "base64",
-      filters: [
-        { dataSize: CHANNEL_ACCOUNT_SIZE },
-        {
-          memcmp: {
-            bytes: rentPayer as Base58EncodedBytes,
-            encoding: "base58",
-            offset: CHANNEL_RENT_PAYER_OFFSET,
-          },
+  const results = await signer.getProgramAccounts(network, program.toString(), {
+    commitment: "confirmed",
+    encoding: "base64",
+    filters: [
+      { dataSize: CHANNEL_ACCOUNT_SIZE },
+      {
+        memcmp: {
+          bytes: rentPayer as Base58EncodedBytes,
+          encoding: "base58",
+          offset: CHANNEL_RENT_PAYER_OFFSET,
         },
-      ],
-    })
-    .send();
+      },
+    ],
+  });
 
   const discovered: DiscoveredChannel[] = [];
   for (const result of results) {

--- a/typescript/packages/mechanisms/svm/src/signer.ts
+++ b/typescript/packages/mechanisms/svm/src/signer.ts
@@ -111,6 +111,24 @@ export type FacilitatorRpcCapabilities = {
   fetchMint(address: string): Promise<unknown>;
 };
 
+/** Options passed to {@link FacilitatorSvmSigner.simulateTransaction}. */
+export type FacilitatorSimulateTransactionOptions = {
+  /**
+   * When true, the RPC verifies signatures during simulation. Defaults to false
+   * because the fee-payer slot is often unsigned until settle.
+   */
+  sigVerify?: boolean;
+  /**
+   * When true, the RPC substitutes a fresh blockhash before simulating (for
+   * facilitator-built messages compiled against a placeholder). Defaults to false.
+   */
+  replaceRecentBlockhash?: boolean;
+  /** Simulation commitment. Defaults to `"confirmed"`. */
+  commitment?: string;
+  /** Wire encoding of the transaction. Defaults to `"base64"`. */
+  encoding?: string;
+};
+
 /**
  * Minimal facilitator signer interface for SVM operations.
  * Supports multiple signers for load balancing and high availability.
@@ -150,14 +168,19 @@ export type FacilitatorSvmSigner = {
 
   /**
    * Simulate a transaction to verify it would succeed onchain.
-   * Does not verify signatures (RPC `sigVerify` is off). Callers must verify
-   * required signatures themselves; the fee-payer slot may be unsigned.
+   * By default does not verify signatures (RPC `sigVerify` is off). Callers must
+   * verify required signatures themselves; the fee-payer slot may be unsigned.
    *
    * @param transaction - Base64 encoded transaction (may be partially signed)
    * @param network - CAIP-2 network identifier
+   * @param options - Optional simulation overrides
    * @throws Error if simulation fails
    */
-  simulateTransaction(transaction: string, network: string): Promise<void>;
+  simulateTransaction(
+    transaction: string,
+    network: string,
+    options?: FacilitatorSimulateTransactionOptions,
+  ): Promise<void>;
 
   /**
    * Send a signed transaction to the network
@@ -248,6 +271,61 @@ export type FacilitatorSvmSigner = {
     lookupTableAddresses: string[],
     network: string,
   ): Promise<Record<string, string[]>>;
+
+  /**
+   * Fetch one account's onchain data. Optional — required by the `upto` scheme;
+   * {@link toFacilitatorSvmSigner} provides an implementation.
+   */
+  getAccountInfo?(
+    accountAddress: string,
+    network: string,
+    options?: { commitment?: string; encoding?: string },
+  ): Promise<FacilitatorAccountInfo | null>;
+
+  /**
+   * Fetch a recent blockhash. Optional — required by the `upto` scheme;
+   * {@link toFacilitatorSvmSigner} provides an implementation.
+   */
+  getLatestBlockhash?(network: string): Promise<{
+    blockhash: string;
+    lastValidBlockHeight: bigint;
+  }>;
+
+  /**
+   * Fetch the current slot. Optional — required by the `upto` scheme;
+   * {@link toFacilitatorSvmSigner} provides an implementation.
+   */
+  getSlot?(network: string, commitment?: string): Promise<bigint>;
+
+  /**
+   * Scan program accounts. Optional — required only for `upto` rent-cleanup
+   * discovery sweeps; {@link toFacilitatorSvmSigner} provides an implementation.
+   */
+  getProgramAccounts?(
+    network: string,
+    programId: string,
+    config: {
+      commitment?: string;
+      encoding?: string;
+      filters?: readonly unknown[];
+    },
+  ): Promise<readonly FacilitatorProgramAccount[]>;
+};
+
+/** Account info returned by {@link FacilitatorSvmSigner.getAccountInfo}. */
+export type FacilitatorAccountInfo = {
+  data: [string, string] | string;
+  owner: string;
+  lamports: bigint;
+};
+
+/** One row from {@link FacilitatorSvmSigner.getProgramAccounts}. */
+export type FacilitatorProgramAccount = {
+  pubkey: Address;
+  account: {
+    data: [string, string];
+    owner: Address;
+  };
 };
 
 /**
@@ -482,15 +560,22 @@ export function toFacilitatorSvmSigner(
       return getBase64EncodedWireTransaction(fullySignedTx);
     },
 
-    simulateTransaction: async (transaction: string, network: string) => {
+    simulateTransaction: async (
+      transaction: string,
+      network: string,
+      options?: FacilitatorSimulateTransactionOptions,
+    ) => {
       const rpc = getRpcForNetwork(network);
       const result = await rpc
-        .simulateTransaction(transaction as never, {
-          sigVerify: false,
-          replaceRecentBlockhash: false,
-          commitment: "confirmed",
-          encoding: "base64",
-        })
+        .simulateTransaction(
+          transaction as never,
+          {
+            sigVerify: options?.sigVerify ?? false,
+            replaceRecentBlockhash: options?.replaceRecentBlockhash ?? false,
+            commitment: options?.commitment ?? "confirmed",
+            encoding: options?.encoding ?? "base64",
+          } as never,
+        )
         .send();
 
       if (result.value.err) {
@@ -641,6 +726,39 @@ export function toFacilitatorSvmSigner(
           `${ErrSmartWalletAltResolutionFailed}: ${error instanceof Error ? error.message : String(error)}`,
         );
       }
+    },
+
+    getAccountInfo: async (accountAddress, network, options) => {
+      const rpc = getRpcForNetwork(network);
+      const result = await rpc
+        .getAccountInfo(accountAddress as never, {
+          commitment: (options?.commitment ?? "confirmed") as never,
+          encoding: (options?.encoding ?? "base64") as never,
+        })
+        .send();
+      const value = result.value as FacilitatorAccountInfo | null;
+      return value;
+    },
+
+    getLatestBlockhash: async (network: string) => {
+      const rpc = getRpcForNetwork(network);
+      const result = await rpc.getLatestBlockhash({ commitment: "finalized" }).send();
+      return {
+        blockhash: result.value.blockhash,
+        lastValidBlockHeight: result.value.lastValidBlockHeight,
+      };
+    },
+
+    getSlot: async (network: string, commitment = "finalized") => {
+      const rpc = getRpcForNetwork(network);
+      return await rpc.getSlot({ commitment: commitment as never }).send();
+    },
+
+    getProgramAccounts: async (network, programId, config) => {
+      const rpc = getRpcForNetwork(network);
+      const response = await rpc.getProgramAccounts(programId as never, config as never).send();
+      const rows = (response as { value?: readonly FacilitatorProgramAccount[] }).value;
+      return rows ?? [];
     },
   };
 }

--- a/typescript/packages/mechanisms/svm/src/signer.ts
+++ b/typescript/packages/mechanisms/svm/src/signer.ts
@@ -756,9 +756,13 @@ export function toFacilitatorSvmSigner(
 
     getProgramAccounts: async (network, programId, config) => {
       const rpc = getRpcForNetwork(network);
-      const response = await rpc.getProgramAccounts(programId as never, config as never).send();
-      const rows = (response as { value?: readonly FacilitatorProgramAccount[] }).value;
-      return rows ?? [];
+      return await rpc
+        .getProgramAccounts(programId as Address, {
+          commitment: (config.commitment ?? "confirmed") as never,
+          encoding: "base64",
+          filters: config.filters as never,
+        })
+        .send();
     },
   };
 }

--- a/typescript/packages/mechanisms/svm/src/upto/facilitator/channel.ts
+++ b/typescript/packages/mechanisms/svm/src/upto/facilitator/channel.ts
@@ -50,8 +50,9 @@ import {
 } from "../../payment-channels/onchain";
 import type { ChannelSplit } from "../../payment-channels/open";
 import type { FacilitatorSvmSigner } from "../../signer";
-import { createRpcClient, TransactionOnchainFailureError } from "../../utils";
-import { BLOCKHASH_COMMITMENT, STATE_COMMITMENT } from "../shared";
+import { TransactionOnchainFailureError } from "../../utils";
+import { STATE_COMMITMENT } from "../shared";
+import type { UptoFacilitatorSigner } from "./signer";
 
 /** Payment-channels `AccountDiscriminator::Channel` (byte 0 is reserved for uninitialized accounts). */
 const CHANNEL_ACCOUNT_DISCRIMINATOR = 1;
@@ -105,21 +106,54 @@ export function reclaimComputeUnitLimit(channelCount: number): number {
 /** Signer capable of signing Solana transactions and raw Ed25519 messages. */
 export type UptoSvmSigner = TransactionSigner & MessagePartialSigner;
 
-/** RPC client shape used by the channel helpers. */
-export type ChannelRpc = ReturnType<typeof createRpcClient>;
+/** Placeholder blockhash for deposit composite sims (`replaceRecentBlockhash: true`). */
+const SIM_PLACEHOLDER_BLOCKHASH = "11111111111111111111111111111111" as Blockhash;
+
+/**
+ * Kit-compatible RPC adapter for generated account fetch helpers.
+ *
+ * @param signer - Upto facilitator signer
+ * @param network - CAIP-2 network identifier
+ * @returns Minimal RPC surface for {@link fetchMaybeChannel}
+ */
+export function accountFetchRpc(
+  signer: UptoFacilitatorSigner,
+  network: string,
+): Parameters<typeof fetchMaybeChannel>[0] {
+  return {
+    getAccountInfo: (
+      accountAddress: Address,
+      config?: { commitment?: string; encoding?: string },
+    ) => ({
+      send: async () => ({
+        context: { slot: 0n },
+        value: await signer.getAccountInfo(accountAddress.toString(), network, {
+          commitment: config?.commitment,
+          encoding: config?.encoding,
+        }),
+      }),
+    }),
+  } as Parameters<typeof fetchMaybeChannel>[0];
+}
 
 /**
  * Whether the channel account already exists onchain (open already broadcast).
  *
- * @param rpc - The RPC client
+ * @param signer - Facilitator signer with read RPC
+ * @param network - CAIP-2 network identifier
  * @param channelId - Channel PDA (base58)
  * @returns Whether the account exists
  */
-export async function channelExists(rpc: ChannelRpc, channelId: string): Promise<boolean> {
-  const info = await rpc
-    .getAccountInfo(address(channelId), { commitment: STATE_COMMITMENT, encoding: "base64" })
-    .send();
-  return info.value !== null;
+export async function channelExists(
+  signer: UptoFacilitatorSigner,
+  network: string,
+  channelId: string,
+): Promise<boolean> {
+  const info = await signer.getAccountInfo(channelId, network, {
+    commitment: STATE_COMMITMENT,
+    encoding: "base64",
+  });
+  return info !== null;
 }
 
 /** Challenge-bound terms that must match the confirmed channel account. */
@@ -150,16 +184,19 @@ export interface VerifiedOpenChannel {
 /**
  * Fetch and bind the confirmed channel account before resource execution.
  *
- * @param rpc - RPC client used to read the channel
+ * @param signer - Facilitator signer with read RPC
+ * @param network - CAIP-2 network identifier
  * @param channelId - Channel PDA
  * @param expected - Challenge-bound channel terms
  * @returns Verified channel facts for settlement
  */
 export async function fetchAndVerifyOpenChannel(
-  rpc: ChannelRpc,
+  signer: UptoFacilitatorSigner,
+  network: string,
   channelId: string,
   expected: ExpectedOpenChannel,
 ): Promise<VerifiedOpenChannel> {
+  const rpc = accountFetchRpc(signer, network);
   for (let attempt = 1; attempt <= CHANNEL_READ_MAX_ATTEMPTS; attempt++) {
     const account = await fetchMaybeChannel(rpc, address(channelId), {
       commitment: STATE_COMMITMENT,
@@ -336,14 +373,16 @@ export interface SettlementSimChannel {
  * `sigVerify: false`.
  *
  * @param feePayer - The fee-payer / channel payee signer
- * @param rpc - The RPC client
+ * @param signer - Facilitator signer (simulate RPC)
+ * @param network - CAIP-2 network identifier
  * @param args - Open transaction and challenge-bound channel terms
  * @param args.openTransactionBase64 - Client-signed open transaction
  * @param args.channel - Challenge-bound channel terms for settle/distribute
  */
 export async function simulateOpenSettleDistribute(
   feePayer: UptoSvmSigner,
-  rpc: ChannelRpc,
+  signer: Pick<FacilitatorSvmSigner, "simulateTransaction">,
+  network: string,
   args: {
     openTransactionBase64: string;
     channel: SettlementSimChannel;
@@ -400,7 +439,7 @@ export async function simulateOpenSettleDistribute(
     distribute,
   ];
 
-  await simulateInstructions(feePayer, rpc, instructions);
+  await simulateInstructions(feePayer, signer, network, instructions);
 }
 
 /** Options for {@link submitSettle}. */
@@ -418,12 +457,34 @@ export interface SubmitSettleOptions {
    * `DEFAULT_COMPUTE_UNIT_PRICE_MICROLAMPORTS` (1).
    */
   computeUnitPriceMicroLamports?: number | undefined;
+  /**
+   * Prefetched blockhash (e.g. from a parallel read in claim settle). When
+   * omitted, {@link submitSettle} fetches one via the signer.
+   */
+  latestBlockhash?: { blockhash: string; lastValidBlockHeight: bigint } | undefined;
+}
+
+/**
+ * Thrown by {@link submitSettle} when explicit simulation fails. The transaction
+ * is never broadcast.
+ */
+export class SettlementSimulationError extends Error {
+  /**
+   * Create the error for a settlement simulation failure.
+   *
+   * @param cause - Underlying simulation error
+   */
+  constructor(cause: unknown) {
+    super(cause instanceof Error ? cause.message : String(cause));
+    this.name = "SettlementSimulationError";
+  }
 }
 
 /**
  * Compile the settle+distribute instructions into a transaction signed by the
- * fee payer, broadcast it, and confirm. Other signers, such as the channel
- * payee on `settle_and_seal`, are carried by the instruction list.
+ * fee payer, simulate it, broadcast via the facilitator signer, and confirm.
+ * Other signers, such as the channel payee on `settle_and_seal`, are carried
+ * by the instruction list.
  *
  * The transaction is prefixed with a statically sized `SetComputeUnitLimit`
  * and an optional `SetComputeUnitPrice`. Static sizing keeps the time-critical
@@ -431,14 +492,19 @@ export interface SubmitSettleOptions {
  * operator-overridable for deployments outside the documented assumptions.
  *
  * @param feePayer - The fee-payer signer
- * @param rpc - The RPC client
+ * @param signer - Facilitator signer (blockhash, simulate, send, confirm)
+ * @param network - CAIP-2 network identifier
  * @param instructions - settle_and_seal (+ optional Ed25519 precompile) then distribute
  * @param options - Compute-budget options
  * @returns The broadcast signature
  */
 export async function submitSettle(
   feePayer: UptoSvmSigner,
-  rpc: ChannelRpc,
+  signer: Pick<
+    UptoFacilitatorSigner,
+    "getLatestBlockhash" | "simulateTransaction" | "sendTransaction" | "confirmTransaction"
+  >,
+  network: string,
   instructions: readonly ServerInstruction[],
   options: SubmitSettleOptions = {},
 ): Promise<Signature> {
@@ -452,9 +518,7 @@ export async function submitSettle(
       : []),
   ];
 
-  const { value: latestBlockhash } = await rpc
-    .getLatestBlockhash({ commitment: BLOCKHASH_COMMITMENT })
-    .send();
+  const latestBlockhash = options.latestBlockhash ?? (await signer.getLatestBlockhash(network));
   const message = pipe(
     createTransactionMessage({ version: 0 }),
     m => setTransactionMessageFeePayerSigner(feePayer, m),
@@ -470,17 +534,26 @@ export async function submitSettle(
   );
   const signed = await signTransactionMessageWithSigners(message);
   const wire = getBase64EncodedWireTransaction(signed);
-  const signature = await rpc.sendTransaction(wire, { encoding: "base64" }).send();
-  await confirmSignature(rpc, signature);
-  return signature;
+  try {
+    await signer.simulateTransaction(wire, network);
+  } catch (error) {
+    throw new SettlementSimulationError(error);
+  }
+  const signature = await signer.sendTransaction(wire, network);
+  try {
+    await signer.confirmTransaction(signature, network);
+  } catch (error) {
+    if (error instanceof TransactionOnchainFailureError) {
+      throw error;
+    }
+    throw new SettlementConfirmationTimeoutError(signature as Signature);
+  }
+  return signature as Signature;
 }
 
 /**
- * Thrown by {@link confirmSignature} when the polling budget elapses before
- * the transaction reaches `confirmed`. Distinct from an onchain rejection:
- * the transaction's fate is unknown, not failed — it may still land. Callers
- * must not treat this the same as a definite failure (e.g. must not assume
- * it is safe to retry the same settlement).
+ * Thrown by {@link submitSettle} when confirmation polling times out. Distinct
+ * from an onchain rejection: the transaction's fate is unknown, not failed.
  */
 export class SettlementConfirmationTimeoutError extends Error {
   /**
@@ -491,43 +564,6 @@ export class SettlementConfirmationTimeoutError extends Error {
   constructor(readonly signature: Signature) {
     super(`timed out waiting for tx ${signature} confirmation`);
     this.name = "SettlementConfirmationTimeoutError";
-  }
-}
-
-/**
- * Poll `getSignatureStatuses` until the signature reaches at least 'confirmed'.
- *
- * @param rpc - The RPC client
- * @param signature - The transaction signature
- * @param timeoutMs - Total time budget (default 30s)
- * @throws {SettlementConfirmationTimeoutError} If the timeout elapses with the outcome still unknown
- * @throws If the transaction failed onchain
- */
-export async function confirmSignature(
-  rpc: ChannelRpc,
-  signature: Signature,
-  timeoutMs = 30_000,
-): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  for (;;) {
-    const { value } = await rpc.getSignatureStatuses([signature]).send();
-    const status = value[0];
-    if (status) {
-      if (status.err) {
-        const errorStr = JSON.stringify(status.err, (_, v) =>
-          typeof v === "bigint" ? v.toString() : v,
-        );
-        throw new Error(`tx ${signature} failed onchain: ${errorStr}`);
-      }
-      const level = status.confirmationStatus;
-      if (level === undefined || level === null || level === "confirmed" || level === "finalized") {
-        return;
-      }
-    }
-    if (Date.now() >= deadline) {
-      throw new SettlementConfirmationTimeoutError(signature);
-    }
-    await new Promise(resolve => setTimeout(resolve, 1_000));
   }
 }
 
@@ -572,25 +608,24 @@ export function getChannelDistributionHash(splits: readonly ChannelSplit[]): Uin
  * open composite may carry a noop payer) and `replaceRecentBlockhash: true`.
  *
  * @param feePayer - The fee-payer signer
- * @param rpc - The RPC client
+ * @param signer - Facilitator signer (simulate RPC)
+ * @param network - CAIP-2 network identifier
  * @param instructions - Instructions to simulate
  */
 async function simulateInstructions(
   feePayer: UptoSvmSigner,
-  rpc: ChannelRpc,
+  signer: Pick<FacilitatorSvmSigner, "simulateTransaction">,
+  network: string,
   instructions: readonly Instruction[],
 ): Promise<void> {
-  const { value: latestBlockhash } = await rpc
-    .getLatestBlockhash({ commitment: BLOCKHASH_COMMITMENT })
-    .send();
   const message = pipe(
     createTransactionMessage({ version: 0 }),
     m => setTransactionMessageFeePayerSigner(feePayer, m),
     m =>
       setTransactionMessageLifetimeUsingBlockhash(
         {
-          blockhash: latestBlockhash.blockhash as Blockhash,
-          lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
+          blockhash: SIM_PLACEHOLDER_BLOCKHASH,
+          lastValidBlockHeight: 0n,
         },
         m,
       ),
@@ -598,18 +633,11 @@ async function simulateInstructions(
   );
   const signed = await partiallySignTransactionMessageWithSigners(message);
   const wire = getBase64EncodedWireTransaction(signed);
-  const result = await rpc
-    .simulateTransaction(wire, {
-      commitment: STATE_COMMITMENT,
-      encoding: "base64",
-      replaceRecentBlockhash: true,
-      sigVerify: false,
-    })
-    .send();
-  if (result.value.err) {
-    const errorStr = JSON.stringify(result.value.err, (_, v) =>
-      typeof v === "bigint" ? v.toString() : v,
+  try {
+    await signer.simulateTransaction(wire, network, { replaceRecentBlockhash: true });
+  } catch (error) {
+    throw new Error(
+      `zero-charge settlement simulation failed: ${error instanceof Error ? error.message : String(error)}`,
     );
-    throw new Error(`zero-charge settlement simulation failed: ${errorStr}`);
   }
 }

--- a/typescript/packages/mechanisms/svm/src/upto/facilitator/index.ts
+++ b/typescript/packages/mechanisms/svm/src/upto/facilitator/index.ts
@@ -9,7 +9,11 @@ export {
 } from "./scheme";
 export type { UptoChannelStorageErrorContext, UptoSvmFacilitatorConfig } from "./scheme";
 export { ErrSettlementPending } from "../../exact/facilitator/errors";
-export { ChannelOpenConfirmationError, SettlementConfirmationTimeoutError } from "./channel";
+export {
+  ChannelOpenConfirmationError,
+  SettlementConfirmationTimeoutError,
+  SettlementSimulationError,
+} from "./channel";
 export type { UptoSvmSigner } from "./channel";
 export { InMemoryUptoChannelStorage } from "./channelStorage";
 export type { UptoChannelRecord, UptoChannelStorage } from "./channelStorage";

--- a/typescript/packages/mechanisms/svm/src/upto/facilitator/rentCleanupManager.ts
+++ b/typescript/packages/mechanisms/svm/src/upto/facilitator/rentCleanupManager.ts
@@ -28,11 +28,11 @@ import {
 } from "../../payment-channels/onchain";
 import { OPEN_SLOT_WINDOW } from "../../payment-channels/open";
 import type { FacilitatorSigningCapabilities, FacilitatorSvmSigner } from "../../signer";
-import { createRpcClient } from "../../utils";
 import { BASIS_POINTS_DENOMINATOR, SLOT_COMMITMENT, STATE_COMMITMENT } from "../shared";
-import type { ChannelRpc, UptoSvmSigner } from "./channel";
-import { reclaimComputeUnitLimit, submitSettle } from "./channel";
+import type { UptoSvmSigner } from "./channel";
+import { accountFetchRpc, reclaimComputeUnitLimit, submitSettle } from "./channel";
 import type { UptoChannelRecord, UptoChannelStorage } from "./channelStorage";
+import { assertUptoFacilitatorSigner, type UptoFacilitatorSigner } from "./signer";
 
 /** Reclaim work item: storage key plus live rent_payer from the channel account. */
 interface ReclaimCandidate {
@@ -240,7 +240,6 @@ export interface UptoSvmRentCleanupManagerConfig {
   signer: FacilitatorSvmSigner;
   storage: UptoChannelStorage;
   network: Network;
-  rpcUrl?: string;
   /**
    * `SetComputeUnitPrice` (microlamports per compute unit) attached to cleanup
    * transactions; `0` omits the instruction. Defaults to
@@ -255,8 +254,6 @@ export interface UptoSvmRentCleanupManagerConfig {
    * (`reclaimComputeUnitLimit`) and are mint-independent.
    */
   settleComputeUnitLimit?: number;
-  /** Injected RPC client used instead of building one from `rpcUrl`. */
-  rpc?: ChannelRpc;
 }
 
 /**
@@ -266,14 +263,12 @@ export interface UptoSvmRentCleanupManagerConfig {
  * {@link cleanup}; the facilitator scheme never auto-starts this.
  */
 export class UptoSvmRentCleanupManager {
-  private readonly signer: FacilitatorSvmSigner;
+  private readonly signer: UptoFacilitatorSigner;
   private readonly getKitSigner: (feePayer: Address) => FacilitatorSigningCapabilities;
   private readonly storage: UptoChannelStorage;
   private readonly network: Network;
-  private readonly rpcUrl: string | undefined;
   private readonly computeUnitPriceMicroLamports: number | undefined;
   private readonly settleComputeUnitLimit: number | undefined;
-  private readonly rpc: ChannelRpc | undefined;
 
   private timer: ReturnType<typeof setInterval> | undefined;
   private discoveryTimer: ReturnType<typeof setInterval> | undefined;
@@ -311,20 +306,13 @@ export class UptoSvmRentCleanupManager {
    * @param config - Signer pool, channel storage, and network/RPC
    */
   constructor(config: UptoSvmRentCleanupManagerConfig) {
-    if (typeof config.signer.getSigner !== "function") {
-      throw new Error(
-        "UptoSvmRentCleanupManager requires getSigner on the signer. " +
-          "Use toFacilitatorSvmSigner() which provides all required methods.",
-      );
-    }
+    assertUptoFacilitatorSigner(config.signer, "UptoSvmRentCleanupManager");
     this.getKitSigner = config.signer.getSigner.bind(config.signer);
     this.signer = config.signer;
     this.storage = config.storage;
     this.network = config.network;
-    this.rpcUrl = config.rpcUrl;
     this.computeUnitPriceMicroLamports = config.computeUnitPriceMicroLamports;
     this.settleComputeUnitLimit = config.settleComputeUnitLimit;
-    this.rpc = config.rpc;
   }
 
   /**
@@ -440,7 +428,7 @@ export class UptoSvmRentCleanupManager {
     const maxClosesPerRun = resolveCleanupCount(opts.maxClosesPerRun, DEFAULT_MAX_CLOSES_PER_RUN);
     const abort = passAbort(this.abortController?.signal, opts.signal);
 
-    const rpc = this.rpc ?? createRpcClient(this.network, this.rpcUrl);
+    const rpc = accountFetchRpc(this.signer, this.network);
     const records = orderForScan(await this.storage.list(), this.scanCursor);
     this.scanCursor = "";
     const nowSecs = Math.floor(Date.now() / 1_000);
@@ -449,7 +437,7 @@ export class UptoSvmRentCleanupManager {
     let closesUsed = 0;
     const reclaimCandidates: ReclaimCandidate[] = [];
     const getCurrentSlot = async (): Promise<bigint> => {
-      currentSlot ??= await rpc.getSlot({ commitment: SLOT_COMMITMENT }).send();
+      currentSlot ??= await this.signer.getSlot(this.network, SLOT_COMMITMENT);
       return currentSlot;
     };
 
@@ -510,7 +498,6 @@ export class UptoSvmRentCleanupManager {
 
           const signature = await this.submitCloseOrDistribute(
             feePayerSigner,
-            rpc,
             record,
             live,
             status,
@@ -522,7 +509,7 @@ export class UptoSvmRentCleanupManager {
             transaction: signature,
             action: status === ChannelStatus.Open ? "abandon_close" : "distribute",
           });
-          await this.syncStorageAfterAction(rpc, record.channelId);
+          await this.syncStorageAfterAction(record.channelId);
           continue;
         }
 
@@ -548,7 +535,7 @@ export class UptoSvmRentCleanupManager {
       }
     }
 
-    await this.submitReclaimBatches(rpc, reclaimCandidates, {
+    await this.submitReclaimBatches(reclaimCandidates, {
       maxReclaimsPerTx,
       maxTxsPerSigner,
       abort,
@@ -565,7 +552,12 @@ export class UptoSvmRentCleanupManager {
    */
   private async runDiscovery(opts: RentDiscoveryOptions): Promise<void> {
     const abort = passAbort(this.abortController?.signal, opts.signal);
-    const rpc = this.rpc ?? createRpcClient(this.network, this.rpcUrl);
+    if (typeof this.signer.getProgramAccounts !== "function") {
+      throw new Error(
+        "UptoSvmRentCleanupManager.discover requires getProgramAccounts on the signer. " +
+          "Use toFacilitatorSvmSigner() which provides all required methods.",
+      );
+    }
 
     const known = new Set((await this.storage.list()).map(record => record.channelId));
     const discovered: string[] = [];
@@ -575,12 +567,12 @@ export class UptoSvmRentCleanupManager {
       abort.throwIfAborted();
       let found;
       try {
-        found = await discoverChannelsByRentPayer(rpc, managed);
+        found = await discoverChannelsByRentPayer(this.signer, this.network, managed);
       } catch (error) {
         opts.onError?.(error);
         continue;
       }
-      currentSlot ??= await rpc.getSlot({ commitment: SLOT_COMMITMENT }).send();
+      currentSlot ??= await this.signer.getSlot(this.network, SLOT_COMMITMENT);
 
       for (const { channelId, channel } of found) {
         if (known.has(channelId)) continue;
@@ -647,7 +639,6 @@ export class UptoSvmRentCleanupManager {
    * alone for Sealed.
    *
    * @param feePayerSigner - Channel feePayer / payee signer
-   * @param rpc - RPC client
    * @param record - Stored channel (must include payTo + tokenProgram)
    * @param live - Refetched channel account
    * @param status - Live status that selected this path
@@ -655,7 +646,6 @@ export class UptoSvmRentCleanupManager {
    */
   private async submitCloseOrDistribute(
     feePayerSigner: UptoSvmSigner,
-    rpc: ChannelRpc,
     record: UptoChannelRecord,
     live: Channel,
     status: ChannelStatus,
@@ -683,7 +673,7 @@ export class UptoSvmRentCleanupManager {
           ]
         : [distribute];
 
-    return submitSettle(feePayerSigner, rpc, instructions, {
+    return submitSettle(feePayerSigner, this.signer, this.network, instructions, {
       computeUnitLimit: this.settleComputeUnitLimit,
       computeUnitPriceMicroLamports: this.computeUnitPriceMicroLamports,
     });
@@ -692,10 +682,10 @@ export class UptoSvmRentCleanupManager {
   /**
    * After a close/distribute, delete the storage entry if the PDA is gone.
    *
-   * @param rpc - RPC client
    * @param channelId - Channel PDA
    */
-  private async syncStorageAfterAction(rpc: ChannelRpc, channelId: string): Promise<void> {
+  private async syncStorageAfterAction(channelId: string): Promise<void> {
+    const rpc = accountFetchRpc(this.signer, this.network);
     const maybe = await fetchMaybeChannel(rpc, address(channelId), {
       commitment: STATE_COMMITMENT,
     });
@@ -716,7 +706,6 @@ export class UptoSvmRentCleanupManager {
    * maxTxsPerSigner more reclaim throughput per pass, not a share of a fixed
    * pool.
    *
-   * @param rpc - RPC client
    * @param candidates - Distributed channels ready to reclaim
    * @param opts - Batch size, tx budget, callbacks
    * @param opts.maxReclaimsPerTx - Max reclaim instructions per transaction
@@ -726,7 +715,6 @@ export class UptoSvmRentCleanupManager {
    * @param opts.onError - Optional error callback
    */
   private async submitReclaimBatches(
-    rpc: ChannelRpc,
     candidates: ReclaimCandidate[],
     opts: {
       maxReclaimsPerTx: number;
@@ -747,7 +735,7 @@ export class UptoSvmRentCleanupManager {
 
     await Promise.all(
       Array.from(byRentPayer.entries()).map(([rentPayer, group]) =>
-        this.submitReclaimGroup(rpc, rentPayer, group, opts, { remaining: opts.maxTxsPerSigner }),
+        this.submitReclaimGroup(rentPayer, group, opts, { remaining: opts.maxTxsPerSigner }),
       ),
     );
   }
@@ -756,7 +744,6 @@ export class UptoSvmRentCleanupManager {
    * Submit one rent payer's reclaim batches sequentially, claiming a slot
    * from the shared budget before each attempt.
    *
-   * @param rpc - RPC client
    * @param rentPayer - Rent payer this group's channels share
    * @param group - This rent payer's reclaim candidates
    * @param opts - Batch size and callbacks
@@ -768,7 +755,6 @@ export class UptoSvmRentCleanupManager {
    * @param budget.remaining - Reclaim transactions this rent payer may submit
    */
   private async submitReclaimGroup(
-    rpc: ChannelRpc,
     rentPayer: string,
     group: ReclaimCandidate[],
     opts: {
@@ -801,6 +787,7 @@ export class UptoSvmRentCleanupManager {
 
       const batch = group.slice(i, i + opts.maxReclaimsPerTx);
       try {
+        const rpc = accountFetchRpc(this.signer, this.network);
         // Refetch each account immediately before acting (stale → skip).
         const liveBatch: ReclaimCandidate[] = [];
         for (const candidate of batch) {
@@ -825,10 +812,16 @@ export class UptoSvmRentCleanupManager {
             rentPayer: candidate.rentPayer,
           }),
         );
-        const signature = await submitSettle(feePayerSigner, rpc, instructions, {
-          computeUnitLimit: reclaimComputeUnitLimit(liveBatch.length),
-          computeUnitPriceMicroLamports: this.computeUnitPriceMicroLamports,
-        });
+        const signature = await submitSettle(
+          feePayerSigner,
+          this.signer,
+          this.network,
+          instructions,
+          {
+            computeUnitLimit: reclaimComputeUnitLimit(liveBatch.length),
+            computeUnitPriceMicroLamports: this.computeUnitPriceMicroLamports,
+          },
+        );
         opts.onReclaim?.({
           channelIds: liveBatch.map(c => c.channelId),
           transaction: signature,

--- a/typescript/packages/mechanisms/svm/src/upto/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/svm/src/upto/facilitator/scheme.ts
@@ -23,7 +23,6 @@ import { SettlementCache } from "../../settlement-cache";
 import type { FacilitatorSigningCapabilities, FacilitatorSvmSigner } from "../../signer";
 import { isUptoSvmPayload, type UptoSvmPayloadV2 } from "../../types";
 import {
-  createRpcClient,
   decodeTransactionFromPayload,
   recordPendingOrTerminal,
   transactionMessageHash,
@@ -44,9 +43,9 @@ import {
   ChannelOpenConfirmationError,
   fetchAndVerifyOpenChannel,
   SettlementConfirmationTimeoutError,
+  SettlementSimulationError,
   simulateOpenSettleDistribute,
   submitSettle,
-  type ChannelRpc,
   type UptoSvmSigner,
 } from "./channel";
 import {
@@ -54,6 +53,7 @@ import {
   type UptoChannelRecord,
   type UptoChannelStorage,
 } from "./channelStorage";
+import { assertUptoFacilitatorSigner, type UptoFacilitatorSigner } from "./signer";
 import { UptoSvmRentCleanupManager } from "./rentCleanupManager";
 
 /** Scheme-specific error returned when the settlement amount exceeds the ceiling. */
@@ -106,13 +106,6 @@ function assertLimit(name: string, value: number | undefined, min: number): void
 
 /** Optional configuration for the upto SVM facilitator. */
 export interface UptoSvmFacilitatorConfig {
-  /** Custom RPC URL (per-network defaults are used when omitted). */
-  rpcUrl?: string;
-  /**
-   * Injected RPC client used instead of building one from `rpcUrl`. Lets the
-   * host route channel sends through its own paced/instrumented transport.
-   */
-  rpc?: ChannelRpc;
   /**
    * Channel storage for rent cleanup. Defaults to in-memory storage.
    * Inject a durable implementation for multi-process facilitators.
@@ -227,6 +220,7 @@ export class UptoSvmScheme implements SchemeNetworkFacilitator {
   private readonly channelStorage: UptoChannelStorage;
   private readonly settlementCache = new SettlementCache();
   private readonly pendingStore: PendingSettlementStore;
+  private readonly signer: UptoFacilitatorSigner;
 
   private readonly getKitSigner: (feePayer: Address) => FacilitatorSigningCapabilities;
 
@@ -235,29 +229,24 @@ export class UptoSvmScheme implements SchemeNetworkFacilitator {
    *
    * @param signer - Facilitator signer (fee payers / channel rent payers /
    *   zero-share channel payees). `getExtra` randomly selects among
-   *   `signer.getAddresses()`. Must provide {@link FacilitatorSvmSigner.getSigner}.
-   * @param config - Optional RPC / channel-storage configuration
+   *   `signer.getAddresses()`. Must expose the optional read RPC caps
+   *   ({@link FacilitatorSvmSigner.getAccountInfo}, etc.) — typically via
+   *   {@link toFacilitatorSvmSigner}.
+   * @param config - Optional channel-storage configuration
    */
-  constructor(
-    private readonly signer: FacilitatorSvmSigner,
-    config: UptoSvmFacilitatorConfig = {},
-  ) {
-    if (typeof signer.getSigner !== "function") {
-      throw new Error(
-        "UptoSvmScheme requires getSigner on the signer. " +
-          "Use toFacilitatorSvmSigner() which provides all required methods.",
-      );
-    }
-    this.getKitSigner = signer.getSigner.bind(signer);
-    if (this.signer.getAddresses().length === 0) {
-      throw new Error("UptoSvmScheme requires at least one fee payer signer");
-    }
+  constructor(signer: FacilitatorSvmSigner, config: UptoSvmFacilitatorConfig = {}) {
     assertLimit("maxChannelLifetimeSecs", config.maxChannelLifetimeSecs, 1);
     assertLimit("maxPriorityFeeMicroLamports", config.maxPriorityFeeMicroLamports, 0);
     assertLimit("maxComputeUnits", config.maxComputeUnits, 1);
     assertLimit("maxRequiredSignatures", config.maxRequiredSignatures, 1);
     assertLimit("computeUnitPriceMicroLamports", config.computeUnitPriceMicroLamports, 0);
     assertLimit("settleComputeUnitLimit", config.settleComputeUnitLimit, 1);
+    assertUptoFacilitatorSigner(signer);
+    this.signer = signer;
+    this.getKitSigner = signer.getSigner.bind(signer);
+    if (this.signer.getAddresses().length === 0) {
+      throw new Error("UptoSvmScheme requires at least one fee payer signer");
+    }
     this.config = config;
     this.channelStorage = config.channelStorage ?? new InMemoryUptoChannelStorage();
     this.pendingStore = config.pendingSettlementStore ?? new InMemoryPendingSettlementStore();
@@ -274,20 +263,28 @@ export class UptoSvmScheme implements SchemeNetworkFacilitator {
 
   /**
    * Create a {@link UptoSvmRentCleanupManager} for the given network, wired to
-   * this scheme's signer pool and channel storage. Does not auto-start; call
+   * this scheme's channel storage. Does not auto-start; call
    * `manager.start(...)` or schedule `manager.cleanup()`.
    *
    * @param network - CAIP-2 network the manager should clean up
+   * @param options - Optional overrides (e.g. a cleanup-only signer on a slower RPC)
+   * @param options.signer - Facilitator signer for cleanup RPC (defaults to this scheme's signer)
    * @returns A rent cleanup manager for that network
    */
-  createRentCleanupManager(network: Network): UptoSvmRentCleanupManager {
+  createRentCleanupManager(
+    network: Network,
+    options?: { signer?: FacilitatorSvmSigner },
+  ): UptoSvmRentCleanupManager {
+    let cleanupSigner: UptoFacilitatorSigner = this.signer;
+    if (options?.signer) {
+      assertUptoFacilitatorSigner(options.signer, "UptoSvmRentCleanupManager");
+      cleanupSigner = options.signer;
+    }
     return new UptoSvmRentCleanupManager({
       computeUnitPriceMicroLamports: this.config.computeUnitPriceMicroLamports,
       network,
-      rpcUrl: this.config.rpcUrl,
       settleComputeUnitLimit: this.config.settleComputeUnitLimit,
-      rpc: this.config.rpc,
-      signer: this.signer,
+      signer: cleanupSigner,
       storage: this.channelStorage,
     });
   }
@@ -542,12 +539,12 @@ export class UptoSvmScheme implements SchemeNetworkFacilitator {
 
     const { channelConfig, feePayerSigner, maxAmount, tokenProgram } = auth.ctx;
     const feePayer = channelConfig.feePayer;
-    const rpc = this.config.rpc ?? createRpcClient(requirements.network, this.config.rpcUrl);
+    const network = requirements.network;
 
     // One authorization → one deposit open. A confirmed channel is replay or a
     // stranded prior open, not a supported re-bind path; handler failure after
     // a successful deposit uses the zero-amount cancel/refund settle instead.
-    if (await channelExists(rpc, p.channelId)) {
+    if (await channelExists(this.signer, network, p.channelId)) {
       return this.settleFailure(payload, ERR_CHANNEL_ALREADY_OPEN, p.from);
     }
 
@@ -567,12 +564,12 @@ export class UptoSvmScheme implements SchemeNetworkFacilitator {
     // Simulate open + settle + distribute before broadcast so settlement-account
     // failures reject without locking the deposit.
     try {
-      await simulateOpenSettleDistribute(feePayerSigner, rpc, {
+      await simulateOpenSettleDistribute(feePayerSigner, this.signer, network, {
         openTransactionBase64: p.openTransaction,
         channel: {
           channelId: p.channelId,
           mint: requirements.asset,
-          network: requirements.network,
+          network,
           payee: feePayer,
           payer: p.from,
           rentPayer: feePayer,
@@ -656,7 +653,7 @@ export class UptoSvmScheme implements SchemeNetworkFacilitator {
     }
 
     try {
-      await fetchAndVerifyOpenChannel(rpc, p.channelId, {
+      await fetchAndVerifyOpenChannel(this.signer, network, p.channelId, {
         authorizedSigner: channelConfig.receiverAuthorizer,
         deposit: maxAmount,
         gracePeriod: channelConfig.withdrawDelay,
@@ -807,20 +804,23 @@ export class UptoSvmScheme implements SchemeNetworkFacilitator {
       return this.settleFailure(payload, "invalid_upto_svm_payment_requirements", p.from);
     }
     const network = requirements.network;
-    const rpc = this.config.rpc ?? createRpcClient(network, this.config.rpcUrl);
+
+    const channelPromise = fetchAndVerifyOpenChannel(this.signer, network, p.channelId, {
+      authorizedSigner: channelConfig.receiverAuthorizer,
+      deposit: payloadMaxAmount,
+      gracePeriod: channelConfig.withdrawDelay,
+      mint: requirements.asset,
+      payee: channelConfig.feePayer,
+      payer: p.from,
+      rentPayer: channelConfig.feePayer,
+      splits: channelConfig.splits,
+    });
+    const blockhashPromise = this.signer.getLatestBlockhash(network);
 
     let channel: Awaited<ReturnType<typeof fetchAndVerifyOpenChannel>>;
+    let prefetchedBlockhash: { blockhash: string; lastValidBlockHeight: bigint };
     try {
-      channel = await fetchAndVerifyOpenChannel(rpc, p.channelId, {
-        authorizedSigner: channelConfig.receiverAuthorizer,
-        deposit: payloadMaxAmount,
-        gracePeriod: channelConfig.withdrawDelay,
-        mint: requirements.asset,
-        payee: channelConfig.feePayer,
-        payer: p.from,
-        rentPayer: channelConfig.feePayer,
-        splits: channelConfig.splits,
-      });
+      [channel, prefetchedBlockhash] = await Promise.all([channelPromise, blockhashPromise]);
     } catch (error) {
       return {
         success: false,
@@ -870,9 +870,10 @@ export class UptoSvmScheme implements SchemeNetworkFacilitator {
       });
 
       const instructions: ServerInstruction[] = [...settle, distribute];
-      const signature = await submitSettle(feePayerSigner, rpc, instructions, {
+      const signature = await submitSettle(feePayerSigner, this.signer, network, instructions, {
         computeUnitLimit: this.config.settleComputeUnitLimit,
         computeUnitPriceMicroLamports: this.config.computeUnitPriceMicroLamports,
+        latestBlockhash: prefetchedBlockhash,
       });
 
       // Settlement is confirmed onchain past this point; storage is cleanup
@@ -899,6 +900,17 @@ export class UptoSvmScheme implements SchemeNetworkFacilitator {
         payer: channel.payer,
       };
     } catch (error) {
+      if (error instanceof SettlementSimulationError) {
+        this.settlementCache.delete(settlementKey);
+        return {
+          success: false,
+          network: payload.accepted.network,
+          transaction: "",
+          errorReason: "invalid_upto_svm_settlement_simulation",
+          errorMessage: error.message,
+          payer: p.from,
+        };
+      }
       // A confirmation timeout leaves the transaction's fate unknown, not
       // failed: it may still land. The dedup entry is kept, not deleted, so
       // a caller retrying this claim cannot race a second settle_and_seal
@@ -1020,7 +1032,7 @@ export class UptoSvmScheme implements SchemeNetworkFacilitator {
       };
     }
 
-    const rpc = this.config.rpc ?? createRpcClient(requirements.network, this.config.rpcUrl);
+    const network = requirements.network;
     let openSlot: bigint;
     let recentSlot: bigint;
     let nonce: bigint;
@@ -1033,7 +1045,7 @@ export class UptoSvmScheme implements SchemeNetworkFacilitator {
           "requirements.extra.recentSlot",
         );
       } else {
-        recentSlot = await rpc.getSlot({ commitment: SLOT_COMMITMENT }).send();
+        recentSlot = await this.signer.getSlot(network, SLOT_COMMITMENT);
       }
     } catch {
       return {

--- a/typescript/packages/mechanisms/svm/src/upto/facilitator/signer.ts
+++ b/typescript/packages/mechanisms/svm/src/upto/facilitator/signer.ts
@@ -1,0 +1,39 @@
+import type { Address } from "@solana/kit";
+
+import type { FacilitatorSigningCapabilities, FacilitatorSvmSigner } from "../../signer";
+
+/**
+ * {@link FacilitatorSvmSigner} narrowed to the optional RPC caps the `upto`
+ * facilitator requires at runtime. Exact-only signers omit the read methods.
+ */
+export type UptoFacilitatorSigner = FacilitatorSvmSigner & {
+  getAccountInfo: NonNullable<FacilitatorSvmSigner["getAccountInfo"]>;
+  getLatestBlockhash: NonNullable<FacilitatorSvmSigner["getLatestBlockhash"]>;
+  getSlot: NonNullable<FacilitatorSvmSigner["getSlot"]>;
+  getSigner(feePayer: Address): FacilitatorSigningCapabilities;
+};
+
+/**
+ * Assert a facilitator signer exposes every optional cap `upto` needs.
+ *
+ * @param signer - Facilitator signer to validate
+ * @param label - Scheme or component name for error messages
+ * @throws Error when a required capability is missing
+ */
+export function assertUptoFacilitatorSigner(
+  signer: FacilitatorSvmSigner,
+  label = "UptoSvmScheme",
+): asserts signer is UptoFacilitatorSigner {
+  if (typeof signer.getSigner !== "function") {
+    throw new Error(`${label} requires getSigner on the signer.`);
+  }
+  if (typeof signer.getAccountInfo !== "function") {
+    throw new Error(`${label} requires getAccountInfo on the signer.`);
+  }
+  if (typeof signer.getLatestBlockhash !== "function") {
+    throw new Error(`${label} requires getLatestBlockhash on the signer.`);
+  }
+  if (typeof signer.getSlot !== "function") {
+    throw new Error(`${label} requires getSlot on the signer.`);
+  }
+}

--- a/typescript/packages/mechanisms/svm/src/utils.ts
+++ b/typescript/packages/mechanisms/svm/src/utils.ts
@@ -35,6 +35,7 @@ import {
 } from "./constants";
 import { DEFAULT_ASSETS, findDefaultAsset, getDefaultAsset } from "./defaultAssets";
 import type { ExactSvmPayloadV1 } from "./types";
+import { SLOT_COMMITMENT } from "./upto/shared";
 
 export { normalizeNetwork } from "./constants";
 
@@ -199,9 +200,9 @@ export async function resolveBlockhash(
  *
  * Prefers a server-provided slot carried in the 402 challenge
  * (`extra.recentSlot`) so the client needn't make its own RPC round-trip. Falls
- * back to `rpc.getSlot()` when the challenge omits it or contains a malformed
- * value. Default RPC commitment (`finalized`) keeps `openSlot <= clock.slot`
- * true when the open lands.
+ * back to `rpc.getSlot({ commitment: SLOT_COMMITMENT })` when the challenge
+ * omits it or contains a malformed value. Finalized commitment keeps
+ * `openSlot <= clock.slot` true when the open lands, matching the facilitator.
  *
  * @param rpc - RPC client used for the fallback fetch
  * @param requirements - The payment requirements (challenge) being paid
@@ -236,7 +237,7 @@ export async function resolveOpenSlot(
     }
   }
 
-  return await rpc.getSlot().send();
+  return await rpc.getSlot({ commitment: SLOT_COMMITMENT }).send();
 }
 
 /**

--- a/typescript/packages/mechanisms/svm/test/unit/discovery.test.ts
+++ b/typescript/packages/mechanisms/svm/test/unit/discovery.test.ts
@@ -6,7 +6,8 @@ import { discoverChannelsByRentPayer } from "../../src/payment-channels/discover
 import { getChannelEncoder } from "../../src/payment-channels/generated/accounts/channel";
 import { PAYMENT_CHANNELS_PROGRAM_ID } from "../../src/payment-channels/onchain";
 import { findPaymentChannelPda } from "../../src/payment-channels/open";
-import type { ChannelRpc } from "../../src/upto/facilitator/channel";
+import { SOLANA_DEVNET_CAIP2 } from "../../src/constants";
+import type { FacilitatorSvmSigner } from "../../src/signer";
 
 /**
  * Builds a channel account whose payer/payee/mint/authorizedSigner/salt/
@@ -57,32 +58,31 @@ async function validDiscoveryChannel(rentPayer: string): Promise<{ pda: string; 
 }
 
 /**
- * A stub RPC exposing only the `getProgramAccounts` shape discovery uses.
+ * A stub signer exposing only the `getProgramAccounts` shape discovery uses.
  *
  * @param rows - Canned getProgramAccounts rows to serve
- * @returns A ChannelRpc-compatible stub
+ * @returns A signer-compatible stub
  */
-function stubRpc(rows: { pubkey: string; owner: string; data: string }[]): ChannelRpc {
+function stubSigner(
+  rows: { pubkey: string; owner: string; data: string }[],
+): Pick<FacilitatorSvmSigner, "getProgramAccounts"> {
   return {
-    getProgramAccounts: vi.fn().mockReturnValue({
-      send: () =>
-        Promise.resolve(
-          rows.map(row => ({
-            account: { data: [row.data, "base64"], owner: row.owner },
-            pubkey: row.pubkey,
-          })),
-        ),
-    }),
-  } as unknown as ChannelRpc;
+    getProgramAccounts: vi.fn().mockResolvedValue(
+      rows.map(row => ({
+        account: { data: [row.data, "base64"] as [string, string], owner: row.owner as Address },
+        pubkey: row.pubkey as Address,
+      })),
+    ),
+  } as unknown as Pick<FacilitatorSvmSigner, "getProgramAccounts">;
 }
 
 describe("discoverChannelsByRentPayer", () => {
   it("accepts a validated account", async () => {
     const rentPayer = (await generateKeyPairSigner()).address;
     const { pda, data } = await validDiscoveryChannel(rentPayer);
-    const rpc = stubRpc([{ data, owner: PAYMENT_CHANNELS_PROGRAM_ID, pubkey: pda }]);
+    const signer = stubSigner([{ data, owner: PAYMENT_CHANNELS_PROGRAM_ID, pubkey: pda }]);
 
-    const discovered = await discoverChannelsByRentPayer(rpc, rentPayer);
+    const discovered = await discoverChannelsByRentPayer(signer, SOLANA_DEVNET_CAIP2, rentPayer);
 
     expect(discovered).toHaveLength(1);
     expect(discovered[0]?.channelId).toBe(pda);
@@ -93,9 +93,9 @@ describe("discoverChannelsByRentPayer", () => {
     const rentPayer = (await generateKeyPairSigner()).address;
     const { pda, data } = await validDiscoveryChannel(rentPayer);
     const wrongOwner = (await generateKeyPairSigner()).address;
-    const rpc = stubRpc([{ data, owner: wrongOwner, pubkey: pda }]);
+    const signer = stubSigner([{ data, owner: wrongOwner, pubkey: pda }]);
 
-    const discovered = await discoverChannelsByRentPayer(rpc, rentPayer);
+    const discovered = await discoverChannelsByRentPayer(signer, SOLANA_DEVNET_CAIP2, rentPayer);
 
     expect(discovered).toHaveLength(0);
   });
@@ -106,9 +106,9 @@ describe("discoverChannelsByRentPayer", () => {
     // The RPC provider claims this address matched, but the account's own
     // fields derive to a different PDA — never trust the filter alone.
     const wrongPubkey = (await generateKeyPairSigner()).address;
-    const rpc = stubRpc([{ data, owner: PAYMENT_CHANNELS_PROGRAM_ID, pubkey: wrongPubkey }]);
+    const signer = stubSigner([{ data, owner: PAYMENT_CHANNELS_PROGRAM_ID, pubkey: wrongPubkey }]);
 
-    const discovered = await discoverChannelsByRentPayer(rpc, rentPayer);
+    const discovered = await discoverChannelsByRentPayer(signer, SOLANA_DEVNET_CAIP2, rentPayer);
 
     expect(discovered).toHaveLength(0);
   });
@@ -116,7 +116,7 @@ describe("discoverChannelsByRentPayer", () => {
   it("rejects a malformed account", async () => {
     const rentPayer = (await generateKeyPairSigner()).address;
     const pda = (await generateKeyPairSigner()).address;
-    const rpc = stubRpc([
+    const signer = stubSigner([
       {
         data: Buffer.from([0x01, 0x02]).toString("base64"),
         owner: PAYMENT_CHANNELS_PROGRAM_ID,
@@ -124,18 +124,19 @@ describe("discoverChannelsByRentPayer", () => {
       },
     ]);
 
-    const discovered = await discoverChannelsByRentPayer(rpc, rentPayer);
+    const discovered = await discoverChannelsByRentPayer(signer, SOLANA_DEVNET_CAIP2, rentPayer);
 
     expect(discovered).toHaveLength(0);
   });
 
   it("filters onchain by account size and rent_payer offset", async () => {
     const rentPayer = (await generateKeyPairSigner()).address;
-    const rpc = stubRpc([]);
+    const signer = stubSigner([]);
 
-    await discoverChannelsByRentPayer(rpc, rentPayer);
+    await discoverChannelsByRentPayer(signer, SOLANA_DEVNET_CAIP2, rentPayer);
 
-    expect(rpc.getProgramAccounts).toHaveBeenCalledWith(
+    expect(signer.getProgramAccounts).toHaveBeenCalledWith(
+      SOLANA_DEVNET_CAIP2,
       PAYMENT_CHANNELS_PROGRAM_ID,
       expect.objectContaining({
         filters: [

--- a/typescript/packages/mechanisms/svm/test/unit/index.test.ts
+++ b/typescript/packages/mechanisms/svm/test/unit/index.test.ts
@@ -153,6 +153,11 @@ describe("@x402/svm", () => {
       confirmTransaction: async () => {},
     };
 
+    const uptoIncompleteSigner: FacilitatorSvmSigner = {
+      ...exactOnlySigner,
+      getSigner: () => ({ address: "11111111111111111111111111111111" as never }) as never,
+    };
+
     it("allows exact-only signers without getSigner", () => {
       expect(exactOnlySigner.getAddresses()).toHaveLength(1);
       expect(exactOnlySigner.getSigner).toBeUndefined();
@@ -162,9 +167,9 @@ describe("@x402/svm", () => {
       expect(() => new ExactSvmScheme(exactOnlySigner)).not.toThrow();
     });
 
-    it("accepts exact-only signers for UptoSvmScheme at compile time but rejects missing getSigner at runtime", () => {
-      expect(() => new UptoSvmScheme(exactOnlySigner)).toThrow(
-        "UptoSvmScheme requires getSigner on the signer",
+    it("accepts exact-only signers for UptoSvmScheme at compile time but rejects missing upto read RPC at runtime", () => {
+      expect(() => new UptoSvmScheme(uptoIncompleteSigner as never)).toThrow(
+        "UptoSvmScheme requires getAccountInfo on the signer",
       );
     });
 
@@ -172,7 +177,7 @@ describe("@x402/svm", () => {
       expect(
         () =>
           new UptoSvmRentCleanupManager({
-            signer: exactOnlySigner,
+            signer: uptoIncompleteSigner as never,
             storage: {
               upsert: async () => {},
               get: async () => undefined,
@@ -181,7 +186,7 @@ describe("@x402/svm", () => {
             },
             network: SOLANA_DEVNET_CAIP2,
           }),
-      ).toThrow("UptoSvmRentCleanupManager requires getSigner on the signer");
+      ).toThrow("UptoSvmRentCleanupManager requires getAccountInfo on the signer");
     });
   });
 

--- a/typescript/packages/mechanisms/svm/test/unit/signer.test.ts
+++ b/typescript/packages/mechanisms/svm/test/unit/signer.test.ts
@@ -293,8 +293,85 @@ describe("SVM Signer Converters", () => {
 
       expect(simulateTransaction).toHaveBeenCalledWith(
         "tx",
-        expect.objectContaining({ sigVerify: false }),
+        expect.objectContaining({
+          sigVerify: false,
+          commitment: "confirmed",
+          encoding: "base64",
+        }),
       );
+    });
+
+    it("should honor simulateTransaction options", async () => {
+      const mockSigner = {
+        address: "FacilitatorAddress1111111111111111111111" as never,
+        signTransactions: vi.fn() as never,
+        signMessages: vi.fn().mockResolvedValue([{}]) as never,
+      };
+
+      const simulateTransaction = vi.fn().mockReturnValue({
+        send: vi.fn().mockResolvedValue({ value: { err: null } }),
+      });
+      const mockRpc = {
+        getBalance: vi.fn(),
+        getSlot: vi.fn(),
+        simulateTransaction,
+      } as never;
+
+      const facilitator = toFacilitatorSvmSigner(mockSigner as never, mockRpc);
+      await facilitator.simulateTransaction("tx", SOLANA_DEVNET_CAIP2, {
+        sigVerify: true,
+        commitment: "finalized",
+        encoding: "base64",
+        replaceRecentBlockhash: true,
+      });
+
+      expect(simulateTransaction).toHaveBeenCalledWith("tx", {
+        sigVerify: true,
+        replaceRecentBlockhash: true,
+        commitment: "finalized",
+        encoding: "base64",
+      });
+    });
+
+    it("should honor replaceRecentBlockhash on simulate", async () => {
+      const mockSigner = {
+        address: "FacilitatorAddress1111111111111111111" as never,
+        signTransactions: vi.fn() as never,
+        signMessages: vi.fn().mockResolvedValue([{}]) as never,
+      };
+
+      const simulateTransaction = vi.fn().mockReturnValue({
+        send: vi.fn().mockResolvedValue({ value: { err: null } }),
+      });
+      const mockRpc = {
+        getBalance: vi.fn(),
+        getSlot: vi.fn(),
+        simulateTransaction,
+      } as never;
+
+      const facilitator = toFacilitatorSvmSigner(mockSigner as never, mockRpc);
+      await facilitator.simulateTransaction("tx", SOLANA_DEVNET_CAIP2, {
+        replaceRecentBlockhash: true,
+      });
+
+      expect(simulateTransaction).toHaveBeenCalledWith(
+        "tx",
+        expect.objectContaining({ replaceRecentBlockhash: true }),
+      );
+    });
+
+    it("should expose upto read RPC helpers from the factory", () => {
+      const mockSigner = {
+        address: "FacilitatorAddress1111111111111111111" as never,
+        signTransactions: vi.fn() as never,
+        signMessages: vi.fn().mockResolvedValue([{}]) as never,
+      };
+
+      const facilitator = toFacilitatorSvmSigner(mockSigner as never);
+      expect(facilitator.getAccountInfo).toBeDefined();
+      expect(facilitator.getLatestBlockhash).toBeDefined();
+      expect(facilitator.getSlot).toBeDefined();
+      expect(facilitator.getProgramAccounts).toBeDefined();
     });
 
     it("should send with skipPreflight enabled", async () => {

--- a/typescript/packages/mechanisms/svm/test/unit/signer.test.ts
+++ b/typescript/packages/mechanisms/svm/test/unit/signer.test.ts
@@ -374,6 +374,44 @@ describe("SVM Signer Converters", () => {
       expect(facilitator.getProgramAccounts).toBeDefined();
     });
 
+    it("should return the kit getProgramAccounts array without a context unwrap", async () => {
+      const mockSigner = {
+        address: "FacilitatorAddress1111111111111111111" as never,
+        signTransactions: vi.fn() as never,
+        signMessages: vi.fn().mockResolvedValue([{}]) as never,
+      };
+
+      const rows = [
+        {
+          pubkey: "ChannelPda11111111111111111111111111111111",
+          account: {
+            data: ["AQID", "base64"] as [string, string],
+            owner: "Program1111111111111111111111111111111111",
+          },
+        },
+      ];
+      const getProgramAccounts = vi.fn().mockReturnValue({
+        send: vi.fn().mockResolvedValue(rows),
+      });
+      const mockRpc = {
+        getBalance: vi.fn(),
+        getSlot: vi.fn(),
+        getProgramAccounts,
+      } as never;
+
+      const facilitator = toFacilitatorSvmSigner(mockSigner as never, mockRpc);
+      const result = await facilitator.getProgramAccounts!(SOLANA_DEVNET_CAIP2, "program", {
+        commitment: "confirmed",
+        encoding: "base64",
+      });
+
+      expect(result).toEqual(rows);
+      expect(getProgramAccounts).toHaveBeenCalledWith(
+        "program",
+        expect.objectContaining({ commitment: "confirmed", encoding: "base64" }),
+      );
+    });
+
     it("should send with skipPreflight enabled", async () => {
       const mockSigner = {
         address: "FacilitatorAddress1111111111111111111" as never,

--- a/typescript/packages/mechanisms/svm/test/unit/smartWalletVerification.test.ts
+++ b/typescript/packages/mechanisms/svm/test/unit/smartWalletVerification.test.ts
@@ -885,7 +885,7 @@ describe("ExactSvmScheme constructor enforcement", () => {
         new ExactSvmScheme(incompleteSigner as never, undefined, {
           enableSmartWalletVerification: true,
         }),
-    ).toThrow("enableSmartWalletVerification requires");
+    ).toThrow("ExactSvmScheme requires simulateTransactionWithInnerInstructions on the signer");
   });
 
   it("throws when signer has the other methods but lacks fetchAddressLookupTables", async () => {
@@ -912,7 +912,7 @@ describe("ExactSvmScheme constructor enforcement", () => {
         new ExactSvmScheme(signerMissingAlt as never, undefined, {
           enableSmartWalletVerification: true,
         }),
-    ).toThrow("enableSmartWalletVerification requires fetchAddressLookupTables");
+    ).toThrow("ExactSvmScheme requires fetchAddressLookupTables on the signer");
   });
 
   it("succeeds when signer has all required methods", async () => {

--- a/typescript/packages/mechanisms/svm/test/unit/upto.channel.test.ts
+++ b/typescript/packages/mechanisms/svm/test/unit/upto.channel.test.ts
@@ -21,12 +21,14 @@ vi.mock("../../src/payment-channels/generated/accounts/channel", async importOri
 import {
   fetchAndVerifyOpenChannel,
   getChannelDistributionHash,
-  type ChannelRpc,
   type ExpectedOpenChannel,
 } from "../../src/upto/facilitator/channel";
+import { SOLANA_DEVNET_CAIP2 } from "../../src/constants";
+import type { UptoFacilitatorSigner } from "../../src/upto/facilitator/signer";
 
 const CHANNEL_ID = USDC_MAINNET_ADDRESS;
-const rpc = {} as ChannelRpc;
+const signer = {} as UptoFacilitatorSigner;
+const NETWORK = SOLANA_DEVNET_CAIP2;
 const PAYEE = USDC_DEVNET_ADDRESS;
 const PAYER = USDC_MAINNET_ADDRESS;
 const AUTHORIZED_SIGNER = USDC_DEVNET_ADDRESS;
@@ -87,7 +89,7 @@ describe("upto SVM channel reads", () => {
       .mockResolvedValueOnce(missingAccount)
       .mockResolvedValueOnce(existingAccount);
 
-    const result = fetchAndVerifyOpenChannel(rpc, CHANNEL_ID, expected);
+    const result = fetchAndVerifyOpenChannel(signer, NETWORK, CHANNEL_ID, expected);
     await vi.advanceTimersByTimeAsync(200);
 
     await expect(result).resolves.toMatchObject({ channelId: CHANNEL_ID });
@@ -98,7 +100,7 @@ describe("upto SVM channel reads", () => {
     vi.useFakeTimers();
     channelAccountMocks.fetchMaybeChannel.mockResolvedValue(missingAccount);
 
-    const result = fetchAndVerifyOpenChannel(rpc, CHANNEL_ID, expected);
+    const result = fetchAndVerifyOpenChannel(signer, NETWORK, CHANNEL_ID, expected);
     const assertion = expect(result).rejects.toThrow(`channel ${CHANNEL_ID} does not exist`);
     await vi.advanceTimersByTimeAsync(3_000);
 
@@ -112,7 +114,7 @@ describe("upto SVM channel reads", () => {
       data: { ...channel, status: 1 },
     });
 
-    await expect(fetchAndVerifyOpenChannel(rpc, CHANNEL_ID, expected)).rejects.toThrow(
+    await expect(fetchAndVerifyOpenChannel(signer, NETWORK, CHANNEL_ID, expected)).rejects.toThrow(
       `channel ${CHANNEL_ID} is not open`,
     );
     expect(channelAccountMocks.fetchMaybeChannel).toHaveBeenCalledTimes(1);

--- a/typescript/packages/mechanisms/svm/test/unit/upto.facilitator.test.ts
+++ b/typescript/packages/mechanisms/svm/test/unit/upto.facilitator.test.ts
@@ -30,6 +30,18 @@ vi.mock("../../src/utils", async () => {
     ...actual,
     createRpcClient: () => ({
       getSlot: () => ({ send: async () => 123_456_789n }),
+      getLatestBlockhash: () => ({
+        send: async () => ({
+          value: { blockhash: USDC_MAINNET_ADDRESS, lastValidBlockHeight: 1n },
+        }),
+      }),
+      getAccountInfo: () => ({ send: async () => ({ value: null }) }),
+      getProgramAccounts: () => ({ send: async () => [] }),
+      simulateTransaction: () => ({ send: async () => ({ value: { err: null } }) }),
+      sendTransaction: () => ({ send: async () => USDC_MAINNET_ADDRESS }),
+      getSignatureStatuses: () => ({
+        send: async () => ({ value: [{ err: null, confirmationStatus: "confirmed" }] }),
+      }),
     }),
   };
 });
@@ -49,7 +61,10 @@ import {
   UptoSvmScheme,
 } from "../../src/upto/facilitator/scheme";
 import { ErrSettlementPending } from "../../src/exact/facilitator/errors";
-import { SettlementConfirmationTimeoutError } from "../../src/upto/facilitator/channel";
+import {
+  SettlementConfirmationTimeoutError,
+  SettlementSimulationError,
+} from "../../src/upto/facilitator/channel";
 import type { UptoChannelStorage } from "../../src/upto/facilitator/channelStorage";
 import { UptoSvmRentCleanupManager } from "../../src/upto/facilitator/rentCleanupManager";
 import type { UptoSvmPayloadV2 } from "../../src/types";
@@ -180,8 +195,12 @@ describe("UptoSvmScheme facilitator channel lifecycle", () => {
     expect(channelMocks.submitSettle).toHaveBeenCalledWith(
       expect.anything(),
       expect.anything(),
+      SOLANA_DEVNET_CAIP2,
       expect.anything(),
-      { computeUnitLimit: 123_456, computeUnitPriceMicroLamports: 7 },
+      expect.objectContaining({
+        computeUnitLimit: 123_456,
+        computeUnitPriceMicroLamports: 7,
+      }),
     );
   });
 
@@ -377,6 +396,7 @@ describe("UptoSvmScheme facilitator channel lifecycle", () => {
     expect(channelMocks.simulateOpenSettleDistribute).toHaveBeenCalledWith(
       expect.anything(),
       expect.anything(),
+      SOLANA_DEVNET_CAIP2,
       expect.objectContaining({
         openTransactionBase64: uptoPayload.openTransaction,
         channel: expect.objectContaining({
@@ -1075,22 +1095,24 @@ describe("UptoSvmScheme facilitator channel lifecycle", () => {
       });
     });
 
-    it("throws when UptoSvmScheme is constructed with a signer lacking getSigner", () => {
+    it("throws when UptoSvmScheme is constructed with a signer lacking upto read RPC", () => {
       const exactOnlySigner: FacilitatorSvmSigner = {
         getAddresses: () => ["11111111111111111111111111111111" as never],
+        getSigner: vi.fn(),
         signTransaction: vi.fn(),
         simulateTransaction: vi.fn(),
         sendTransaction: vi.fn(),
         confirmTransaction: vi.fn(),
       };
-      expect(() => new UptoSvmScheme(exactOnlySigner)).toThrow(
-        "UptoSvmScheme requires getSigner on the signer",
+      expect(() => new UptoSvmScheme(exactOnlySigner as never)).toThrow(
+        "UptoSvmScheme requires getAccountInfo on the signer",
       );
     });
 
-    it("throws when UptoSvmRentCleanupManager is constructed with a signer lacking getSigner", () => {
+    it("throws when UptoSvmRentCleanupManager is constructed with a signer lacking upto read RPC", () => {
       const exactOnlySigner: FacilitatorSvmSigner = {
         getAddresses: () => ["11111111111111111111111111111111" as never],
+        getSigner: vi.fn(),
         signTransaction: vi.fn(),
         simulateTransaction: vi.fn(),
         sendTransaction: vi.fn(),
@@ -1099,11 +1121,33 @@ describe("UptoSvmScheme facilitator channel lifecycle", () => {
       expect(
         () =>
           new UptoSvmRentCleanupManager({
-            signer: exactOnlySigner,
+            signer: exactOnlySigner as never,
             storage: { upsert: vi.fn(), get: vi.fn(), list: vi.fn(), delete: vi.fn() },
             network: SOLANA_DEVNET_CAIP2,
           }),
-      ).toThrow("UptoSvmRentCleanupManager requires getSigner on the signer");
+      ).toThrow("UptoSvmRentCleanupManager requires getAccountInfo on the signer");
+    });
+
+    it("returns invalid_upto_svm_settlement_simulation when claim submitSettle simulation fails", async () => {
+      const { facilitator, payload, requirements, receiverAuthorizer, uptoPayload } =
+        await buildFixture();
+      channelMocks.submitSettle.mockRejectedValue(
+        new SettlementSimulationError(new Error("sim failed")),
+      );
+      const voucherSignature = await signVoucher(receiverAuthorizer, {
+        channelId: uptoPayload.channelId,
+        cumulativeAmount: 0n,
+        expiresAt: BigInt(uptoPayload.expiresAt),
+      });
+      await expect(
+        facilitator.settle(
+          { ...payload, payload: { ...uptoPayload, voucherSignature } },
+          { ...requirements, amount: "0" },
+        ),
+      ).resolves.toMatchObject({
+        success: false,
+        errorReason: "invalid_upto_svm_settlement_simulation",
+      });
     });
   });
 });

--- a/typescript/packages/mechanisms/svm/test/unit/upto.pendingSettlement.test.ts
+++ b/typescript/packages/mechanisms/svm/test/unit/upto.pendingSettlement.test.ts
@@ -34,6 +34,11 @@ vi.mock("../../src/utils", async () => {
     ...actual,
     createRpcClient: () => ({
       getSlot: () => ({ send: async () => 123_456_789n }),
+      getLatestBlockhash: () => ({
+        send: async () => ({
+          value: { blockhash: USDC_MAINNET_ADDRESS, lastValidBlockHeight: 1n },
+        }),
+      }),
     }),
   };
 });

--- a/typescript/packages/mechanisms/svm/test/unit/upto.rentCleanup.test.ts
+++ b/typescript/packages/mechanisms/svm/test/unit/upto.rentCleanup.test.ts
@@ -248,7 +248,7 @@ describe("UptoSvmRentCleanupManager — cleanup", () => {
       expect.objectContaining({ channelId: record.channelId, action: "abandon_close" }),
     );
     expect(submitSettleMock).toHaveBeenCalledTimes(1);
-    const instructions = submitSettleMock.mock.calls[0]![2] as unknown[];
+    const instructions = submitSettleMock.mock.calls[0]![3] as unknown[];
     expect(instructions.length).toBeGreaterThanOrEqual(2);
     expect(await storage.get(record.channelId)).toBeUndefined();
   });
@@ -280,7 +280,7 @@ describe("UptoSvmRentCleanupManager — cleanup", () => {
     expect(onClose).toHaveBeenCalledWith(
       expect.objectContaining({ channelId: record.channelId, action: "distribute" }),
     );
-    const instructions = submitSettleMock.mock.calls[0]![2] as unknown[];
+    const instructions = submitSettleMock.mock.calls[0]![3] as unknown[];
     expect(instructions).toHaveLength(1);
   });
 
@@ -319,11 +319,11 @@ describe("UptoSvmRentCleanupManager — cleanup", () => {
     expect(onReclaim.mock.calls[0]![0].channelIds).toEqual(
       expect.arrayContaining([a.channelId, b.channelId]),
     );
-    const instructions = submitSettleMock.mock.calls[0]![2] as { data: Uint8Array }[];
+    const instructions = submitSettleMock.mock.calls[0]![3] as { data: Uint8Array }[];
     expect(instructions).toHaveLength(2);
     expect(instructions.every(ix => ix.data[0] === RECLAIM_DISCRIMINATOR)).toBe(true);
     // Reclaim batches carry a per-channel compute-unit limit (base + 2 × per-channel).
-    expect(submitSettleMock.mock.calls[0]![3]).toMatchObject({ computeUnitLimit: 35_000 });
+    expect(submitSettleMock.mock.calls[0]![4]).toMatchObject({ computeUnitLimit: 35_000 });
     expect(await storage.get(a.channelId)).toBeUndefined();
     expect(await storage.get(b.channelId)).toBeUndefined();
   });
@@ -657,6 +657,14 @@ function multiKeySigner(
       if (!signer) throw new Error(`no signer for feePayer ${feePayer}`);
       return signer as unknown as TransactionSigner & { signMessages: never };
     },
+    getAccountInfo: vi.fn(),
+    getLatestBlockhash: vi.fn(),
+    getSlot: vi.fn().mockImplementation(() => getSlotMock()),
+    getProgramAccounts: vi.fn(),
+    signTransaction: vi.fn(),
+    simulateTransaction: vi.fn(),
+    sendTransaction: vi.fn(),
+    confirmTransaction: vi.fn(),
   } as FacilitatorSvmSigner;
 }
 
@@ -706,7 +714,7 @@ describe("UptoSvmRentCleanupManager — onchain discovery", () => {
     const onDiscover = vi.fn();
     await manager.discover({ onDiscover });
 
-    expect(discoverChannelsMock).toHaveBeenCalledWith(expect.anything(), feePayer.address);
+    expect(discoverChannelsMock).toHaveBeenCalledWith(expect.anything(), NETWORK, feePayer.address);
     expect(onDiscover).toHaveBeenCalledWith({ channelIds: [discoveredChannelId] });
     // Only what the chain proves: the Open/Sealed metadata stays empty, which
     // a Distributed channel never needs again.

--- a/typescript/packages/mechanisms/svm/test/unit/upto.test.ts
+++ b/typescript/packages/mechanisms/svm/test/unit/upto.test.ts
@@ -36,7 +36,7 @@ import {
 } from "../../src/payment-channels/open";
 import { encodeVoucherMessageBytes, VOUCHER_MAGIC } from "../../src/payment-channels/voucher";
 import { UptoSvmScheme as UptoClientScheme } from "../../src/upto/client/scheme";
-import { resolveUptoSvmMemo } from "../../src/upto/shared";
+import { resolveUptoSvmMemo, SLOT_COMMITMENT } from "../../src/upto/shared";
 import { UptoSvmScheme as UptoServerScheme } from "../../src/upto/server/scheme";
 import {
   DEFAULT_SETTLE_COMPUTE_UNIT_LIMIT,
@@ -1209,14 +1209,21 @@ describe("upto SVM scheme", () => {
       ).toThrow(/computeUnitPriceMicroLamports/);
       expect(
         () =>
-          new UptoFacilitatorScheme(mockSigner as never, {
-            maxPriorityFeeMicroLamports: 0,
-            maxComputeUnits: 1,
-            maxRequiredSignatures: 1,
-            maxChannelLifetimeSecs: 1,
-            computeUnitPriceMicroLamports: 0,
-            settleComputeUnitLimit: 1,
-          }),
+          new UptoFacilitatorScheme(
+            toFacilitatorSvmSigner({
+              address: feePayer,
+              signTransactions: vi.fn(),
+              signMessages: vi.fn(),
+            } as never),
+            {
+              maxPriorityFeeMicroLamports: 0,
+              maxComputeUnits: 1,
+              maxRequiredSignatures: 1,
+              maxChannelLifetimeSecs: 1,
+              computeUnitPriceMicroLamports: 0,
+              settleComputeUnitLimit: 1,
+            },
+          ),
       ).not.toThrow();
     });
 
@@ -1622,7 +1629,7 @@ describe("upto SVM scheme", () => {
       );
     });
 
-    it("simulates open + settle + distribute with sigVerify disabled", async () => {
+    it("simulates open + settle + distribute with replaceRecentBlockhash via the signer", async () => {
       const payer = await generateKeyPairSigner();
       const feePayer = await generateKeyPairSigner();
       const receiverAuthorizer = await generateKeyPairSigner();
@@ -1640,19 +1647,10 @@ describe("upto SVM scheme", () => {
         tokenProgram: TOKEN_PROGRAM_ADDRESS,
       });
 
-      const simulateTransaction = vi.fn().mockReturnValue({
-        send: async () => ({ value: { err: null } }),
-      });
-      const rpc = {
-        getLatestBlockhash: () => ({
-          send: async () => ({
-            value: { blockhash: DUMMY_BLOCKHASH, lastValidBlockHeight: 1n },
-          }),
-        }),
-        simulateTransaction,
-      };
+      const simulateTransaction = vi.fn().mockResolvedValue(undefined);
+      const signer = { simulateTransaction };
 
-      await simulateOpenSettleDistribute(feePayer, rpc as never, {
+      await simulateOpenSettleDistribute(feePayer, signer, SOLANA_DEVNET_CAIP2, {
         openTransactionBase64: open.transaction,
         channel: {
           channelId: open.channelId,
@@ -1666,13 +1664,9 @@ describe("upto SVM scheme", () => {
         },
       });
 
-      expect(simulateTransaction).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.objectContaining({
-          replaceRecentBlockhash: true,
-          sigVerify: false,
-        }),
-      );
+      expect(simulateTransaction).toHaveBeenCalledWith(expect.any(String), SOLANA_DEVNET_CAIP2, {
+        replaceRecentBlockhash: true,
+      });
     });
   });
 
@@ -1688,36 +1682,36 @@ describe("upto SVM scheme", () => {
     };
 
     /**
-     * RPC mock capturing sent wire transactions.
+     * Facilitator signer mock capturing settle simulate/send/confirm.
      *
-     * @returns Mock rpc plus the simulate/send spies
+     * @returns Mock signer plus spies
      */
-    function makeSettleRpc() {
-      const simulateTransaction = vi.fn();
-      const sendSend = vi.fn().mockResolvedValue(SIG);
-      const sendTransaction = vi.fn().mockReturnValue({ send: sendSend });
-      const rpc = {
-        getLatestBlockhash: () => ({
-          send: async () => ({
-            value: { blockhash: DUMMY_BLOCKHASH, lastValidBlockHeight: 1n },
-          }),
+    function makeSettleSigner() {
+      const simulateTransaction = vi.fn().mockResolvedValue(undefined);
+      const sendTransaction = vi.fn().mockResolvedValue(SIG);
+      const confirmTransaction = vi.fn().mockResolvedValue(undefined);
+      const signer = {
+        getLatestBlockhash: vi.fn().mockResolvedValue({
+          blockhash: DUMMY_BLOCKHASH,
+          lastValidBlockHeight: 1n,
         }),
-        getSignatureStatuses: () => ({
-          send: async () => ({ value: [{ err: null, confirmationStatus: "confirmed" }] }),
-        }),
-        sendTransaction,
         simulateTransaction,
+        sendTransaction,
+        confirmTransaction,
       };
-      return { rpc, sendTransaction, simulateTransaction };
+      return { signer, simulateTransaction, sendTransaction };
     }
 
-    it("applies the static default limit and price without simulating", async () => {
+    it("simulates before send and applies the static default compute budget", async () => {
       const feePayer = await generateKeyPairSigner();
-      const { rpc, sendTransaction, simulateTransaction } = makeSettleRpc();
+      const { signer, simulateTransaction, sendTransaction } = makeSettleSigner();
 
-      const signature = await submitSettle(feePayer, rpc as never, [memoIx]);
+      const signature = await submitSettle(feePayer, signer as never, SOLANA_DEVNET_CAIP2, [
+        memoIx,
+      ]);
       expect(signature).toBe(SIG);
-      expect(simulateTransaction).not.toHaveBeenCalled();
+      expect(simulateTransaction).toHaveBeenCalledTimes(1);
+      expect(sendTransaction).toHaveBeenCalledTimes(1);
 
       // Broadcast: static limit + default price, then the payload ix.
       const wire = sendTransaction.mock.calls[0]![0] as string;
@@ -1731,11 +1725,24 @@ describe("upto SVM scheme", () => {
       expect(instructions[2]!.program).toBe(MEMO_PROGRAM_ADDRESS);
     });
 
+    it("does not send when simulation fails", async () => {
+      const feePayer = await generateKeyPairSigner();
+      const { signer, sendTransaction } = makeSettleSigner();
+      signer.simulateTransaction.mockRejectedValue(new Error("sim failed"));
+
+      await expect(
+        submitSettle(feePayer, signer as never, SOLANA_DEVNET_CAIP2, [memoIx]),
+      ).rejects.toThrow("sim failed");
+      expect(sendTransaction).not.toHaveBeenCalled();
+    });
+
     it("honors the compute-unit limit override", async () => {
       const feePayer = await generateKeyPairSigner();
-      const { rpc, sendTransaction } = makeSettleRpc();
+      const { signer, sendTransaction } = makeSettleSigner();
 
-      await submitSettle(feePayer, rpc as never, [memoIx], { computeUnitLimit: 222_222 });
+      await submitSettle(feePayer, signer as never, SOLANA_DEVNET_CAIP2, [memoIx], {
+        computeUnitLimit: 222_222,
+      });
 
       const wire = sendTransaction.mock.calls[0]![0] as string;
       expect(readComputeLimitData(decodeTopLevelInstructions(wire)[0]!.data)).toBe(222_222);
@@ -1743,15 +1750,15 @@ describe("upto SVM scheme", () => {
 
     it("honors the compute-unit price option, omitting the instruction at 0", async () => {
       const feePayer = await generateKeyPairSigner();
-      const priced = makeSettleRpc();
-      await submitSettle(feePayer, priced.rpc as never, [memoIx], {
+      const priced = makeSettleSigner();
+      await submitSettle(feePayer, priced.signer as never, SOLANA_DEVNET_CAIP2, [memoIx], {
         computeUnitPriceMicroLamports: 250,
       });
       const pricedIxs = decodeTopLevelInstructions(priced.sendTransaction.mock.calls[0]![0]);
       expect(readComputePriceData(pricedIxs[1]!.data)).toBe(250n);
 
-      const unpriced = makeSettleRpc();
-      await submitSettle(feePayer, unpriced.rpc as never, [memoIx], {
+      const unpriced = makeSettleSigner();
+      await submitSettle(feePayer, unpriced.signer as never, SOLANA_DEVNET_CAIP2, [memoIx], {
         computeUnitPriceMicroLamports: 0,
       });
       const unpricedIxs = decodeTopLevelInstructions(unpriced.sendTransaction.mock.calls[0]![0]);
@@ -1929,7 +1936,8 @@ describe("upto SVM scheme", () => {
 
     it("resolveOpenSlot falls back to rpc.getSlot when extra.recentSlot is omitted", async () => {
       const getSlotSend = vi.fn().mockResolvedValue(OPEN_SLOT);
-      const rpc = { getSlot: () => ({ send: getSlotSend }) } as never;
+      const getSlot = vi.fn().mockReturnValue({ send: getSlotSend });
+      const rpc = { getSlot } as never;
       const slot = await resolveOpenSlot(rpc, {
         scheme: "upto",
         network: SOLANA_DEVNET_CAIP2,
@@ -1940,6 +1948,7 @@ describe("upto SVM scheme", () => {
         extra: {},
       });
       expect(slot).toBe(OPEN_SLOT);
+      expect(getSlot).toHaveBeenCalledWith({ commitment: SLOT_COMMITMENT });
       expect(getSlotSend).toHaveBeenCalled();
     });
 
@@ -1984,6 +1993,10 @@ describe("upto SVM scheme", () => {
               : (() => {
                   throw new Error(`No signer for feePayer ${feePayer}`);
                 })(),
+        getAccountInfo: vi.fn(),
+        getLatestBlockhash: vi.fn(),
+        getSlot: vi.fn(),
+        getProgramAccounts: vi.fn(),
         signTransaction: async () => "",
         simulateTransaction: async () => {},
         sendTransaction: async () => "",


### PR DESCRIPTION
## Description

- SVM upto facilitator RPC now goes through the facilitator signer instead of a separate scheme rpc / rpcUrl. That matches the EVM facilitator signer, which already owns chain reads and writes (readContract, writeContract, sendTransaction) rather than taking a second RPC on scheme config. Pass a paced RPC client (or default URL) on the signer.
- Claim settlement simulates before the skipPreflight send and rejects with invalid_upto_svm_settlement_simulation without broadcasting
-  deposit composite simulation uses a placeholder blockhash plus replaceRecentBlockhash. Claim also overlaps the channel read with a blockhash prefetch, and open-slot freshness uses finalized getSlot on both client and facilitator. 

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [ ] I have formatted and linted my code
- [ ] All new and existing tests pass
- [ ] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [ ] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 