### PR TITLE
fix(evm): restore x402UptoPermit2Proxy canonical deployment address

### DIFF
--- a/contracts/evm/README.md
+++ b/contracts/evm/README.md
@@ -23,7 +23,7 @@ Both contracts:
 | Contract | Address |
 |----------|---------|
 | x402ExactPermit2Proxy | `0x402085c248EeA27D92E8b30b2C58ed07f9E20001` |
-| x402UptoPermit2Proxy | `0x402015c795ecb48A360bDC6e35a2EaEb313a0002` |
+| x402UptoPermit2Proxy | `0x4020A4f3b7b90ccA423B9fabCc0CE57C6C240002` |
 
 **Batch settlement (CREATE2 vanity `0x4020…`)**
 
@@ -41,7 +41,7 @@ Both contracts:
 
 | Chain | Exact | Upto |
 |-------|-------|------|
-| Base Mainnet | [Deployed](https://basescan.org/address/0x402085c248EeA27D92E8b30b2C58ed07f9E20001) | — |
+| Base Mainnet | [Deployed](https://basescan.org/address/0x402085c248EeA27D92E8b30b2C58ed07f9E20001) | [Deployed](https://basescan.org/address/0x4020A4f3b7b90ccA423B9fabCc0CE57C6C240002) |
 | Base Sepolia | [Deployed](https://sepolia.basescan.org/address/0x402085c248EeA27D92E8b30b2C58ed07f9E20001) | [Legacy\*](https://sepolia.basescan.org/address/0x402039b3d6E6BEC5A02c2C9fd937ac17A6940002) |
 
 **Batch settlement deployments**
@@ -61,7 +61,7 @@ Both contracts:
 | Monad Mainnet | [Deployed](https://monadscan.com/address/0x4020074e9dF2ce1deE5A9C1b5c3f541D02a10003) | [Deployed](https://monadscan.com/address/0x4020806089470a89826cB9fB1f4059150b550004) | [Deployed](https://monadscan.com/address/0x4020425FAf3B746C082C2f942b4E5159887B0005) |
 
 > \*Older testnet deployments may use prior vanity salts; the canonical **Upto** address for
-> CREATE2 deployments from this tree is `0x402015c7…313a0002` (see `forge script script/ComputeAddress.s.sol`).
+> CREATE2 deployments from this tree is `0x4020A4f3…C240002` (see `forge script script/ComputeAddress.s.sol`).
 
 ## Prerequisites
 
@@ -106,7 +106,7 @@ and `keccak256(initCode)`—not on who sends the transaction.
    ```
    You should see:
    - Exact → `0x402085c248EeA27D92E8b30b2C58ed07f9E20001`
-   - Upto  → `0x402015c795ecb48A360bDC6e35a2EaEb313a0002`
+   - Upto  → `0x4020A4f3b7b90ccA423B9fabCc0CE57C6C240002`
 
 3. **Check prerequisites on the target chain**
    - [Permit2](https://github.com/Uniswap/permit2) must be deployed at `0x000000000022D473030F116dDEE9F6B43aC78BA3`

--- a/contracts/evm/script/ComputeAddress.s.sol
+++ b/contracts/evm/script/ComputeAddress.s.sol
@@ -43,8 +43,8 @@ contract ComputeAddress is Script {
     bytes32 constant DEFAULT_EXACT_SALT = 0x0000000000000000000000000000000000000000000000003000000007263b0e;
 
     /// @notice Default salt for x402UptoPermit2Proxy
-    /// @dev Vanity mined for address 0x402015c795ecb48a360bdc6e35a2eaeb313a0002
-    bytes32 constant DEFAULT_UPTO_SALT = 0x0000000000000000000000000000000000000000000000000800000007e2e4de;
+    /// @dev Vanity mined for address 0x4020a4f3b7b90cca423b9fabcc0ce57c6c240002
+    bytes32 constant DEFAULT_UPTO_SALT = 0x000000000000000000000000000000000000000000000000b000000001db633d;
 
     /// @notice Expected initCodeHash for x402ExactPermit2Proxy (pre-built, includes CBOR metadata)
     bytes32 constant EXACT_INIT_CODE_HASH = 0xe774d1d5a07218946ab54efe010b300481478b86861bb17d69c98a57f68a604c;

--- a/contracts/evm/script/Deploy.s.sol
+++ b/contracts/evm/script/Deploy.s.sol
@@ -45,8 +45,8 @@ contract DeployX402Proxies is Script {
     bytes32 constant EXACT_SALT = 0x0000000000000000000000000000000000000000000000003000000007263b0e;
 
     /// @notice Salt for x402UptoPermit2Proxy deterministic deployment
-    /// @dev Vanity mined for address 0x402015c795ecb48a360bdc6e35a2eaeb313a0002
-    bytes32 constant UPTO_SALT = 0x0000000000000000000000000000000000000000000000000800000007e2e4de;
+    /// @dev Vanity mined for address 0x4020a4f3b7b90cca423b9fabcc0ce57c6c240002
+    bytes32 constant UPTO_SALT = 0x000000000000000000000000000000000000000000000000b000000001db633d;
 
     /// @notice Expected initCodeHash for x402ExactPermit2Proxy (pre-built, includes CBOR metadata)
     bytes32 constant EXACT_INIT_CODE_HASH = 0xe774d1d5a07218946ab54efe010b300481478b86861bb17d69c98a57f68a604c;

--- a/contracts/evm/src/x402BasePermit2Proxy.sol
+++ b/contracts/evm/src/x402BasePermit2Proxy.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {ReentrancyGuardTransient} from "@openzeppelin/contracts/utils/ReentrancyGuardTransient.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import {IERC20Permit} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol";
 
 import {ISignatureTransfer} from "./interfaces/ISignatureTransfer.sol";
@@ -22,11 +22,9 @@ import {ISignatureTransfer} from "./interfaces/ISignatureTransfer.sol";
  *      every chain keeps the initCode identical, preserving a uniform CREATE2
  *      address for these proxies across all chains.
  *
- *      Uses {ReentrancyGuardTransient} (EIP-1153); deploy only on chains with transient storage support.
- *
  * @author x402 Protocol
  */
-abstract contract x402BasePermit2Proxy is ReentrancyGuardTransient {
+abstract contract x402BasePermit2Proxy is ReentrancyGuard {
     /// @notice The Permit2 contract address (set once at construction, immutable)
     ISignatureTransfer public immutable PERMIT2;
 

--- a/contracts/evm/test/Deploy.t.sol
+++ b/contracts/evm/test/Deploy.t.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {DeployX402Proxies} from "../script/Deploy.s.sol";
+import {x402ExactPermit2Proxy} from "../src/x402ExactPermit2Proxy.sol";
+import {x402UptoPermit2Proxy} from "../src/x402UptoPermit2Proxy.sol";
+
+/// @title DeployX402ProxiesTest
+/// @notice Regression tests for the CREATE2 deployment path (non-local chain IDs), where
+///         Deploy.s.sol must reproduce the documented canonical addresses exactly. A prior
+///         change silently regressed UPTO_SALT to a stale value that no longer matched the
+///         live, SDK-referenced x402UptoPermit2Proxy deployment; these tests pin both
+///         canonical addresses so a future salt/initCode regression fails loudly here
+///         instead of silently deploying an orphaned contract on a new chain.
+contract DeployX402ProxiesTest is Test {
+    address constant CANONICAL_PERMIT2 = 0x000000000022D473030F116dDEE9F6B43aC78BA3;
+    address constant CREATE2_DEPLOYER = 0x4e59b44847b379578588920cA78FbF26c0B4956C;
+
+    address constant EXPECTED_EXACT_ADDRESS = 0x402085c248EeA27D92E8b30b2C58ed07f9E20001;
+    address constant EXPECTED_UPTO_ADDRESS = 0x4020A4f3b7b90ccA423B9fabCc0CE57C6C240002;
+
+    /// @dev Bytecode of Arachnid's deterministic CREATE2 deployer, same on every EVM chain.
+    bytes constant CREATE2_DEPLOYER_CODE =
+        hex"7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf3";
+
+    function _simulateRealChain() internal {
+        vm.chainId(8453); // any non-anvil chain ID forces the CREATE2 (non-local) deployment path
+        vm.etch(CREATE2_DEPLOYER, CREATE2_DEPLOYER_CODE);
+        vm.etch(CANONICAL_PERMIT2, hex"60006000fd"); // just needs non-empty code for the prereq check
+    }
+
+    function test_runDeploysToCanonicalAddresses() public {
+        _simulateRealChain();
+
+        DeployX402Proxies deployer = new DeployX402Proxies();
+        deployer.run();
+
+        assertGt(EXPECTED_EXACT_ADDRESS.code.length, 0, "no code at canonical Exact address");
+        assertGt(EXPECTED_UPTO_ADDRESS.code.length, 0, "no code at canonical Upto address");
+
+        assertEq(
+            address(x402ExactPermit2Proxy(EXPECTED_EXACT_ADDRESS).PERMIT2()),
+            CANONICAL_PERMIT2,
+            "Exact PERMIT2 mismatch"
+        );
+        assertEq(
+            address(x402UptoPermit2Proxy(EXPECTED_UPTO_ADDRESS).PERMIT2()), CANONICAL_PERMIT2, "Upto PERMIT2 mismatch"
+        );
+    }
+
+    function test_runIsIdempotent() public {
+        _simulateRealChain();
+
+        DeployX402Proxies deployer = new DeployX402Proxies();
+        deployer.run();
+        deployer.run(); // must detect existing deployments and skip, not attempt to redeploy
+
+        assertGt(EXPECTED_EXACT_ADDRESS.code.length, 0);
+        assertGt(EXPECTED_UPTO_ADDRESS.code.length, 0);
+    }
+}

--- a/contracts/evm/vanity-miner/src/main.rs
+++ b/contracts/evm/vanity-miner/src/main.rs
@@ -39,7 +39,7 @@ const EXACT_INIT_CODE_HASH: [u8; 32] =
     hex_literal::hex!("e774d1d5a07218946ab54efe010b300481478b86861bb17d69c98a57f68a604c");
 // x402UptoPermit2Proxy (deterministic build, no CBOR metadata)
 const UPTO_INIT_CODE_HASH: [u8; 32] =
-    hex_literal::hex!("01575bfc9cacbf6463db62ee8867594b1657139c8493a712ef6bcefa848a20b7");
+    hex_literal::hex!("74f7a29cbc3c55f87cdef7f7c551643189e8bb62eed9de67753aebc402b83797");
 // x402BatchSettlement — keccak256(type(x402BatchSettlement).creationCode) after `forge build`
 const BATCH_INIT_CODE_HASH: [u8; 32] =
     hex_literal::hex!("ed07c0a1aeb6bd4b8e28932959d66e9f2c1a2f6ebb1fd3dc5f3fbcf8135850f6");


### PR DESCRIPTION


<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

x402BasePermit2Proxy (shared by both Exact and Upto proxies) was switched from ReentrancyGuard to ReentrancyGuardTransient in the x402BatchSettlement PR (#1950), bundled in as an incidental "gas efficiency" change unrelated to that PR's actual scope. That same merge also silently regressed UPTO_SALT back to a stale, pre-#1880 value.

The combination broke Upto's deterministic deployment: Deploy.s.sol and ComputeAddress.s.sol compute 0x402015c795ecb48A360bDC6e35a2EaEb313a0002, an address that was never actually deployed anywhere, while every SDK (Go/TS/Python) and the spec hardcode the real canonical address, 0x4020A4f3b7b90ccA423B9fabCc0CE57C6C240002, live on Base Mainnet and other chains today. Running the deploy script against a fresh chain would silently deploy a fully-functional but orphaned contract that no client or facilitator would ever look up.

Exact was never affected only by coincidence: its canonical bytecode was already pinned to a frozen initCode blob (for an unrelated, older CBOR-metadata problem), so it never recompiles from source. Upto had no such protection and drifted along with the base contract's source. Batch Settlement was never at risk either, it inherits ReentrancyGuardTransient directly from OpenZeppelin and has no dependency on x402BasePermit2Proxy.

The ReentrancyGuardTransient swap on the shared base contract was also never in scope for any of the three Cantina audits (Feb/Mar/May 2026); the May audit that shipped alongside this change scoped only the new Batch Settlement contracts. This was a separate gas improvement that was made to a parent contract, and has no affect on the security of the deployed contracts.

Fix: revert x402BasePermit2Proxy to ReentrancyGuard and restore UPTO_SALT to its pre-#1880-regression value, so Upto's from-source compilation (as originally documented) reproduces the real, live canonical address again. Verified end-to-end: the resulting initCode hash and CREATE2 address match the live Base Mainnet deployment exactly (confirmed by fetching and diffing on-chain bytecode).

Adds a regression test that exercises the actual CREATE2 (non-local chain) deployment path for both proxies and asserts the documented canonical addresses, which the codebase previously had no coverage for.

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [ ] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 