### PR TITLE
fix(go): use maxTimeoutSeconds for EIP-3009 validBefore

### DIFF
--- a/go/.changes/unreleased/fixed-20260827-095832.yaml
+++ b/go/.changes/unreleased/fixed-20260827-095832.yaml
@@ -1,0 +1,3 @@
+kind: fixed
+body: fixed Golang SDK EIP-3009 client not using paymentRequirements.maxTimeoutSeconds for validBefore
+time: 2026-08-27T09:58:32.096574+02:00

--- a/go/mechanisms/evm/exact/client/scheme.go
+++ b/go/mechanisms/evm/exact/client/scheme.go
@@ -276,7 +276,8 @@ func (c *ExactEvmScheme) createEIP3009Payload(
 	}
 
 	// V2 specific: No buffer on validAfter (can use immediately)
-	validAfter, validBefore := evm.CreateValidityWindow(time.Hour)
+	timeoutDuration := time.Duration(requirements.MaxTimeoutSeconds) * time.Second
+	validAfter, validBefore := evm.CreateValidityWindow(timeoutDuration)
 
 	// Extract extra fields for EIP-3009
 	tokenName := assetInfo.Name


### PR DESCRIPTION
## Description

Makes Golang SDK EIP-3009 client implementation use `now + paymentRequirements.maxTimeoutSeconds` for `validBefore` instead of `now + 1 hour`, which is already the case for Permit2 version and TypeScript SDK.

This allows more control over EIP-3009 authorization lifetime.

## Tests

- [x] `go test ./...` from the `/go` directory

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)