### PR TITLE
fix(core): return EXTENSION-RESPONSES on settle/verify

### DIFF
--- a/typescript/.changeset/extension-responses-sidechannel.md
+++ b/typescript/.changeset/extension-responses-sidechannel.md
@@ -1,0 +1,5 @@
+---
+"@x402/core": patch
+---
+
+Populate `extensionResponses` on verify/settle from the facilitator `EXTENSION-RESPONSES` header as a server-internal sidechannel (aligned with Python). Do not merge into `extensions`; strip the sidechannel from buyer-facing `PAYMENT-RESPONSE` encoding.

--- a/typescript/packages/core/src/http/httpFacilitatorClient.ts
+++ b/typescript/packages/core/src/http/httpFacilitatorClient.ts
@@ -253,22 +253,42 @@ function isAbortOrTimeoutError(error: unknown): boolean {
 const EXTENSION_RESPONSE_LOG_FIELD_ALLOWLIST = ["status", "rejectedReason", "reason", "code"];
 
 /**
+ * Decodes the facilitator `EXTENSION-RESPONSES` header into a plain object.
+ * Returns undefined when the header is missing or malformed.
+ *
+ * @param response - The HTTP response from the facilitator
+ * @returns Decoded extension responses, or undefined if missing/malformed
+ */
+function extractExtensionResponsesHeader(response: Response): Record<string, unknown> | undefined {
+  const header = response.headers.get("EXTENSION-RESPONSES");
+  if (!header) return undefined;
+  try {
+    const decoded = JSON.parse(safeBase64Decode(header));
+    if (!decoded || typeof decoded !== "object" || Array.isArray(decoded)) {
+      return undefined;
+    }
+    return decoded as Record<string, unknown>;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Reads the `EXTENSION-RESPONSES` header from a facilitator HTTP response and logs
  * allowlisted fields. Silently ignores malformed headers.
  *
  * @param response - The HTTP response from the facilitator
+ * @param decoded - Optional pre-decoded header object (avoids double-parse)
  */
-function logExtensionResponsesHeader(response: Response): void {
-  const header = response.headers.get("EXTENSION-RESPONSES");
-  if (!header) return;
+function logExtensionResponsesHeader(response: Response, decoded?: Record<string, unknown>): void {
+  const payload = decoded ?? extractExtensionResponsesHeader(response);
+  if (!payload) return;
   try {
-    const decoded = JSON.parse(safeBase64Decode(header));
-    if (!decoded || typeof decoded !== "object" || Array.isArray(decoded)) return;
     const sanitized: Record<string, Record<string, unknown>> = {};
-    for (const [extensionKey, payload] of Object.entries(decoded as Record<string, unknown>)) {
+    for (const [extensionKey, value] of Object.entries(payload)) {
       const source =
-        payload && typeof payload === "object" && !Array.isArray(payload)
-          ? (payload as Record<string, unknown>)
+        value && typeof value === "object" && !Array.isArray(value)
+          ? (value as Record<string, unknown>)
           : {};
       const filtered: Record<string, unknown> = {};
       for (const key of EXTENSION_RESPONSE_LOG_FIELD_ALLOWLIST) {
@@ -280,8 +300,28 @@ function logExtensionResponsesHeader(response: Response): void {
     }
     console.log(`[x402] extension responses: ${JSON.stringify(sanitized)}`);
   } catch {
-    // Ignore malformed header
+    // Ignore malformed payload shapes
   }
+}
+
+/**
+ * Attach decoded EXTENSION-RESPONSES onto `extensionResponses` (server-internal
+ * sidechannel). Never merges into `extensions`, which remains body-only and may
+ * be forwarded to buyers via PAYMENT-RESPONSE.
+ *
+ * @param result - Facilitator response object to annotate
+ * @param response - The HTTP response from the facilitator
+ * @returns The same result, possibly with extensionResponses set
+ */
+function attachExtensionResponsesFromHeader<
+  T extends { extensionResponses?: Record<string, unknown> },
+>(result: T, response: Response): T {
+  const headerExtensions = extractExtensionResponsesHeader(response);
+  logExtensionResponsesHeader(response, headerExtensions);
+  if (headerExtensions) {
+    result.extensionResponses = headerExtensions;
+  }
+  return result;
 }
 
 /**
@@ -401,8 +441,7 @@ export class HTTPFacilitatorClient implements FacilitatorClient {
       }
 
       const verifyResult = await parseSuccessResponse(response, verifyResponseSchema, "verify");
-      logExtensionResponsesHeader(response);
-      return verifyResult;
+      return attachExtensionResponsesFromHeader(verifyResult, response);
     });
   }
 
@@ -460,8 +499,7 @@ export class HTTPFacilitatorClient implements FacilitatorClient {
       }
 
       const settleResult = await parseSuccessResponse(response, settleResponseSchema, "settle");
-      logExtensionResponsesHeader(response);
-      return settleResult;
+      return attachExtensionResponsesFromHeader(settleResult, response);
     });
   }
 

--- a/typescript/packages/core/src/http/index.ts
+++ b/typescript/packages/core/src/http/index.ts
@@ -61,7 +61,10 @@ export function decodePaymentRequiredHeader(paymentRequiredHeader: string): Paym
  * @returns Base64 encoded string representation of the payment response
  */
 export function encodePaymentResponseHeader(paymentResponse: SettleResponse): string {
-  return safeBase64Encode(JSON.stringify(paymentResponse));
+  // Strip server-internal facilitator sidechannel; never forward to buyers.
+  const buyerFacing = { ...paymentResponse };
+  delete buyerFacing.extensionResponses;
+  return safeBase64Encode(JSON.stringify(buyerFacing));
 }
 
 /**

--- a/typescript/packages/core/src/types/facilitator.ts
+++ b/typescript/packages/core/src/types/facilitator.ts
@@ -13,6 +13,7 @@ export type VerifyResponse = {
   invalidMessage?: string;
   payer?: string;
   extensions?: Record<string, unknown>;
+  extensionResponses?: Record<string, unknown>;
   extra?: Record<string, unknown>;
 };
 
@@ -32,6 +33,7 @@ export type SettleResponse = {
   /** Actual amount settled in atomic token units. Present for schemes like `upto` where settlement amount may differ from the authorized maximum. */
   amount?: string;
   extensions?: Record<string, unknown>;
+  extensionResponses?: Record<string, unknown>;
   extra?: Record<string, unknown>;
 };
 

--- a/typescript/packages/core/test/unit/http/httpFacilitatorClient.test.ts
+++ b/typescript/packages/core/test/unit/http/httpFacilitatorClient.test.ts
@@ -8,6 +8,7 @@ import {
   getFacilitatorResponseError,
 } from "../../../src/types";
 import { PaymentPayload, PaymentRequirements } from "../../../src/types/payments";
+import { safeBase64Encode } from "../../../src/utils";
 
 const paymentRequirements: PaymentRequirements = {
   scheme: "exact",
@@ -169,6 +170,116 @@ describe("HTTPFacilitatorClient", () => {
     expect(result.errorReason).toBeUndefined();
     expect(result.errorMessage).toBeUndefined();
     expect(result.payer).toBeUndefined();
+  });
+
+  describe("EXTENSION-RESPONSES header", () => {
+    const extensionPayload = {
+      bazaar: { status: "accepted", catalogId: "cat-1" },
+    };
+
+    it("sets extensionResponses from header on settle without touching extensions", async () => {
+      const header = safeBase64Encode(JSON.stringify(extensionPayload));
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          new Response(
+            JSON.stringify({
+              success: true,
+              transaction: "0xabc",
+              network: "eip155:8453",
+            }),
+            {
+              status: 200,
+              headers: { "EXTENSION-RESPONSES": header },
+            },
+          ),
+        ),
+      );
+
+      const client = new HTTPFacilitatorClient({ url: "https://facilitator.test" });
+      const result = await client.settle(paymentPayload, paymentRequirements);
+
+      expect(result.extensionResponses).toEqual(extensionPayload);
+      expect(result.extensions).toBeUndefined();
+    });
+
+    it("sets extensionResponses from header on verify without touching extensions", async () => {
+      const header = safeBase64Encode(JSON.stringify(extensionPayload));
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          new Response(
+            JSON.stringify({
+              isValid: true,
+            }),
+            {
+              status: 200,
+              headers: { "EXTENSION-RESPONSES": header },
+            },
+          ),
+        ),
+      );
+
+      const client = new HTTPFacilitatorClient({ url: "https://facilitator.test" });
+      const result = await client.verify(paymentPayload, paymentRequirements);
+
+      expect(result.extensionResponses).toEqual(extensionPayload);
+      expect(result.extensions).toBeUndefined();
+    });
+
+    it("keeps body extensions independent from header extensionResponses", async () => {
+      const bodyExtensions = { bazaar: { status: "from-body" } };
+      const header = safeBase64Encode(JSON.stringify(extensionPayload));
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          new Response(
+            JSON.stringify({
+              success: true,
+              transaction: "0xabc",
+              network: "eip155:8453",
+              extensions: bodyExtensions,
+            }),
+            {
+              status: 200,
+              headers: { "EXTENSION-RESPONSES": header },
+            },
+          ),
+        ),
+      );
+
+      const client = new HTTPFacilitatorClient({ url: "https://facilitator.test" });
+      const result = await client.settle(paymentPayload, paymentRequirements);
+
+      expect(result.extensions).toEqual(bodyExtensions);
+      expect(result.extensionResponses).toEqual(extensionPayload);
+    });
+
+    it("ignores malformed EXTENSION-RESPONSES without throwing", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          new Response(
+            JSON.stringify({
+              success: true,
+              transaction: "0xabc",
+              network: "eip155:8453",
+            }),
+            {
+              status: 200,
+              headers: { "EXTENSION-RESPONSES": "not-valid-base64!!!" },
+            },
+          ),
+        ),
+      );
+
+      const client = new HTTPFacilitatorClient({ url: "https://facilitator.test" });
+      const result = await client.settle(paymentPayload, paymentRequirements);
+
+      expect(result.success).toBe(true);
+      expect(result.extensions).toBeUndefined();
+      expect(result.extensionResponses).toBeUndefined();
+    });
   });
 
   describe("URL normalization", () => {

--- a/typescript/packages/core/test/unit/http/x402HTTPClient.parsePaymentResult.test.ts
+++ b/typescript/packages/core/test/unit/http/x402HTTPClient.parsePaymentResult.test.ts
@@ -121,4 +121,17 @@ describe("x402HTTPClient.parsePaymentResult", () => {
 
     expect(result).toEqual({ status: 200, paymentStatus: "none", body, header: undefined });
   });
+
+  it("encodePaymentResponseHeader excludes extensionResponses sidechannel", () => {
+    const settleResponse = buildSettleResponse({
+      success: true,
+      transaction: "0xabc",
+    });
+    settleResponse.extensionResponses = { bazaar: { status: "processing" } };
+    const encoded = encodePaymentResponseHeader(settleResponse);
+    const decoded = JSON.parse(Buffer.from(encoded, "base64").toString("utf8"));
+    expect(decoded.extensionResponses).toBeUndefined();
+    expect(decoded.success).toBe(true);
+    expect(decoded.transaction).toBe("0xabc");
+  });
 });


### PR DESCRIPTION
## Description

Fixes #3270.

`HTTPFacilitatorClient.verify()` / `.settle()` previously decoded the facilitator `EXTENSION-RESPONSES` header only to `console.log` allowlisted fields, then discarded the payload. Resource servers using the official client therefore could not branch on extension outcomes after verify/settle.

Aligned with the merged Python sidechannel in #3306 (and the three-channel model in the v2 spec / bazaar docs):

- Decode `EXTENSION-RESPONSES` into optional `extensionResponses` on `VerifyResponse` / `SettleResponse` (server-internal sidechannel).
- Do **not** merge header data into `extensions` (body-only; may be forwarded to buyers).
- `encodePaymentResponseHeader` strips `extensionResponses` so it never leaks into buyer-facing `PAYMENT-RESPONSE`.
- Missing/malformed header → ignored (no throw); body `extensions` stay independent.

## Tests

- `pnpm exec vitest run test/unit/http/httpFacilitatorClient.test.ts test/unit/http/x402HTTPClient.parsePaymentResult.test.ts` in `typescript/packages/core` (51 passed)
- Prettier + eslint clean for `@x402/core`

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge)
- [x] I added a changelog fragment for user-facing changes (`typescript/.changeset/extension-responses-sidechannel.md`)

## AI disclosure (CONTRIBUTING soft gate)

Majority of this change was drafted by an AI agent under human direction. Intended for **human review** before merge. Commit is **signed**.