### PR TITLE
feat(ts/go): auth-capture client v1.1

### DIFF
--- a/examples/go/clients/http/README.md
+++ b/examples/go/clients/http/README.md
@@ -68,8 +68,10 @@ signer, err := evmsigners.NewClientSignerFromPrivateKey(os.Getenv("EVM_PRIVATE_K
 
 // Configure client with builder pattern.
 // Newx402Client() enables default spend controls: recognized pegged assets only, capped at $1 USD.
+// Registers exact, upto, and auth-capture EVM schemes (plus SVM when configured).
 client := x402.Newx402Client().
-    Register("eip155:*", evm.NewExactEvmScheme(signer))
+    Register("eip155:*", evm.NewExactEvmScheme(signer)).
+    Register("eip155:*", authcaptureclient.NewAuthCaptureEvmScheme(signer))
 
 // Optional: raise the cap or opt into non-default tokens
 // client.SetSpendControls(x402.SpendControls{MaxAmountPerPayment: "$5"})

--- a/examples/go/clients/http/builder_pattern.go
+++ b/examples/go/clients/http/builder_pattern.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	x402 "github.com/x402-foundation/x402/go/v2"
+	authcaptureclient "github.com/x402-foundation/x402/go/v2/mechanisms/evm/auth-capture/client"
 	exactevm "github.com/x402-foundation/x402/go/v2/mechanisms/evm/exact/client"
 	uptoevm "github.com/x402-foundation/x402/go/v2/mechanisms/evm/upto/client"
 	exactsvm "github.com/x402-foundation/x402/go/v2/mechanisms/svm/exact/client"
@@ -38,6 +39,7 @@ func createBuilderPatternClient(evmPrivateKey, svmPrivateKey, evmRpcURL string) 
 	// Register EVM schemes for all EVM networks
 	client.Register("eip155:*", exactevm.NewExactEvmScheme(evmSigner, rpcConfig))
 	client.Register("eip155:*", uptoevm.NewUptoEvmScheme(evmSigner, rpcConfig))
+	client.Register("eip155:*", authcaptureclient.NewAuthCaptureEvmScheme(evmSigner))
 
 	// You can also register specific networks for fine-grained control
 	// For example, use a different signer for Ethereum mainnet:

--- a/examples/go/clients/http/mechanism_helper_registration.go
+++ b/examples/go/clients/http/mechanism_helper_registration.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	x402 "github.com/x402-foundation/x402/go/v2"
+	authcaptureclient "github.com/x402-foundation/x402/go/v2/mechanisms/evm/auth-capture/client"
 	exactevm "github.com/x402-foundation/x402/go/v2/mechanisms/evm/exact/client"
 	uptoevm "github.com/x402-foundation/x402/go/v2/mechanisms/evm/upto/client"
 	exactsvm "github.com/x402-foundation/x402/go/v2/mechanisms/svm/exact/client"
@@ -39,6 +40,7 @@ func createMechanismHelperRegistrationClient(evmPrivateKey, svmPrivateKey, evmRp
 	// Register EVM schemes for all EVM networks using wildcard
 	client.Register("eip155:*", exactevm.NewExactEvmScheme(evmSigner, rpcConfig))
 	client.Register("eip155:*", uptoevm.NewUptoEvmScheme(evmSigner, rpcConfig))
+	client.Register("eip155:*", authcaptureclient.NewAuthCaptureEvmScheme(evmSigner))
 
 	// Register SVM scheme if key is provided
 	if svmPrivateKey != "" {

--- a/examples/typescript/clients/README.md
+++ b/examples/typescript/clients/README.md
@@ -6,11 +6,10 @@ This directory contains TypeScript client examples demonstrating how to make HTT
 
 | Directory | Description |
 | --- | --- |
-| [`fetch/`](./fetch/) | Using `@x402/fetch` with the native Fetch API |
-| [`axios/`](./axios/) | Using `@x402/axios` with Axios |
+| [`fetch/`](./fetch/) | Using `@x402/fetch` with the native Fetch API (exact, upto, auth-capture, and SVM schemes) |
+| [`axios/`](./axios/) | Using `@x402/axios` with Axios (exact, upto, auth-capture, and SVM schemes) |
 | [`advanced/`](./advanced/) | Advanced patterns: lifecycle hooks, network preferences, spend controls |
 | [`custom/`](./custom/) | Manual implementation without `@x402/fetch` or `@x402/axios` |
-| [`auth-capture/`](./auth-capture/) | Pays an auth-capture endpoint by signing an ERC-3009 `ReceiveWithAuthorization` |
 | [`batch-settlement/`](./batch-settlement/) | Pays a sequence of requests over one payment channel using cumulative vouchers |
 | [`builder-code/`](./builder-code/) | Verifies ERC-8021 builder-code attribution on the settlement transaction |
 | [`erc7702/`](./erc7702/) | Paying from an ERC-7702 delegated EOA |

--- a/examples/typescript/clients/axios/README.md
+++ b/examples/typescript/clients/axios/README.md
@@ -4,12 +4,16 @@ Example client demonstrating how to use `@x402/axios` to make HTTP requests to e
 
 ```typescript
 import { x402Client, wrapAxiosWithPayment } from "@x402/axios";
+import { AuthCaptureEvmScheme } from "@x402/evm/auth-capture/client";
 import { ExactEvmScheme } from "@x402/evm/exact/client";
+import { UptoEvmScheme } from "@x402/evm/upto/client";
 import { privateKeyToAccount } from "viem/accounts";
 import axios from "axios";
 
 const client = new x402Client()
   .register("eip155:*", new ExactEvmScheme(privateKeyToAccount(process.env.EVM_PRIVATE_KEY)))
+  .register("eip155:*", new UptoEvmScheme(privateKeyToAccount(process.env.EVM_PRIVATE_KEY)))
+  .register("eip155:*", new AuthCaptureEvmScheme(privateKeyToAccount(process.env.EVM_PRIVATE_KEY)))
   .setSpendControls({
     maxAmountPerPayment: "$1",
   });

--- a/examples/typescript/clients/axios/index.ts
+++ b/examples/typescript/clients/axios/index.ts
@@ -1,5 +1,6 @@
 import { config } from "dotenv";
 import { x402Client, wrapAxiosWithPayment, x402HTTPClient } from "@x402/axios";
+import { AuthCaptureEvmScheme } from "@x402/evm/auth-capture/client";
 import { ExactEvmScheme } from "@x402/evm/exact/client";
 import { UptoEvmScheme } from "@x402/evm/upto/client";
 import { ExactSvmScheme } from "@x402/svm/exact/client";
@@ -36,6 +37,7 @@ async function main(): Promise<void> {
   const client = new x402Client()
     .register("eip155:*", new ExactEvmScheme(evmSigner, rpcOptions))
     .register("eip155:*", new UptoEvmScheme(evmSigner, rpcOptions))
+    .register("eip155:*", new AuthCaptureEvmScheme(evmSigner))
     .register("solana:*", new ExactSvmScheme(svmSigner))
     .register("solana:*", new UptoSvmScheme(svmSigner))
     .setSpendControls({

--- a/examples/typescript/clients/fetch/README.md
+++ b/examples/typescript/clients/fetch/README.md
@@ -4,7 +4,9 @@ Example client demonstrating how to use `@x402/fetch` to make HTTP requests to e
 
 ```typescript
 import { x402Client, wrapFetchWithPayment } from "@x402/fetch";
+import { AuthCaptureEvmScheme } from "@x402/evm/auth-capture/client";
 import { ExactEvmScheme } from "@x402/evm/exact/client";
+import { UptoEvmScheme } from "@x402/evm/upto/client";
 import { ExactSvmScheme } from "@x402/svm/exact/client";
 import { privateKeyToAccount } from "viem/accounts";
 import { createKeyPairSignerFromBytes } from "@solana/kit";
@@ -12,6 +14,8 @@ import { base58 } from "@scure/base";
 
 const client = new x402Client()
   .register("eip155:*", new ExactEvmScheme(privateKeyToAccount(process.env.EVM_PRIVATE_KEY)))
+  .register("eip155:*", new UptoEvmScheme(privateKeyToAccount(process.env.EVM_PRIVATE_KEY)))
+  .register("eip155:*", new AuthCaptureEvmScheme(privateKeyToAccount(process.env.EVM_PRIVATE_KEY)))
   .register("solana:*", new ExactSvmScheme(await createKeyPairSignerFromBytes(base58.decode(process.env.SVM_PRIVATE_KEY))))
   .setSpendControls({
     maxAmountPerPayment: "$1",

--- a/examples/typescript/clients/fetch/index.ts
+++ b/examples/typescript/clients/fetch/index.ts
@@ -1,5 +1,6 @@
 import { config } from "dotenv";
 import { x402Client, wrapFetchWithPayment, x402HTTPClient } from "@x402/fetch";
+import { AuthCaptureEvmScheme } from "@x402/evm/auth-capture/client";
 import { ExactEvmScheme } from "@x402/evm/exact/client";
 import { UptoEvmScheme } from "@x402/evm/upto/client";
 import { ExactSvmScheme } from "@x402/svm/exact/client";
@@ -42,6 +43,7 @@ async function main(): Promise<void> {
     const rpcOptions = evmRpcUrl ? { rpcUrl: evmRpcUrl } : undefined;
     client.register("eip155:*", new ExactEvmScheme(evmSigner, rpcOptions));
     client.register("eip155:*", new UptoEvmScheme(evmSigner, rpcOptions));
+    client.register("eip155:*", new AuthCaptureEvmScheme(evmSigner));
   }
   if (svmPrivateKey) {
     const svmSigner = await createKeyPairSignerFromBytes(base58.decode(svmPrivateKey));

--- a/go/.changes/unreleased/add-go-auth-capture-client.yaml
+++ b/go/.changes/unreleased/add-go-auth-capture-client.yaml
@@ -1,0 +1,2 @@
+kind: added
+body: Add Go auth-capture client with ERC-3009 and Permit2 collect payload signing

--- a/go/mechanisms/evm/auth-capture/README.md
+++ b/go/mechanisms/evm/auth-capture/README.md
@@ -1,0 +1,36 @@
+# Auth-Capture EVM Scheme (`go/mechanisms/evm/auth-capture`)
+
+The **auth-capture** scheme adds refundable payments to x402, built on Base's audited [Commerce Payments Protocol](https://github.com/base/commerce-payments). The client signs a single collect payload (ERC-3009 by default, or Permit2) whose nonce is the payer-agnostic PaymentInfo hash.
+
+See the [auth-capture EVM specification](https://github.com/x402-foundation/x402/blob/main/specs/schemes/auth-capture/scheme_auth_capture_evm.md) for protocol details.
+
+## Import Path
+
+| Role   | Import                                                                      |
+| ------ | --------------------------------------------------------------------------- |
+| Client | `github.com/x402-foundation/x402/go/v2/mechanisms/evm/auth-capture/client` |
+
+## Client Usage
+
+Register `AuthCaptureEvmScheme` with an `x402Client`. The client signs the payer-agnostic PaymentInfo hash and emits an ERC-3009 (default) or Permit2 payload.
+
+When `extra.receiverAuthorizer` or `extra.policy` is non-zero, salt binding is on: the client emits a random `saltNonce` and a keccak `salt` committing to those addresses. Otherwise the wire shape is unbound (`salt` is random 32 bytes, no `saltNonce`).
+
+The client resolves the commerce-payments deployment from optional `extra.authCaptureEscrow` (v1.1 default when omitted). That selects the escrow bound into the signature nonce and the collector used for `authorization.to` / `permit2Authorization.spender`.
+
+```go
+import (
+    x402 "github.com/x402-foundation/x402/go/v2"
+    authcaptureclient "github.com/x402-foundation/x402/go/v2/mechanisms/evm/auth-capture/client"
+    evmsigners "github.com/x402-foundation/x402/go/v2/signers/evm"
+)
+
+signer, _ := evmsigners.NewClientSignerFromPrivateKey(os.Getenv("EVM_PRIVATE_KEY"))
+
+client := x402.Newx402Client()
+client.Register("eip155:*", authcaptureclient.NewAuthCaptureEvmScheme(signer))
+```
+
+`ClientEvmSigner` only needs `Address()` and `SignTypedData`; no RPC is required for payload construction.
+
+The client participates in the collect (`authorize` / `charge`) step only. Capture, void, and refund lifecycle payloads are server/facilitator responsibilities.

--- a/go/mechanisms/evm/auth-capture/client/scheme.go
+++ b/go/mechanisms/evm/auth-capture/client/scheme.go
@@ -1,0 +1,339 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"time"
+
+	x402 "github.com/x402-foundation/x402/go/v2"
+	"github.com/x402-foundation/x402/go/v2/mechanisms/evm"
+	authcapture "github.com/x402-foundation/x402/go/v2/mechanisms/evm/auth-capture"
+	"github.com/x402-foundation/x402/go/v2/types"
+)
+
+// AuthCaptureEvmScheme implements SchemeNetworkClient for auth-capture EVM payments.
+type AuthCaptureEvmScheme struct {
+	signer evm.ClientEvmSigner
+	now    func() time.Time
+}
+
+// NewAuthCaptureEvmScheme creates a client-side auth-capture scheme bound to signer.
+func NewAuthCaptureEvmScheme(signer evm.ClientEvmSigner) *AuthCaptureEvmScheme {
+	return &AuthCaptureEvmScheme{
+		signer: signer,
+		now:    time.Now,
+	}
+}
+
+// Scheme returns the scheme identifier.
+func (c *AuthCaptureEvmScheme) Scheme() string {
+	return authcapture.SchemeAuthCapture
+}
+
+func (c *AuthCaptureEvmScheme) FindDefaultAsset(asset string, network x402.Network) *x402.DefaultAsset {
+	info := evm.FindDefaultAsset(asset, string(network))
+	if info == nil {
+		return nil
+	}
+	return &x402.DefaultAsset{Asset: info.Asset, Decimals: info.Decimals, Symbol: info.Symbol}
+}
+
+// CreatePaymentPayload builds and signs an auth-capture collect payload for the given requirements.
+func (c *AuthCaptureEvmScheme) CreatePaymentPayload(
+	ctx context.Context,
+	requirements types.PaymentRequirements,
+) (types.PaymentPayload, error) {
+	extra, deployment, err := parseAuthCaptureExtra(requirements)
+	if err != nil {
+		return types.PaymentPayload{}, err
+	}
+
+	if requirements.MaxTimeoutSeconds <= 0 {
+		return types.PaymentPayload{}, fmt.Errorf("'maxTimeoutSeconds' is required in PaymentRequirements (used to derive preApprovalExpiry)")
+	}
+
+	chainID, err := evm.GetEvmChainId(string(requirements.Network))
+	if err != nil {
+		return types.PaymentPayload{}, err
+	}
+
+	maxAmount := requirements.Amount
+	nowSeconds := c.now().Unix()
+	preApprovalExpiry := uint64(nowSeconds + int64(requirements.MaxTimeoutSeconds))
+
+	assetTransferMethod := extra.AssetTransferMethod
+	if assetTransferMethod == "" {
+		assetTransferMethod = string(evm.AssetTransferMethodEIP3009)
+	}
+
+	bindOn := authcapture.IsSaltBindingOn(extra)
+	saltNonce, err := authcapture.GenerateSalt()
+	if err != nil {
+		return types.PaymentPayload{}, err
+	}
+
+	var salt string
+	if bindOn {
+		salt, err = authcapture.DeriveBoundSalt(
+			authcapture.ExtraAddress(extra.ReceiverAuthorizer),
+			authcapture.ExtraAddress(extra.Policy),
+			saltNonce,
+		)
+		if err != nil {
+			return types.PaymentPayload{}, err
+		}
+	} else {
+		salt = saltNonce
+	}
+
+	paymentInfo := authcapture.PaymentInfoStruct{
+		Operator:            extra.CaptureAuthorizer,
+		Payer:               c.signer.Address(),
+		Receiver:            requirements.PayTo,
+		Token:               requirements.Asset,
+		MaxAmount:           maxAmount,
+		PreApprovalExpiry:   preApprovalExpiry,
+		AuthorizationExpiry: extra.CaptureDeadline,
+		RefundExpiry:        extra.RefundDeadline,
+		MinFeeBps:           extra.MinFeeBps,
+		MaxFeeBps:           extra.MaxFeeBps,
+		FeeReceiver:         extra.FeeRecipient,
+		Salt:                salt,
+	}
+
+	nonce, err := authcapture.ComputePayerAgnosticPaymentInfoHash(chainID, paymentInfo, deployment.Escrow)
+	if err != nil {
+		return types.PaymentPayload{}, err
+	}
+
+	if assetTransferMethod == string(evm.AssetTransferMethodPermit2) {
+		return c.createPermit2Payload(ctx, requirements, bindOn, salt, saltNonce, nonce, preApprovalExpiry, chainID, deployment)
+	}
+
+	return c.createEIP3009Payload(ctx, requirements, extra, bindOn, salt, saltNonce, nonce, preApprovalExpiry, chainID, deployment)
+}
+
+func (c *AuthCaptureEvmScheme) createEIP3009Payload(
+	ctx context.Context,
+	requirements types.PaymentRequirements,
+	extra authcapture.AuthCaptureExtra,
+	bindOn bool,
+	salt string,
+	saltNonce string,
+	nonce string,
+	preApprovalExpiry uint64,
+	chainID *big.Int,
+	deployment authcapture.AuthCaptureDeployment,
+) (types.PaymentPayload, error) {
+	authorization := authcapture.Eip3009Authorization{
+		From:        c.signer.Address(),
+		To:          deployment.EIP3009Collector,
+		Value:       requirements.Amount,
+		ValidAfter:  "0",
+		ValidBefore: fmt.Sprintf("%d", preApprovalExpiry),
+		Nonce:       nonce,
+	}
+
+	signature, err := authcapture.SignERC3009(ctx, c.signer, authorization, extra, requirements.Asset, chainID)
+	if err != nil {
+		return types.PaymentPayload{}, fmt.Errorf("failed to sign ERC-3009 authorization: %w", err)
+	}
+
+	payload := map[string]interface{}{
+		"authorization": map[string]interface{}{
+			"from":        authorization.From,
+			"to":          authorization.To,
+			"value":       authorization.Value,
+			"validAfter":  authorization.ValidAfter,
+			"validBefore": authorization.ValidBefore,
+			"nonce":       authorization.Nonce,
+		},
+		"signature": evm.BytesToHex(signature),
+		"salt":      salt,
+	}
+	if bindOn {
+		payload["saltNonce"] = saltNonce
+	}
+
+	return types.PaymentPayload{
+		X402Version: 2,
+		Payload:     payload,
+	}, nil
+}
+
+func (c *AuthCaptureEvmScheme) createPermit2Payload(
+	ctx context.Context,
+	requirements types.PaymentRequirements,
+	bindOn bool,
+	salt string,
+	saltNonce string,
+	nonce string,
+	preApprovalExpiry uint64,
+	chainID *big.Int,
+	deployment authcapture.AuthCaptureDeployment,
+) (types.PaymentPayload, error) {
+	permitNonce, err := authcapture.NonceHexToDecimalString(nonce)
+	if err != nil {
+		return types.PaymentPayload{}, err
+	}
+
+	permit := authcapture.Permit2Authorization{
+		From: c.signer.Address(),
+		Permitted: authcapture.Permit2TokenPermissions{
+			Token:  requirements.Asset,
+			Amount: requirements.Amount,
+		},
+		Spender:  deployment.Permit2Collector,
+		Nonce:    permitNonce,
+		Deadline: fmt.Sprintf("%d", preApprovalExpiry),
+	}
+
+	signature, err := authcapture.SignPermit2(ctx, c.signer, permit, chainID)
+	if err != nil {
+		return types.PaymentPayload{}, fmt.Errorf("failed to sign Permit2 authorization: %w", err)
+	}
+
+	payload := map[string]interface{}{
+		"permit2Authorization": map[string]interface{}{
+			"from": permit.From,
+			"permitted": map[string]interface{}{
+				"token":  permit.Permitted.Token,
+				"amount": permit.Permitted.Amount,
+			},
+			"spender":  permit.Spender,
+			"nonce":    permit.Nonce,
+			"deadline": permit.Deadline,
+		},
+		"signature": evm.BytesToHex(signature),
+		"salt":      salt,
+	}
+	if bindOn {
+		payload["saltNonce"] = saltNonce
+	}
+
+	return types.PaymentPayload{
+		X402Version: 2,
+		Payload:     payload,
+	}, nil
+}
+
+func parseAuthCaptureExtra(requirements types.PaymentRequirements) (authcapture.AuthCaptureExtra, authcapture.AuthCaptureDeployment, error) {
+	if requirements.Extra == nil {
+		return authcapture.AuthCaptureExtra{}, authcapture.AuthCaptureDeployment{}, fmt.Errorf("'captureAuthorizer' is required in payment requirements extra")
+	}
+	ex := requirements.Extra
+
+	name, _ := ex["name"].(string)
+	if name == "" {
+		return authcapture.AuthCaptureExtra{}, authcapture.AuthCaptureDeployment{}, fmt.Errorf("EIP-712 domain parameter 'name' is required in payment requirements for asset %s", requirements.Asset)
+	}
+	version, _ := ex["version"].(string)
+	if version == "" {
+		return authcapture.AuthCaptureExtra{}, authcapture.AuthCaptureDeployment{}, fmt.Errorf("EIP-712 domain parameter 'version' is required in payment requirements for asset %s", requirements.Asset)
+	}
+
+	captureAuthorizer, _ := ex["captureAuthorizer"].(string)
+	if captureAuthorizer == "" {
+		return authcapture.AuthCaptureExtra{}, authcapture.AuthCaptureDeployment{}, fmt.Errorf("'captureAuthorizer' is required in payment requirements extra")
+	}
+	feeRecipient, _ := ex["feeRecipient"].(string)
+	if feeRecipient == "" {
+		return authcapture.AuthCaptureExtra{}, authcapture.AuthCaptureDeployment{}, fmt.Errorf("'feeRecipient' is required in payment requirements extra")
+	}
+
+	captureDeadline, err := extraUint64(ex, "captureDeadline")
+	if err != nil {
+		return authcapture.AuthCaptureExtra{}, authcapture.AuthCaptureDeployment{}, fmt.Errorf("'captureDeadline' is required in payment requirements extra")
+	}
+	refundDeadline, err := extraUint64(ex, "refundDeadline")
+	if err != nil {
+		return authcapture.AuthCaptureExtra{}, authcapture.AuthCaptureDeployment{}, fmt.Errorf("'refundDeadline' is required in payment requirements extra")
+	}
+	minFeeBps, err := extraUint16(ex, "minFeeBps")
+	if err != nil {
+		return authcapture.AuthCaptureExtra{}, authcapture.AuthCaptureDeployment{}, fmt.Errorf("'minFeeBps' is required in payment requirements extra")
+	}
+	maxFeeBps, err := extraUint16(ex, "maxFeeBps")
+	if err != nil {
+		return authcapture.AuthCaptureExtra{}, authcapture.AuthCaptureDeployment{}, fmt.Errorf("'maxFeeBps' is required in payment requirements extra")
+	}
+
+	authCaptureEscrow := stringFromExtra(ex, "authCaptureEscrow")
+	deployment := authcapture.ResolveAuthCaptureDeployment(authCaptureEscrow)
+	if deployment == nil {
+		return authcapture.AuthCaptureExtra{}, authcapture.AuthCaptureDeployment{}, fmt.Errorf("invalid authCaptureEscrow in payment requirements extra")
+	}
+
+	extraOut := authcapture.AuthCaptureExtra{
+		CaptureAuthorizer:   captureAuthorizer,
+		CaptureDeadline:     captureDeadline,
+		RefundDeadline:      refundDeadline,
+		FeeRecipient:        feeRecipient,
+		MinFeeBps:           minFeeBps,
+		MaxFeeBps:           maxFeeBps,
+		Name:                name,
+		Version:             version,
+		ReceiverAuthorizer:  stringFromExtra(ex, "receiverAuthorizer"),
+		Policy:              stringFromExtra(ex, "policy"),
+		PaymentFlow:         stringFromExtra(ex, "paymentFlow"),
+		CaptureMode:         stringFromExtra(ex, "captureMode"),
+		OperatorType:        stringFromExtra(ex, "operatorType"),
+		AssetTransferMethod: stringFromExtra(ex, "assetTransferMethod"),
+		AuthCaptureEscrow:   deployment.Escrow,
+	}
+	return extraOut, *deployment, nil
+}
+
+func stringFromExtra(ex map[string]interface{}, key string) string {
+	if v, ok := ex[key].(string); ok {
+		return v
+	}
+	return ""
+}
+
+func extraUint64(ex map[string]interface{}, key string) (uint64, error) {
+	value, ok := ex[key]
+	if !ok {
+		return 0, fmt.Errorf("missing %s", key)
+	}
+	switch v := value.(type) {
+	case float64:
+		if v < 0 || v != float64(uint64(v)) {
+			return 0, fmt.Errorf("invalid %s", key)
+		}
+		return uint64(v), nil
+	case int:
+		if v < 0 {
+			return 0, fmt.Errorf("invalid %s", key)
+		}
+		return uint64(v), nil
+	case int64:
+		if v < 0 {
+			return 0, fmt.Errorf("invalid %s", key)
+		}
+		return uint64(v), nil
+	case uint64:
+		return v, nil
+	case json.Number:
+		n, err := v.Int64()
+		if err != nil || n < 0 {
+			return 0, fmt.Errorf("invalid %s", key)
+		}
+		return uint64(n), nil
+	default:
+		return 0, fmt.Errorf("invalid %s", key)
+	}
+}
+
+func extraUint16(ex map[string]interface{}, key string) (uint16, error) {
+	n, err := extraUint64(ex, key)
+	if err != nil {
+		return 0, err
+	}
+	if n > 65535 {
+		return 0, fmt.Errorf("invalid %s", key)
+	}
+	return uint16(n), nil
+}

--- a/go/mechanisms/evm/auth-capture/client/scheme_test.go
+++ b/go/mechanisms/evm/auth-capture/client/scheme_test.go
@@ -1,0 +1,256 @@
+package client
+
+import (
+	"context"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/x402-foundation/x402/go/v2/mechanisms/evm"
+	authcapture "github.com/x402-foundation/x402/go/v2/mechanisms/evm/auth-capture"
+	"github.com/x402-foundation/x402/go/v2/types"
+)
+
+type mockSigner struct {
+	address string
+	sig     []byte
+	err     error
+
+	lastDomain      evm.TypedDataDomain
+	lastTypes       map[string][]evm.TypedDataField
+	lastPrimaryType string
+	lastMessage     map[string]interface{}
+}
+
+func (m *mockSigner) Address() string { return m.address }
+func (m *mockSigner) SignTypedData(_ context.Context, domain evm.TypedDataDomain, types map[string][]evm.TypedDataField, primaryType string, message map[string]interface{}) ([]byte, error) {
+	m.lastDomain = domain
+	m.lastTypes = types
+	m.lastPrimaryType = primaryType
+	m.lastMessage = message
+	return m.sig, m.err
+}
+
+func mockRequirements(extra map[string]interface{}) types.PaymentRequirements {
+	future := time.Now().Unix() + 86400
+	baseExtra := map[string]interface{}{
+		"captureAuthorizer": "0xcccccccccccccccccccccccccccccccccccccccc",
+		"captureDeadline":   float64(future),
+		"refundDeadline":    float64(future + 86400),
+		"feeRecipient":      "0x4444444444444444444444444444444444444444",
+		"minFeeBps":         float64(0),
+		"maxFeeBps":         float64(100),
+		"name":              "USDC",
+		"version":           "2",
+	}
+	for k, v := range extra {
+		baseExtra[k] = v
+	}
+	return types.PaymentRequirements{
+		Scheme:            authcapture.SchemeAuthCapture,
+		Network:           "eip155:84532",
+		Amount:            "1000000",
+		Asset:             "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+		PayTo:             "0x1234567890123456789012345678901234567890",
+		MaxTimeoutSeconds: 3600,
+		Extra:             baseExtra,
+	}
+}
+
+func TestAuthCaptureEvmScheme_Scheme(t *testing.T) {
+	scheme := NewAuthCaptureEvmScheme(&mockSigner{address: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"})
+	if scheme.Scheme() != authcapture.SchemeAuthCapture {
+		t.Fatalf("scheme = %q", scheme.Scheme())
+	}
+}
+
+func TestCreatePaymentPayload_InvalidAuthCaptureEscrow(t *testing.T) {
+	scheme := NewAuthCaptureEvmScheme(&mockSigner{address: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"})
+	req := mockRequirements(map[string]interface{}{
+		"authCaptureEscrow": "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+	})
+	if _, err := scheme.CreatePaymentPayload(context.Background(), req); err == nil || !strings.Contains(err.Error(), "authCaptureEscrow") {
+		t.Fatalf("expected authCaptureEscrow error, got %v", err)
+	}
+}
+
+func TestCreatePaymentPayload_V1_0EscrowPin(t *testing.T) {
+	signer := &mockSigner{
+		address: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		sig:     []byte{0xde, 0xad, 0xbe, 0xef},
+	}
+	scheme := NewAuthCaptureEvmScheme(signer)
+	scheme.now = func() time.Time { return time.Unix(1700000000, 0) }
+
+	result, err := scheme.CreatePaymentPayload(context.Background(), mockRequirements(map[string]interface{}{
+		"authCaptureEscrow": authcapture.AuthCaptureEscrowV1_0Address,
+	}))
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	auth := result.Payload["authorization"].(map[string]interface{})
+	if auth["to"] != authcapture.EIP3009TokenCollectorV1_0Address {
+		t.Fatalf("to = %v, want v1.0 collector", auth["to"])
+	}
+}
+
+func TestCreatePaymentPayload_EIP3009(t *testing.T) {
+	signer := &mockSigner{
+		address: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		sig:     []byte{0xde, 0xad, 0xbe, 0xef},
+	}
+	scheme := NewAuthCaptureEvmScheme(signer)
+	scheme.now = func() time.Time { return time.Unix(1700000000, 0) }
+
+	result, err := scheme.CreatePaymentPayload(context.Background(), mockRequirements(nil))
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if result.X402Version != 2 {
+		t.Fatalf("x402Version = %d", result.X402Version)
+	}
+	if !authcapture.IsEip3009Payload(result.Payload) {
+		t.Fatalf("payload = %+v", result.Payload)
+	}
+	if result.Payload["signature"] != "0xdeadbeef" {
+		t.Fatalf("signature = %v", result.Payload["signature"])
+	}
+
+	auth := result.Payload["authorization"].(map[string]interface{})
+	if auth["from"] != signer.address {
+		t.Fatalf("from = %v", auth["from"])
+	}
+	if auth["to"] != authcapture.EIP3009TokenCollectorAddress {
+		t.Fatalf("to = %v", auth["to"])
+	}
+	if auth["value"] != "1000000" {
+		t.Fatalf("value = %v", auth["value"])
+	}
+	if auth["validBefore"] != "1700003600" {
+		t.Fatalf("validBefore = %v", auth["validBefore"])
+	}
+	if _, ok := result.Payload["saltNonce"]; ok {
+		t.Fatal("expected no saltNonce for unbound salt")
+	}
+	if signer.lastPrimaryType != "ReceiveWithAuthorization" {
+		t.Fatalf("primaryType = %q", signer.lastPrimaryType)
+	}
+	if signer.lastDomain.Name != "USDC" || signer.lastDomain.Version != "2" {
+		t.Fatalf("domain = %+v", signer.lastDomain)
+	}
+	if signer.lastDomain.ChainID.Cmp(big.NewInt(84532)) != 0 {
+		t.Fatalf("chainId = %v", signer.lastDomain.ChainID)
+	}
+	if !strings.EqualFold(signer.lastDomain.VerifyingContract, "0x036CbD53842c5426634e7929541eC2318f3dCF7e") {
+		t.Fatalf("verifyingContract = %q", signer.lastDomain.VerifyingContract)
+	}
+}
+
+func TestCreatePaymentPayload_MissingExtraFields(t *testing.T) {
+	scheme := NewAuthCaptureEvmScheme(&mockSigner{address: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"})
+
+	req := mockRequirements(map[string]interface{}{"name": ""})
+	if _, err := scheme.CreatePaymentPayload(context.Background(), req); err == nil || !strings.Contains(err.Error(), "name") {
+		t.Fatalf("expected name error, got %v", err)
+	}
+
+	req = mockRequirements(map[string]interface{}{"version": ""})
+	if _, err := scheme.CreatePaymentPayload(context.Background(), req); err == nil || !strings.Contains(err.Error(), "version") {
+		t.Fatalf("expected version error, got %v", err)
+	}
+
+	req = mockRequirements(map[string]interface{}{"captureAuthorizer": ""})
+	if _, err := scheme.CreatePaymentPayload(context.Background(), req); err == nil || !strings.Contains(err.Error(), "captureAuthorizer") {
+		t.Fatalf("expected captureAuthorizer error, got %v", err)
+	}
+
+	req = mockRequirements(map[string]interface{}{"feeRecipient": ""})
+	if _, err := scheme.CreatePaymentPayload(context.Background(), req); err == nil || !strings.Contains(err.Error(), "feeRecipient") {
+		t.Fatalf("expected feeRecipient error, got %v", err)
+	}
+}
+
+func TestCreatePaymentPayload_BoundSalt(t *testing.T) {
+	scheme := NewAuthCaptureEvmScheme(&mockSigner{
+		address: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		sig:     []byte{0x01},
+	})
+	result, err := scheme.CreatePaymentPayload(context.Background(), mockRequirements(map[string]interface{}{
+		"receiverAuthorizer": "0x1111111111111111111111111111111111111111",
+	}))
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	saltNonce, ok := result.Payload["saltNonce"].(string)
+	if !ok || len(saltNonce) != 66 {
+		t.Fatalf("saltNonce = %v", result.Payload["saltNonce"])
+	}
+	salt, ok := result.Payload["salt"].(string)
+	if !ok || len(salt) != 66 {
+		t.Fatalf("salt = %v", result.Payload["salt"])
+	}
+	if salt == saltNonce {
+		t.Fatal("expected bound salt to differ from saltNonce")
+	}
+}
+
+func TestCreatePaymentPayload_FreshUnboundSalt(t *testing.T) {
+	scheme := NewAuthCaptureEvmScheme(&mockSigner{
+		address: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		sig:     []byte{0x01},
+	})
+	a, err := scheme.CreatePaymentPayload(context.Background(), mockRequirements(nil))
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	b, err := scheme.CreatePaymentPayload(context.Background(), mockRequirements(nil))
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if a.Payload["salt"] == b.Payload["salt"] {
+		t.Fatal("expected fresh salt on each call")
+	}
+}
+
+func TestCreatePaymentPayload_BadNetwork(t *testing.T) {
+	scheme := NewAuthCaptureEvmScheme(&mockSigner{address: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"})
+	req := mockRequirements(nil)
+	req.Network = "solana:mainnet"
+	if _, err := scheme.CreatePaymentPayload(context.Background(), req); err == nil || !strings.Contains(err.Error(), "solana:mainnet") {
+		t.Fatalf("expected network error, got %v", err)
+	}
+}
+
+func TestCreatePaymentPayload_Permit2(t *testing.T) {
+	signer := &mockSigner{
+		address: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		sig:     []byte{0xde, 0xad, 0xbe, 0xef},
+	}
+	scheme := NewAuthCaptureEvmScheme(signer)
+	result, err := scheme.CreatePaymentPayload(context.Background(), mockRequirements(map[string]interface{}{
+		"assetTransferMethod": "permit2",
+	}))
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !authcapture.IsPermit2Payload(result.Payload) {
+		t.Fatalf("payload = %+v", result.Payload)
+	}
+	auth := result.Payload["permit2Authorization"].(map[string]interface{})
+	if auth["spender"] != authcapture.Permit2TokenCollectorAddress {
+		t.Fatalf("spender = %v", auth["spender"])
+	}
+	if _, ok := new(big.Int).SetString(auth["nonce"].(string), 10); !ok {
+		t.Fatalf("nonce not decimal uint256 string: %v", auth["nonce"])
+	}
+	if signer.lastPrimaryType != "PermitTransferFrom" {
+		t.Fatalf("primaryType = %q", signer.lastPrimaryType)
+	}
+	if signer.lastDomain.Name != "Permit2" {
+		t.Fatalf("domain name = %q", signer.lastDomain.Name)
+	}
+	if signer.lastDomain.VerifyingContract != evm.PERMIT2Address {
+		t.Fatalf("verifyingContract = %q", signer.lastDomain.VerifyingContract)
+	}
+}

--- a/go/mechanisms/evm/auth-capture/constants.go
+++ b/go/mechanisms/evm/auth-capture/constants.go
@@ -25,16 +25,16 @@ const (
 	OperatorRefundCollectorV1_0Address = "0x934907bffd0901b6A21e398B9C53A4A38F02fa5d"
 
 	// AuthCaptureEscrowV1_1Address is the commerce-payments v1.1 AuthCaptureEscrow deployment (default).
-	AuthCaptureEscrowV1_1Address = "0x215Ebf02d98A792de612B888aFbcc4ddF1F02F06"
+	AuthCaptureEscrowV1_1Address = "0x13AC3b34322D12FE27D5e192D0c2b2266d4F29CB"
 
 	// EIP3009TokenCollectorV1_1Address is the commerce-payments v1.1 EIP-3009 token collector.
-	EIP3009TokenCollectorV1_1Address = "0xb57Db6Cd58D880ee5A271Fa25aB5daAcF5444a81"
+	EIP3009TokenCollectorV1_1Address = "0xEA902B37036bcb4944577ec2101ABdEDF56EbD28"
 
 	// Permit2TokenCollectorV1_1Address is the commerce-payments v1.1 Permit2 token collector.
-	Permit2TokenCollectorV1_1Address = "0xA058A1088a96D95EC08d2d66F456208199eD2D68"
+	Permit2TokenCollectorV1_1Address = "0x1aacb38b16a1a8709e80746825E53A0C9Cae9b70"
 
 	// OperatorRefundCollectorV1_1Address is the commerce-payments v1.1 operator refund collector.
-	OperatorRefundCollectorV1_1Address = "0x1babb602099e4Ebcf6F7fCd41c787Bd3BeF1A618"
+	OperatorRefundCollectorV1_1Address = "0x6a1ADdEEb4bD9c5811a613e20c172b6CE61A4aaB"
 
 	// AuthCaptureEscrowAddress is the default AuthCaptureEscrow deployment (v1.1).
 	AuthCaptureEscrowAddress = AuthCaptureEscrowV1_1Address

--- a/go/mechanisms/evm/auth-capture/constants.go
+++ b/go/mechanisms/evm/auth-capture/constants.go
@@ -1,0 +1,167 @@
+package authcapture
+
+import (
+	"strings"
+
+	"github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/x402-foundation/x402/go/v2/mechanisms/evm"
+)
+
+const (
+	// SchemeAuthCapture is the scheme identifier for auth-capture payments.
+	SchemeAuthCapture = "auth-capture"
+
+	// AuthCaptureEscrowV1_0Address is the commerce-payments v1.0 AuthCaptureEscrow deployment.
+	AuthCaptureEscrowV1_0Address = "0xBdEA0D1bcC5966192B070Fdf62aB4EF5b4420cff"
+
+	// EIP3009TokenCollectorV1_0Address is the commerce-payments v1.0 EIP-3009 token collector.
+	EIP3009TokenCollectorV1_0Address = "0x0E3dF9510de65469C4518D7843919c0b8C7A7757"
+
+	// Permit2TokenCollectorV1_0Address is the commerce-payments v1.0 Permit2 token collector.
+	Permit2TokenCollectorV1_0Address = "0x992476B9Ee81d52a5BdA0622C333938D0Af0aB26"
+
+	// OperatorRefundCollectorV1_0Address is the commerce-payments v1.0 operator refund collector.
+	OperatorRefundCollectorV1_0Address = "0x934907bffd0901b6A21e398B9C53A4A38F02fa5d"
+
+	// AuthCaptureEscrowV1_1Address is the commerce-payments v1.1 AuthCaptureEscrow deployment (default).
+	AuthCaptureEscrowV1_1Address = "0x215Ebf02d98A792de612B888aFbcc4ddF1F02F06"
+
+	// EIP3009TokenCollectorV1_1Address is the commerce-payments v1.1 EIP-3009 token collector.
+	EIP3009TokenCollectorV1_1Address = "0xb57Db6Cd58D880ee5A271Fa25aB5daAcF5444a81"
+
+	// Permit2TokenCollectorV1_1Address is the commerce-payments v1.1 Permit2 token collector.
+	Permit2TokenCollectorV1_1Address = "0xA058A1088a96D95EC08d2d66F456208199eD2D68"
+
+	// OperatorRefundCollectorV1_1Address is the commerce-payments v1.1 operator refund collector.
+	OperatorRefundCollectorV1_1Address = "0x1babb602099e4Ebcf6F7fCd41c787Bd3BeF1A618"
+
+	// AuthCaptureEscrowAddress is the default AuthCaptureEscrow deployment (v1.1).
+	AuthCaptureEscrowAddress = AuthCaptureEscrowV1_1Address
+
+	// EIP3009TokenCollectorAddress is the default EIP-3009 token collector (v1.1).
+	EIP3009TokenCollectorAddress = EIP3009TokenCollectorV1_1Address
+
+	// Permit2TokenCollectorAddress is the default Permit2 token collector (v1.1).
+	Permit2TokenCollectorAddress = Permit2TokenCollectorV1_1Address
+
+	// OperatorRefundCollectorAddress is the default operator refund collector (v1.1).
+	OperatorRefundCollectorAddress = OperatorRefundCollectorV1_1Address
+
+	saltBindingTypeString = "x402AuthCaptureSaltBinding(address receiverAuthorizer,address policy,uint256 saltNonce)"
+
+	paymentInfoTypeString = "PaymentInfo(address operator,address payer,address receiver,address token,uint120 maxAmount,uint48 preApprovalExpiry,uint48 authorizationExpiry,uint48 refundExpiry,uint16 minFeeBps,uint16 maxFeeBps,address feeReceiver,uint256 salt)"
+)
+
+// AuthCaptureDeploymentVersion identifies a commerce-payments deployment set.
+type AuthCaptureDeploymentVersion string
+
+const (
+	AuthCaptureDeploymentV1_0 AuthCaptureDeploymentVersion = "v1.0"
+	AuthCaptureDeploymentV1_1 AuthCaptureDeploymentVersion = "v1.1"
+)
+
+// AuthCaptureDeployment is a resolved commerce-payments deployment (escrow + collectors).
+type AuthCaptureDeployment struct {
+	Version                 AuthCaptureDeploymentVersion
+	Escrow                  string
+	EIP3009Collector        string
+	Permit2Collector        string
+	OperatorRefundCollector string
+}
+
+var (
+	authCaptureDeploymentV1_0 = AuthCaptureDeployment{
+		Version:                 AuthCaptureDeploymentV1_0,
+		Escrow:                  AuthCaptureEscrowV1_0Address,
+		EIP3009Collector:        EIP3009TokenCollectorV1_0Address,
+		Permit2Collector:        Permit2TokenCollectorV1_0Address,
+		OperatorRefundCollector: OperatorRefundCollectorV1_0Address,
+	}
+
+	authCaptureDeploymentV1_1 = AuthCaptureDeployment{
+		Version:                 AuthCaptureDeploymentV1_1,
+		Escrow:                  AuthCaptureEscrowV1_1Address,
+		EIP3009Collector:        EIP3009TokenCollectorV1_1Address,
+		Permit2Collector:        Permit2TokenCollectorV1_1Address,
+		OperatorRefundCollector: OperatorRefundCollectorV1_1Address,
+	}
+)
+
+// ResolveAuthCaptureDeployment selects the commerce-payments deployment from
+// optional extra.authCaptureEscrow. Absent or the v1.1 escrow selects v1.1;
+// the v1.0 escrow selects v1.0. Returns nil for unknown or invalid addresses.
+func ResolveAuthCaptureDeployment(escrow string) *AuthCaptureDeployment {
+	if escrow == "" {
+		d := authCaptureDeploymentV1_1
+		return &d
+	}
+	if !evm.IsValidAddress(escrow) {
+		return nil
+	}
+	normalized := strings.ToLower(evm.NormalizeAddress(escrow))
+	switch normalized {
+	case strings.ToLower(AuthCaptureEscrowV1_1Address), strings.ToLower(AuthCaptureEscrowAddress):
+		d := authCaptureDeploymentV1_1
+		return &d
+	case strings.ToLower(AuthCaptureEscrowV1_0Address):
+		d := authCaptureDeploymentV1_0
+		return &d
+	default:
+		return nil
+	}
+}
+
+// SaltBindingTypeHash is keccak256(SALT_BINDING_TYPEHASH string).
+var SaltBindingTypeHash = crypto.Keccak256Hash([]byte(saltBindingTypeString))
+
+// PaymentInfoTypeHash is keccak256(PaymentInfo type string); must match AuthCaptureEscrow.PAYMENT_INFO_TYPEHASH.
+var PaymentInfoTypeHash = crypto.Keccak256Hash([]byte(paymentInfoTypeString))
+
+// ReceiveAuthorizationTypes defines EIP-712 types for ERC-3009 ReceiveWithAuthorization.
+var ReceiveAuthorizationTypes = map[string][]evm.TypedDataField{
+	"ReceiveWithAuthorization": {
+		{Name: "from", Type: "address"},
+		{Name: "to", Type: "address"},
+		{Name: "value", Type: "uint256"},
+		{Name: "validAfter", Type: "uint256"},
+		{Name: "validBefore", Type: "uint256"},
+		{Name: "nonce", Type: "bytes32"},
+	},
+}
+
+// Permit2TransferFromTypes defines EIP-712 types for Permit2 PermitTransferFrom (no witness).
+var Permit2TransferFromTypes = map[string][]evm.TypedDataField{
+	"PermitTransferFrom": {
+		{Name: "permitted", Type: "TokenPermissions"},
+		{Name: "spender", Type: "address"},
+		{Name: "nonce", Type: "uint256"},
+		{Name: "deadline", Type: "uint256"},
+	},
+	"TokenPermissions": {
+		{Name: "token", Type: "address"},
+		{Name: "amount", Type: "uint256"},
+	},
+}
+
+// GetReceiveAuthorizationEIP712Types returns the complete EIP-712 types map for ERC-3009 signing.
+func GetReceiveAuthorizationEIP712Types() map[string][]evm.TypedDataField {
+	return map[string][]evm.TypedDataField{
+		"EIP712Domain": {
+			{Name: "name", Type: "string"},
+			{Name: "version", Type: "string"},
+			{Name: "chainId", Type: "uint256"},
+			{Name: "verifyingContract", Type: "address"},
+		},
+		"ReceiveWithAuthorization": ReceiveAuthorizationTypes["ReceiveWithAuthorization"],
+	}
+}
+
+// GetPermit2TransferFromEIP712Types returns the complete EIP-712 types map for Permit2 PermitTransferFrom.
+func GetPermit2TransferFromEIP712Types() map[string][]evm.TypedDataField {
+	return map[string][]evm.TypedDataField{
+		"EIP712Domain":       evm.EIP712DomainTypes,
+		"PermitTransferFrom": Permit2TransferFromTypes["PermitTransferFrom"],
+		"TokenPermissions":   Permit2TransferFromTypes["TokenPermissions"],
+	}
+}

--- a/go/mechanisms/evm/auth-capture/nonce.go
+++ b/go/mechanisms/evm/auth-capture/nonce.go
@@ -1,0 +1,292 @@
+package authcapture
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/x402-foundation/x402/go/v2/mechanisms/evm"
+)
+
+var (
+	paymentInfoHashABI  abi.Arguments
+	paymentInfoOuterABI abi.Arguments
+	saltBindingABI      abi.Arguments
+)
+
+func init() {
+	bytes32Ty, _ := abi.NewType("bytes32", "", nil)
+	addressTy, _ := abi.NewType("address", "", nil)
+	uint120Ty, _ := abi.NewType("uint120", "", nil)
+	uint48Ty, _ := abi.NewType("uint48", "", nil)
+	uint16Ty, _ := abi.NewType("uint16", "", nil)
+	uint256Ty, _ := abi.NewType("uint256", "", nil)
+
+	paymentInfoHashABI = abi.Arguments{
+		{Type: bytes32Ty},
+		{Type: addressTy},
+		{Type: addressTy},
+		{Type: addressTy},
+		{Type: addressTy},
+		{Type: uint120Ty},
+		{Type: uint48Ty},
+		{Type: uint48Ty},
+		{Type: uint48Ty},
+		{Type: uint16Ty},
+		{Type: uint16Ty},
+		{Type: addressTy},
+		{Type: uint256Ty},
+	}
+
+	paymentInfoOuterABI = abi.Arguments{
+		{Type: uint256Ty},
+		{Type: addressTy},
+		{Type: bytes32Ty},
+	}
+
+	saltBindingABI = abi.Arguments{
+		{Type: bytes32Ty},
+		{Type: addressTy},
+		{Type: addressTy},
+		{Type: uint256Ty},
+	}
+}
+
+func hashPaymentInfo(chainID *big.Int, paymentInfo PaymentInfoStruct, payer string, escrowAddress string) (string, error) {
+	maxAmount, ok := new(big.Int).SetString(paymentInfo.MaxAmount, 10)
+	if !ok {
+		return "", fmt.Errorf("invalid maxAmount: %s", paymentInfo.MaxAmount)
+	}
+	saltBig, err := saltToBigInt(paymentInfo.Salt)
+	if err != nil {
+		return "", err
+	}
+
+	encoded, err := paymentInfoHashABI.Pack(
+		PaymentInfoTypeHash,
+		common.HexToAddress(paymentInfo.Operator),
+		common.HexToAddress(payer),
+		common.HexToAddress(paymentInfo.Receiver),
+		common.HexToAddress(paymentInfo.Token),
+		maxAmount,
+		new(big.Int).SetUint64(paymentInfo.PreApprovalExpiry),
+		new(big.Int).SetUint64(paymentInfo.AuthorizationExpiry),
+		new(big.Int).SetUint64(paymentInfo.RefundExpiry),
+		paymentInfo.MinFeeBps,
+		paymentInfo.MaxFeeBps,
+		common.HexToAddress(paymentInfo.FeeReceiver),
+		saltBig,
+	)
+	if err != nil {
+		return "", fmt.Errorf("failed to ABI-encode PaymentInfo: %w", err)
+	}
+	paymentInfoHash := crypto.Keccak256Hash(encoded)
+
+	outerEncoded, err := paymentInfoOuterABI.Pack(
+		chainID,
+		common.HexToAddress(escrowAddress),
+		paymentInfoHash,
+	)
+	if err != nil {
+		return "", fmt.Errorf("failed to ABI-encode payment info outer hash: %w", err)
+	}
+	return evm.BytesToHex(crypto.Keccak256(outerEncoded)), nil
+}
+
+// ComputePayerAgnosticPaymentInfoHash returns the payer-agnostic PaymentInfo hash
+// used as the ERC-3009 nonce and Permit2 nonce (as uint256).
+func ComputePayerAgnosticPaymentInfoHash(chainID *big.Int, paymentInfo PaymentInfoStruct, escrowAddress ...string) (string, error) {
+	escrow := AuthCaptureEscrowAddress
+	if len(escrowAddress) > 0 && escrowAddress[0] != "" {
+		escrow = escrowAddress[0]
+	}
+	zero := "0x0000000000000000000000000000000000000000"
+	return hashPaymentInfo(chainID, paymentInfo, zero, escrow)
+}
+
+// SignERC3009 signs ReceiveWithAuthorization with the token EIP-712 domain from extra.
+func SignERC3009(
+	ctx context.Context,
+	signer evm.ClientEvmSigner,
+	authorization Eip3009Authorization,
+	extra AuthCaptureExtra,
+	tokenAddress string,
+	chainID *big.Int,
+) ([]byte, error) {
+	domain := evm.TypedDataDomain{
+		Name:              extra.Name,
+		Version:           extra.Version,
+		ChainID:           chainID,
+		VerifyingContract: evm.NormalizeAddress(tokenAddress),
+	}
+
+	value, ok := new(big.Int).SetString(authorization.Value, 10)
+	if !ok {
+		return nil, fmt.Errorf("invalid authorization value: %s", authorization.Value)
+	}
+	validAfter, ok := new(big.Int).SetString(authorization.ValidAfter, 10)
+	if !ok {
+		return nil, fmt.Errorf("invalid validAfter: %s", authorization.ValidAfter)
+	}
+	validBefore, ok := new(big.Int).SetString(authorization.ValidBefore, 10)
+	if !ok {
+		return nil, fmt.Errorf("invalid validBefore: %s", authorization.ValidBefore)
+	}
+	nonceBytes, err := evm.HexToBytes(authorization.Nonce)
+	if err != nil {
+		return nil, fmt.Errorf("invalid authorization nonce: %w", err)
+	}
+
+	message := map[string]interface{}{
+		"from":        evm.NormalizeAddress(authorization.From),
+		"to":          evm.NormalizeAddress(authorization.To),
+		"value":       value,
+		"validAfter":  validAfter,
+		"validBefore": validBefore,
+		"nonce":       nonceBytes,
+	}
+
+	return signer.SignTypedData(
+		ctx,
+		domain,
+		GetReceiveAuthorizationEIP712Types(),
+		"ReceiveWithAuthorization",
+		message,
+	)
+}
+
+// SignPermit2 signs PermitTransferFrom against the canonical Permit2 domain (no witness).
+func SignPermit2(
+	ctx context.Context,
+	signer evm.ClientEvmSigner,
+	permit Permit2Authorization,
+	chainID *big.Int,
+) ([]byte, error) {
+	domain := evm.TypedDataDomain{
+		Name:              "Permit2",
+		ChainID:           chainID,
+		VerifyingContract: evm.PERMIT2Address,
+	}
+
+	amount, ok := new(big.Int).SetString(permit.Permitted.Amount, 10)
+	if !ok {
+		return nil, fmt.Errorf("invalid permitted amount: %s", permit.Permitted.Amount)
+	}
+	nonce, ok := new(big.Int).SetString(permit.Nonce, 10)
+	if !ok {
+		return nil, fmt.Errorf("invalid permit nonce: %s", permit.Nonce)
+	}
+	deadline, ok := new(big.Int).SetString(permit.Deadline, 10)
+	if !ok {
+		return nil, fmt.Errorf("invalid permit deadline: %s", permit.Deadline)
+	}
+
+	message := map[string]interface{}{
+		"permitted": map[string]interface{}{
+			"token":  evm.NormalizeAddress(permit.Permitted.Token),
+			"amount": amount,
+		},
+		"spender":  evm.NormalizeAddress(permit.Spender),
+		"nonce":    nonce,
+		"deadline": deadline,
+	}
+
+	return signer.SignTypedData(
+		ctx,
+		domain,
+		GetPermit2TransferFromEIP712Types(),
+		"PermitTransferFrom",
+		message,
+	)
+}
+
+// GenerateSalt returns a fresh cryptographically-random 32-byte salt (0x-prefixed hex).
+func GenerateSalt() (string, error) {
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("failed to generate salt: %w", err)
+	}
+	return evm.BytesToHex(buf), nil
+}
+
+// NormalizeBytes32 zero-pads a hex integer to a full 32-byte word.
+func NormalizeBytes32(value string) (string, error) {
+	hexPart := strings.TrimPrefix(strings.TrimPrefix(value, "0x"), "0X")
+	if len(hexPart) == 0 || len(hexPart) > 64 {
+		return "", fmt.Errorf("invalid bytes32: %s", value)
+	}
+	if _, err := hex.DecodeString(hexPart); err != nil {
+		return "", fmt.Errorf("invalid bytes32: %s", value)
+	}
+	return "0x" + strings.ToLower(strings.Repeat("0", 64-len(hexPart))+hexPart), nil
+}
+
+// ExtraAddress treats absent or invalid values as the zero address.
+func ExtraAddress(value string) string {
+	if value == "" || !evm.IsValidAddress(value) {
+		return "0x0000000000000000000000000000000000000000"
+	}
+	return evm.NormalizeAddress(value)
+}
+
+// IsNonZeroAddress reports whether value is a valid non-zero EVM address.
+func IsNonZeroAddress(value string) bool {
+	if value == "" || !evm.IsValidAddress(value) {
+		return false
+	}
+	return !strings.EqualFold(evm.NormalizeAddress(value), "0x0000000000000000000000000000000000000000")
+}
+
+// IsSaltBindingOn is true when receiverAuthorizer or policy is non-zero.
+func IsSaltBindingOn(extra AuthCaptureExtra) bool {
+	return IsNonZeroAddress(extra.ReceiverAuthorizer) || IsNonZeroAddress(extra.Policy)
+}
+
+// DeriveBoundSalt returns keccak256(abi.encode(SALT_BINDING_TYPEHASH, receiverAuthorizer, policy, saltNonce)).
+func DeriveBoundSalt(receiverAuthorizer, policy, saltNonce string) (string, error) {
+	saltNonceBig, err := saltToBigInt(saltNonce)
+	if err != nil {
+		return "", err
+	}
+	encoded, err := saltBindingABI.Pack(
+		SaltBindingTypeHash,
+		common.HexToAddress(receiverAuthorizer),
+		common.HexToAddress(policy),
+		saltNonceBig,
+	)
+	if err != nil {
+		return "", fmt.Errorf("failed to ABI-encode bound salt: %w", err)
+	}
+	return evm.BytesToHex(crypto.Keccak256(encoded)), nil
+}
+
+func saltToBigInt(salt string) (*big.Int, error) {
+	hexPart := strings.TrimPrefix(strings.TrimPrefix(salt, "0x"), "0X")
+	if hexPart == "" {
+		return nil, fmt.Errorf("invalid salt: %s", salt)
+	}
+	if _, err := hex.DecodeString(hexPart); err != nil {
+		return nil, fmt.Errorf("invalid salt: %s", salt)
+	}
+	saltBig, ok := new(big.Int).SetString(hexPart, 16)
+	if !ok {
+		return nil, fmt.Errorf("invalid salt: %s", salt)
+	}
+	return saltBig, nil
+}
+
+// NonceHexToDecimalString interprets a 32-byte nonce hash as a uint256 decimal string.
+func NonceHexToDecimalString(nonceHex string) (string, error) {
+	nonceBytes, err := evm.HexToBytes(nonceHex)
+	if err != nil {
+		return "", err
+	}
+	return new(big.Int).SetBytes(nonceBytes).String(), nil
+}

--- a/go/mechanisms/evm/auth-capture/nonce_test.go
+++ b/go/mechanisms/evm/auth-capture/nonce_test.go
@@ -57,7 +57,7 @@ func TestComputePayerAgnosticPaymentInfoHash_Golden84532(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	want := "0xabfa4347d9119b8da1991d399233436d6f556a502312f784c38d080a1e49f993"
+	want := "0x341988b065a5131b3a82818eb7aba9010135f326af1af7695fce4d2bbebd0b76"
 	if hash != want {
 		t.Fatalf("hash = %q, want %q", hash, want)
 	}
@@ -68,7 +68,7 @@ func TestComputePayerAgnosticPaymentInfoHash_Golden8453(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	want := "0x9c63347600c217bfe7b607adfdef36a85d764610f1bdb19ed12fda5704b91528"
+	want := "0xa393f8f76a2327a7678488b2d504bda611b7586bb3f334b255a11bb5a75e79ca"
 	if hash != want {
 		t.Fatalf("hash = %q, want %q", hash, want)
 	}

--- a/go/mechanisms/evm/auth-capture/nonce_test.go
+++ b/go/mechanisms/evm/auth-capture/nonce_test.go
@@ -1,0 +1,238 @@
+package authcapture
+
+import (
+	"math/big"
+	"testing"
+)
+
+func TestResolveAuthCaptureDeployment(t *testing.T) {
+	v11 := ResolveAuthCaptureDeployment("")
+	if v11 == nil || v11.Version != AuthCaptureDeploymentV1_1 {
+		t.Fatalf("default deployment = %+v", v11)
+	}
+	if v11.Escrow != AuthCaptureEscrowV1_1Address {
+		t.Fatalf("default escrow = %q", v11.Escrow)
+	}
+
+	pinnedV11 := ResolveAuthCaptureDeployment(AuthCaptureEscrowV1_1Address)
+	if pinnedV11 == nil || pinnedV11.Version != AuthCaptureDeploymentV1_1 {
+		t.Fatalf("v1.1 pin = %+v", pinnedV11)
+	}
+
+	v10 := ResolveAuthCaptureDeployment(AuthCaptureEscrowV1_0Address)
+	if v10 == nil || v10.Version != AuthCaptureDeploymentV1_0 {
+		t.Fatalf("v1.0 pin = %+v", v10)
+	}
+	if v10.EIP3009Collector != EIP3009TokenCollectorV1_0Address {
+		t.Fatalf("v1.0 collector = %q", v10.EIP3009Collector)
+	}
+
+	if ResolveAuthCaptureDeployment("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef") != nil {
+		t.Fatal("expected unknown escrow to be rejected")
+	}
+	if ResolveAuthCaptureDeployment("not-an-address") != nil {
+		t.Fatal("expected invalid address to be rejected")
+	}
+}
+
+func mockPaymentInfo() PaymentInfoStruct {
+	return PaymentInfoStruct{
+		Operator:            "0x1111111111111111111111111111111111111111",
+		Payer:               "0xpppppppppppppppppppppppppppppppppppppppp",
+		Receiver:            "0x2222222222222222222222222222222222222222",
+		Token:               "0x3333333333333333333333333333333333333333",
+		MaxAmount:           "1000000",
+		PreApprovalExpiry:   281474976710655,
+		AuthorizationExpiry: 281474976710655,
+		RefundExpiry:        281474976710655,
+		MinFeeBps:           0,
+		MaxFeeBps:           100,
+		FeeReceiver:         "0x4444444444444444444444444444444444444444",
+		Salt:                "0x0000000000000000000000000000000000000000000000000000000000000001",
+	}
+}
+
+func TestComputePayerAgnosticPaymentInfoHash_Golden84532(t *testing.T) {
+	hash, err := ComputePayerAgnosticPaymentInfoHash(big.NewInt(84532), mockPaymentInfo())
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	want := "0xabfa4347d9119b8da1991d399233436d6f556a502312f784c38d080a1e49f993"
+	if hash != want {
+		t.Fatalf("hash = %q, want %q", hash, want)
+	}
+}
+
+func TestComputePayerAgnosticPaymentInfoHash_Golden8453(t *testing.T) {
+	hash, err := ComputePayerAgnosticPaymentInfoHash(big.NewInt(8453), mockPaymentInfo())
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	want := "0x9c63347600c217bfe7b607adfdef36a85d764610f1bdb19ed12fda5704b91528"
+	if hash != want {
+		t.Fatalf("hash = %q, want %q", hash, want)
+	}
+}
+
+func TestComputePayerAgnosticPaymentInfoHash_Golden84532_V1_0(t *testing.T) {
+	hash, err := ComputePayerAgnosticPaymentInfoHash(big.NewInt(84532), mockPaymentInfo(), AuthCaptureEscrowV1_0Address)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	want := "0x19de8ffcb747e5caadb3dda7435cf54992e87cdf0c90e5315ffa129dbb22461e"
+	if hash != want {
+		t.Fatalf("hash = %q, want %q", hash, want)
+	}
+}
+
+func TestComputePayerAgnosticPaymentInfoHash_Golden8453_V1_0(t *testing.T) {
+	hash, err := ComputePayerAgnosticPaymentInfoHash(big.NewInt(8453), mockPaymentInfo(), AuthCaptureEscrowV1_0Address)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	want := "0x198bbfeaab2f8e36302c662ae41bceaef47a1eb4bf2549cb87aa8daa7f7bb43a"
+	if hash != want {
+		t.Fatalf("hash = %q, want %q", hash, want)
+	}
+}
+
+func TestComputePayerAgnosticPaymentInfoHash_Format(t *testing.T) {
+	hash, err := ComputePayerAgnosticPaymentInfoHash(big.NewInt(84532), mockPaymentInfo())
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(hash) != 66 || hash[:2] != "0x" {
+		t.Fatalf("unexpected hash format: %q", hash)
+	}
+}
+
+func TestComputePayerAgnosticPaymentInfoHash_Deterministic(t *testing.T) {
+	info := mockPaymentInfo()
+	a, err := ComputePayerAgnosticPaymentInfoHash(big.NewInt(84532), info)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	b, err := ComputePayerAgnosticPaymentInfoHash(big.NewInt(84532), info)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if a != b {
+		t.Fatalf("hashes differ: %q vs %q", a, b)
+	}
+}
+
+func TestComputePayerAgnosticPaymentInfoHash_DifferentChainID(t *testing.T) {
+	info := mockPaymentInfo()
+	a, _ := ComputePayerAgnosticPaymentInfoHash(big.NewInt(84532), info)
+	b, _ := ComputePayerAgnosticPaymentInfoHash(big.NewInt(8453), info)
+	if a == b {
+		t.Fatal("expected different hashes for different chain IDs")
+	}
+}
+
+func TestComputePayerAgnosticPaymentInfoHash_DifferentPaymentInfo(t *testing.T) {
+	info := mockPaymentInfo()
+	other := info
+	other.MaxAmount = "2000000"
+	a, _ := ComputePayerAgnosticPaymentInfoHash(big.NewInt(84532), info)
+	b, _ := ComputePayerAgnosticPaymentInfoHash(big.NewInt(84532), other)
+	if a == b {
+		t.Fatal("expected different hashes for different maxAmount")
+	}
+}
+
+func TestComputePayerAgnosticPaymentInfoHash_DifferentSalt(t *testing.T) {
+	info := mockPaymentInfo()
+	other := info
+	other.Salt = "0x0000000000000000000000000000000000000000000000000000000000000002"
+	a, _ := ComputePayerAgnosticPaymentInfoHash(big.NewInt(84532), info)
+	b, _ := ComputePayerAgnosticPaymentInfoHash(big.NewInt(84532), other)
+	if a == b {
+		t.Fatal("expected different hashes for different salt")
+	}
+}
+
+func TestComputePayerAgnosticPaymentInfoHash_PayerAgnostic(t *testing.T) {
+	base := mockPaymentInfo()
+	a := base
+	a.Payer = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	b := base
+	b.Payer = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	c := base
+	c.Payer = "0x0000000000000000000000000000000000000000"
+
+	hashA, _ := ComputePayerAgnosticPaymentInfoHash(big.NewInt(84532), a)
+	hashB, _ := ComputePayerAgnosticPaymentInfoHash(big.NewInt(84532), b)
+	hashC, _ := ComputePayerAgnosticPaymentInfoHash(big.NewInt(84532), c)
+	if hashA != hashB || hashA != hashC {
+		t.Fatalf("expected payer-agnostic hashes to match: %q %q %q", hashA, hashB, hashC)
+	}
+}
+
+func TestGenerateSalt(t *testing.T) {
+	s1, err := GenerateSalt()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	s2, err := GenerateSalt()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(s1) != 66 || s1[:2] != "0x" {
+		t.Fatalf("bad salt format: %q", s1)
+	}
+	if s1 == s2 {
+		t.Fatal("expected unique salts")
+	}
+}
+
+func TestSaltBinding(t *testing.T) {
+	authorizer := "0x1111111111111111111111111111111111111111"
+	zero := "0x0000000000000000000000000000000000000000"
+	nonce := "0x0000000000000000000000000000000000000000000000000000000000000abc"
+
+	if IsSaltBindingOn(AuthCaptureExtra{}) {
+		t.Fatal("expected binding off for empty extra")
+	}
+	if IsSaltBindingOn(AuthCaptureExtra{ReceiverAuthorizer: zero, Policy: zero}) {
+		t.Fatal("expected binding off for zero addresses")
+	}
+	if !IsSaltBindingOn(AuthCaptureExtra{ReceiverAuthorizer: authorizer}) {
+		t.Fatal("expected binding on for non-zero receiverAuthorizer")
+	}
+
+	a, err := DeriveBoundSalt(authorizer, zero, nonce)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	b, err := DeriveBoundSalt(authorizer, zero, nonce)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if a != b {
+		t.Fatalf("expected deterministic bound salt, got %q vs %q", a, b)
+	}
+	want := "0xd0967e09b6c8fccf96277d95a03e98583e8605ab10858b1349aa50ea6d78132c"
+	if a != want {
+		t.Fatalf("bound salt = %q, want %q", a, want)
+	}
+
+	base := a
+	changedAuthorizer, _ := DeriveBoundSalt("0x2222222222222222222222222222222222222222", zero, nonce)
+	if changedAuthorizer == base {
+		t.Fatal("expected bound salt to change when receiverAuthorizer changes")
+	}
+	changedNonce, _ := DeriveBoundSalt(authorizer, zero, "0x0000000000000000000000000000000000000000000000000000000000000abd")
+	if changedNonce == base {
+		t.Fatal("expected bound salt to change when saltNonce changes")
+	}
+}
+
+func TestTypeHashConstants(t *testing.T) {
+	if SaltBindingTypeHash.Hex() != "0x8a2a7e41a0bda000ded071ff38b79401d2603e1826516ff2635b11fe9e30877f" {
+		t.Fatalf("SaltBindingTypeHash = %s", SaltBindingTypeHash.Hex())
+	}
+	if PaymentInfoTypeHash.Hex() != "0xae68ac7ce30c86ece8196b61a7c486d8f0061f575037fbd34e7fe4e2820c6591" {
+		t.Fatalf("PaymentInfoTypeHash = %s", PaymentInfoTypeHash.Hex())
+	}
+}

--- a/go/mechanisms/evm/auth-capture/types.go
+++ b/go/mechanisms/evm/auth-capture/types.go
@@ -1,0 +1,266 @@
+package authcapture
+
+import (
+	"strings"
+)
+
+// PaymentInfoStruct is the onchain PaymentInfo struct (canonical Solidity names).
+type PaymentInfoStruct struct {
+	Operator            string `json:"operator"`
+	Payer               string `json:"payer"`
+	Receiver            string `json:"receiver"`
+	Token               string `json:"token"`
+	MaxAmount           string `json:"maxAmount"`
+	PreApprovalExpiry   uint64 `json:"preApprovalExpiry"`
+	AuthorizationExpiry uint64 `json:"authorizationExpiry"`
+	RefundExpiry        uint64 `json:"refundExpiry"`
+	MinFeeBps           uint16 `json:"minFeeBps"`
+	MaxFeeBps           uint16 `json:"maxFeeBps"`
+	FeeReceiver         string `json:"feeReceiver"`
+	Salt                string `json:"salt"`
+}
+
+// AuthCaptureExtra is the wire extra after facilitator enhancement (absolute deadlines).
+type AuthCaptureExtra struct {
+	CaptureAuthorizer   string
+	CaptureDeadline     uint64
+	RefundDeadline      uint64
+	FeeRecipient        string
+	MinFeeBps           uint16
+	MaxFeeBps           uint16
+	Name                string
+	Version             string
+	PaymentFlow         string
+	CaptureMode         string
+	ReceiverAuthorizer  string
+	Policy              string
+	OperatorType        string
+	AssetTransferMethod string
+	AuthCaptureEscrow   string
+}
+
+// Eip3009Authorization is the ERC-3009 ReceiveWithAuthorization message on the wire.
+type Eip3009Authorization struct {
+	From        string `json:"from"`
+	To          string `json:"to"`
+	Value       string `json:"value"`
+	ValidAfter  string `json:"validAfter"`
+	ValidBefore string `json:"validBefore"`
+	Nonce       string `json:"nonce"`
+}
+
+// Permit2TokenPermissions is the permitted token/amount pair inside PermitTransferFrom.
+type Permit2TokenPermissions struct {
+	Token  string `json:"token"`
+	Amount string `json:"amount"`
+}
+
+// Permit2Authorization is the Permit2 PermitTransferFrom message on the wire.
+type Permit2Authorization struct {
+	From      string                  `json:"from"`
+	Permitted Permit2TokenPermissions `json:"permitted"`
+	Spender   string                  `json:"spender"`
+	Nonce     string                  `json:"nonce"`
+	Deadline  string                  `json:"deadline"`
+}
+
+// IsAuthCaptureExtra reports whether value has every spec-mandated AuthCaptureExtra field.
+func IsAuthCaptureExtra(value interface{}) bool {
+	m, ok := value.(map[string]interface{})
+	if !ok {
+		return false
+	}
+	if !isNonEmptyString(m["captureAuthorizer"]) {
+		return false
+	}
+	if !isJSONNumber(m["captureDeadline"]) {
+		return false
+	}
+	if !isJSONNumber(m["refundDeadline"]) {
+		return false
+	}
+	if !isNonEmptyString(m["feeRecipient"]) {
+		return false
+	}
+	if !isJSONNumber(m["minFeeBps"]) {
+		return false
+	}
+	if !isJSONNumber(m["maxFeeBps"]) {
+		return false
+	}
+	if !isNonEmptyString(m["name"]) {
+		return false
+	}
+	return isNonEmptyString(m["version"])
+}
+
+func isNonEmptyString(value interface{}) bool {
+	s, ok := value.(string)
+	return ok && s != ""
+}
+
+func isJSONNumber(value interface{}) bool {
+	switch value.(type) {
+	case float64, int, int64, uint64, uint16, int32, uint32:
+		return true
+	default:
+		return false
+	}
+}
+
+func isHexString(value interface{}) bool {
+	s, ok := value.(string)
+	if !ok {
+		return false
+	}
+	if !strings.HasPrefix(s, "0x") && !strings.HasPrefix(s, "0X") {
+		return false
+	}
+	hexPart := s[2:]
+	if len(hexPart) == 0 || len(hexPart) > 64 {
+		return false
+	}
+	for _, c := range hexPart {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') && (c < 'A' || c > 'F') {
+			return false
+		}
+	}
+	return true
+}
+
+func collectSaltFields(v map[string]interface{}) (saltNonce string, ok bool) {
+	if !isHexString(v["salt"]) {
+		return "", false
+	}
+	if v["saltNonce"] == nil {
+		return "", true
+	}
+	if !isHexString(v["saltNonce"]) {
+		return "", false
+	}
+	return v["saltNonce"].(string), true
+}
+
+func readChargeCompletion(v map[string]interface{}) bool {
+	hasAny := false
+	for _, key := range []string{"amount", "feeBps", "feeAmount", "feeReceiver", "authorizerSignature"} {
+		if _, ok := v[key]; ok {
+			hasAny = true
+			break
+		}
+	}
+	if !hasAny {
+		return true
+	}
+	_, hasAmount := v["amount"].(string)
+	_, hasFeeBpsFloat := v["feeBps"].(float64)
+	_, hasFeeBpsInt := v["feeBps"].(int)
+	hasFeeBps := hasFeeBpsFloat || hasFeeBpsInt
+	_, hasFeeAmount := v["feeAmount"].(string)
+	_, hasFeeReceiver := v["feeReceiver"].(string)
+	_, hasAuthorizerSig := v["authorizerSignature"].(string)
+	if !hasAmount || !hasFeeReceiver || !hasAuthorizerSig {
+		return false
+	}
+	if hasFeeBps && !hasFeeAmount {
+		return true
+	}
+	if hasFeeAmount && !hasFeeBps {
+		return true
+	}
+	return false
+}
+
+// IsEip3009Payload reports whether value is an EIP-3009-shaped auth-capture collect payload.
+func IsEip3009Payload(value interface{}) bool {
+	v, ok := value.(map[string]interface{})
+	if !ok {
+		return false
+	}
+	if v["type"] != nil {
+		return false
+	}
+	auth, ok := v["authorization"].(map[string]interface{})
+	if !ok || auth == nil {
+		return false
+	}
+	if _, ok := v["signature"].(string); !ok {
+		return false
+	}
+	saltNonce, ok := collectSaltFields(v)
+	if !ok {
+		return false
+	}
+	hasAnyCharge := false
+	for _, key := range []string{"amount", "feeBps", "feeAmount", "feeReceiver", "authorizerSignature"} {
+		if _, ok := v[key]; ok {
+			hasAnyCharge = true
+			break
+		}
+	}
+	if hasAnyCharge {
+		if saltNonce == "" {
+			return false
+		}
+		return readChargeCompletion(v)
+	}
+	return true
+}
+
+// IsPermit2Payload reports whether value is a Permit2-shaped auth-capture collect payload.
+func IsPermit2Payload(value interface{}) bool {
+	v, ok := value.(map[string]interface{})
+	if !ok {
+		return false
+	}
+	if v["type"] != nil {
+		return false
+	}
+	if _, ok := v["signature"].(string); !ok {
+		return false
+	}
+	auth, ok := v["permit2Authorization"].(map[string]interface{})
+	if !ok || auth == nil {
+		return false
+	}
+	if _, ok := auth["from"].(string); !ok {
+		return false
+	}
+	if _, ok := auth["spender"].(string); !ok {
+		return false
+	}
+	if _, ok := auth["nonce"].(string); !ok {
+		return false
+	}
+	if _, ok := auth["deadline"].(string); !ok {
+		return false
+	}
+	permitted, ok := auth["permitted"].(map[string]interface{})
+	if !ok || permitted == nil {
+		return false
+	}
+	if _, ok := permitted["token"].(string); !ok {
+		return false
+	}
+	if _, ok := permitted["amount"].(string); !ok {
+		return false
+	}
+	saltNonce, ok := collectSaltFields(v)
+	if !ok {
+		return false
+	}
+	hasAnyCharge := false
+	for _, key := range []string{"amount", "feeBps", "feeAmount", "feeReceiver", "authorizerSignature"} {
+		if _, ok := v[key]; ok {
+			hasAnyCharge = true
+			break
+		}
+	}
+	if hasAnyCharge {
+		if saltNonce == "" {
+			return false
+		}
+		return readChargeCompletion(v)
+	}
+	return true
+}

--- a/go/mechanisms/evm/auth-capture/types_test.go
+++ b/go/mechanisms/evm/auth-capture/types_test.go
@@ -1,0 +1,200 @@
+package authcapture
+
+import "testing"
+
+func TestIsAuthCaptureExtra(t *testing.T) {
+	future := float64(4102444800)
+	valid := map[string]interface{}{
+		"captureAuthorizer": "0xcccccccccccccccccccccccccccccccccccccccc",
+		"captureDeadline":   future,
+		"refundDeadline":    future + 86400,
+		"feeRecipient":      "0x4444444444444444444444444444444444444444",
+		"minFeeBps":         float64(0),
+		"maxFeeBps":         float64(100),
+		"name":              "USDC",
+		"version":           "2",
+	}
+
+	if !IsAuthCaptureExtra(valid) {
+		t.Fatal("expected valid extra")
+	}
+	if IsAuthCaptureExtra(nil) || IsAuthCaptureExtra("string") || IsAuthCaptureExtra(42) {
+		t.Fatal("expected non-object to be rejected")
+	}
+
+	noAuthorizer := copyMap(valid)
+	delete(noAuthorizer, "captureAuthorizer")
+	if IsAuthCaptureExtra(noAuthorizer) {
+		t.Fatal("expected missing captureAuthorizer to be rejected")
+	}
+
+	badDeadline := copyMap(valid)
+	badDeadline["captureDeadline"] = "soon"
+	if IsAuthCaptureExtra(badDeadline) {
+		t.Fatal("expected non-number captureDeadline to be rejected")
+	}
+
+	badFeeRecipient := copyMap(valid)
+	badFeeRecipient["feeRecipient"] = 42
+	if IsAuthCaptureExtra(badFeeRecipient) {
+		t.Fatal("expected non-string feeRecipient to be rejected")
+	}
+
+	noName := copyMap(valid)
+	delete(noName, "name")
+	if IsAuthCaptureExtra(noName) {
+		t.Fatal("expected missing name to be rejected")
+	}
+
+	noMinFee := copyMap(valid)
+	delete(noMinFee, "minFeeBps")
+	if IsAuthCaptureExtra(noMinFee) {
+		t.Fatal("expected missing minFeeBps to be rejected")
+	}
+
+	noMaxFee := copyMap(valid)
+	delete(noMaxFee, "maxFeeBps")
+	if IsAuthCaptureExtra(noMaxFee) {
+		t.Fatal("expected missing maxFeeBps to be rejected")
+	}
+
+	oldShape := map[string]interface{}{
+		"escrowAddress":   "0xeee",
+		"operatorAddress": "0xccc",
+		"tokenCollector":  "0xbbb",
+		"name":            "USDC",
+		"version":         "2",
+	}
+	if IsAuthCaptureExtra(oldShape) {
+		t.Fatal("expected old commerce-era extra to be rejected")
+	}
+}
+
+func TestIsEip3009Payload(t *testing.T) {
+	future := "4102444800"
+	valid := map[string]interface{}{
+		"authorization": map[string]interface{}{
+			"from":        "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			"to":          "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+			"value":       "1000000",
+			"validAfter":  "0",
+			"validBefore": future,
+			"nonce":       "0x1234567890123456789012345678901234567890123456789012345678901234",
+		},
+		"signature": "0xabcd",
+		"salt":      "0x0000000000000000000000000000000000000000000000000000000000000abc",
+	}
+
+	if !IsEip3009Payload(valid) {
+		t.Fatal("expected valid EIP-3009 payload")
+	}
+
+	noAuth := copyMap(valid)
+	delete(noAuth, "authorization")
+	if IsEip3009Payload(noAuth) {
+		t.Fatal("expected missing authorization to be rejected")
+	}
+
+	noSig := copyMap(valid)
+	delete(noSig, "signature")
+	if IsEip3009Payload(noSig) {
+		t.Fatal("expected missing signature to be rejected")
+	}
+
+	noSalt := copyMap(valid)
+	delete(noSalt, "salt")
+	if IsEip3009Payload(noSalt) {
+		t.Fatal("expected missing salt to be rejected")
+	}
+
+	withSaltNonce := copyMap(valid)
+	withSaltNonce["saltNonce"] = "0x0000000000000000000000000000000000000000000000000000000000000abc"
+	if !IsEip3009Payload(withSaltNonce) {
+		t.Fatal("expected bound payload with saltNonce")
+	}
+
+	lifecycle := copyMap(valid)
+	lifecycle["type"] = "capture"
+	if IsEip3009Payload(lifecycle) {
+		t.Fatal("expected lifecycle payload to be rejected")
+	}
+
+	if IsEip3009Payload(validPermit2()) || IsEip3009Payload(nil) {
+		t.Fatal("expected Permit2/null to be rejected")
+	}
+}
+
+func TestIsPermit2Payload(t *testing.T) {
+	valid := validPermit2()
+	if !IsPermit2Payload(valid) {
+		t.Fatal("expected valid Permit2 payload")
+	}
+
+	noPermit := copyMap(valid)
+	delete(noPermit, "permit2Authorization")
+	if IsPermit2Payload(noPermit) {
+		t.Fatal("expected missing permit2Authorization to be rejected")
+	}
+
+	noSalt := copyMap(valid)
+	delete(noSalt, "salt")
+	if IsPermit2Payload(noSalt) {
+		t.Fatal("expected missing salt to be rejected")
+	}
+
+	badFrom := copyMap(valid)
+	auth := copyMap(valid["permit2Authorization"].(map[string]interface{}))
+	auth["from"] = 42
+	badFrom["permit2Authorization"] = auth
+	if IsPermit2Payload(badFrom) {
+		t.Fatal("expected non-string from to be rejected")
+	}
+
+	if IsPermit2Payload(validEip3009()) {
+		t.Fatal("expected EIP-3009 payload to be rejected")
+	}
+}
+
+func validEip3009() map[string]interface{} {
+	return map[string]interface{}{
+		"authorization": map[string]interface{}{
+			"from":        "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			"to":          "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+			"value":       "1000000",
+			"validAfter":  "0",
+			"validBefore": "4102444800",
+			"nonce":       "0x1234567890123456789012345678901234567890123456789012345678901234",
+		},
+		"signature": "0xabcd",
+		"salt":      "0x0000000000000000000000000000000000000000000000000000000000000abc",
+	}
+}
+
+func validPermit2() map[string]interface{} {
+	return map[string]interface{}{
+		"permit2Authorization": map[string]interface{}{
+			"from": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			"permitted": map[string]interface{}{
+				"token":  "0xeeee",
+				"amount": "1000000",
+			},
+			"spender":  "0xdddd",
+			"nonce":    "12345",
+			"deadline": "4102444800",
+		},
+		"signature": "0xabcd",
+		"salt":      "0x0000000000000000000000000000000000000000000000000000000000000abc",
+	}
+}
+
+func copyMap(in map[string]interface{}) map[string]interface{} {
+	out := make(map[string]interface{}, len(in))
+	for k, v := range in {
+		if nested, ok := v.(map[string]interface{}); ok {
+			out[k] = copyMap(nested)
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}

--- a/go/mechanisms/evm/constants.go
+++ b/go/mechanisms/evm/constants.go
@@ -6,9 +6,10 @@ import (
 
 const (
 	// Scheme identifiers
-	SchemeExact   = "exact"
-	SchemeUpto    = "upto"
-	SchemeBatched = "batch-settlement"
+	SchemeExact       = "exact"
+	SchemeUpto        = "upto"
+	SchemeBatched     = "batch-settlement"
+	SchemeAuthCapture = "auth-capture"
 
 	// Default token decimals for USDC
 	DefaultDecimals = 6

--- a/specs/schemes/auth-capture/scheme_auth_capture_evm.md
+++ b/specs/schemes/auth-capture/scheme_auth_capture_evm.md
@@ -4,10 +4,10 @@
 
 This is the EVM binding of [`auth-capture`](./scheme_auth_capture.md). It specifies the contracts, wire fields, signatures, and facilitator logic that realize the scheme on EVM chains.
 
-The binding builds on the [base/commerce-payments](https://github.com/base/commerce-payments) contract stack:
+The binding builds on the [base/commerce-payments](https://github.com/base/commerce-payments) contract stack. Two CREATE2 deployments are specified, selected by OPTIONAL `extra.authCaptureEscrow` as [Commerce-payments deployments](#commerce-payments-deployments) sets out. The default is the v1.1 set.
 
-- `AuthCaptureEscrow` — the escrow singleton. It holds funds, enforces the expiry ordering, moves value on every operation, and gates each of them on `msg.sender == paymentInfo.operator`. Its address is the same on every supported chain.
-- **Token collectors** — one canonical contract per funding path, each turning an authorization into a token pull:
+- `AuthCaptureEscrow` — the escrow singleton. It holds funds, enforces the expiry ordering, moves value on every operation, and gates each of them on `msg.sender == paymentInfo.operator`. Its address is the same on every supported chain for a given deployment.
+- **Token collectors** — one canonical contract per funding path in that deployment, each turning an authorization into a token pull:
   - `EIP3009_TOKEN_COLLECTOR_ADDRESS` — collects from the payer via ERC-3009 `receiveWithAuthorization` (USDC, EURC, and other EIP-3009 tokens).
   - `PERMIT2_TOKEN_COLLECTOR_ADDRESS` — collects from the payer via Uniswap Permit2 `permitTransferFrom` (any ERC-20).
   - `OPERATOR_REFUND_COLLECTOR_ADDRESS` — collects refund liquidity from `paymentInfo.operator`.
@@ -20,16 +20,16 @@ The client produces exactly one signature: an ERC-3009 or Permit2 authorization 
 
 Two kinds are specified: `"delegated"`, where the facilitator is the operator, and `"custom"`, where a custom smart contract is. A third value, `"policy"`, is RESERVED for the contract operators in [Future operator type: `policy`](#future-operator-type-policy); `extra.policy` is defined and bound into the payment's identity already, so that adding that type later changes no field and no derivation.
 
-The kinds are choices about who submits which calls. They are defined in terms of the escrow's own functions, referred to below as the **escrow ABI**. The **collect** operations are `authorize` and `charge` — whichever `extra.paymentFlow` selects for the client's payload. The **lifecycle** operations are `capture`, `void`, and `refund`.
+The kinds are choices about who submits which calls. They are defined in terms of the escrow's own functions, referred to below as the **escrow ABI**. The **collect** operations are `authorize` and `charge` — whichever `extra.paymentFlow` selects for the client's payload. The **lifecycle** operations are `capture`, `void`, and `refund`. The signatures below are the v1.1 escrow. When `extra.authCaptureEscrow` is the v1.0 escrow, `charge` and `capture` take `uint16 feeBps` in place of `uint256 feeAmount`; `authorize`, `void`, and `refund` are identical across both. A `"custom"` operator MUST expose the collect ABI of the escrow it forwards to.
 
 
-| Operation   | Signature                                                                                                                          |
-| ----------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `authorize` | `authorize(PaymentInfo paymentInfo, uint256 amount, address tokenCollector, bytes collectorData)`                                  |
-| `charge`    | `charge(PaymentInfo paymentInfo, uint256 amount, address tokenCollector, bytes collectorData, uint16 feeBps, address feeReceiver)` |
-| `capture`   | `capture(PaymentInfo paymentInfo, uint256 amount, uint16 feeBps, address feeReceiver)`                                             |
-| `void`      | `void(PaymentInfo paymentInfo)`                                                                                                    |
-| `refund`    | `refund(PaymentInfo paymentInfo, uint256 amount, address tokenCollector, bytes collectorData)`                                     |
+| Operation   | Signature                                                                                                                              |
+| ----------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `authorize` | `authorize(PaymentInfo paymentInfo, uint256 amount, address tokenCollector, bytes collectorData)`                                      |
+| `charge`    | `charge(PaymentInfo paymentInfo, uint256 amount, address tokenCollector, bytes collectorData, uint256 feeAmount, address feeReceiver)` |
+| `capture`   | `capture(PaymentInfo paymentInfo, uint256 amount, uint256 feeAmount, address feeReceiver)`                                             |
+| `void`      | `void(PaymentInfo paymentInfo)`                                                                                                        |
+| `refund`    | `refund(PaymentInfo paymentInfo, uint256 amount, address tokenCollector, bytes collectorData)`                                         |
 
 
 ### `"delegated"` — facilitator is the operator
@@ -38,7 +38,7 @@ The facilitator is itself the operator and calls the escrow directly with the es
 
 When `extra.receiverAuthorizer` is a non-zero address, the facilitator relays collect and lifecycle operations. What the server gives up is enforcement: nothing onchain requires an authorizer signature, checks it against the one the server holds, or stops a capture the server never asked for, so the facilitator's own verification is the only gate. A server choosing `"delegated"` with a receiver authorizer is trusting the facilitator to relay exactly what the client payload and its own authorizer signed, and nothing else. That trust is bounded by the escrow's client-side guarantees — the client-signed maximum, the fee bounds, and `reclaim` after the capture deadline — but within those bounds it is trust, not proof.
 
-When `extra.receiverAuthorizer` is absent or the zero address, `"delegated"` is collect-only: the facilitator relays `authorize` or a full-amount `charge`, and MUST reject `payload.type` of `"capture"`, `"void"`, or `"refund"`. Later lifecycle operations run out of band under the operator's own rules (for example a self-facilitating server that submits capture from the same smart-contract account through its own API).
+When `extra.receiverAuthorizer` is absent or the zero address, `"delegated"` is authorize-only: the facilitator may relay `authorize`, but MUST reject `charge` and `payload.type` of `"capture"`, `"void"`, or `"refund"`. Later lifecycle operations run out of band under the operator's own rules (for example a self-facilitating server that submits capture from the same smart-contract account through its own API).
 
 ### `"custom"` — collect-only relay, lifecycle out of band
 
@@ -66,7 +66,7 @@ At verification time the facilitator branches on `extra.operatorType` and applie
 | `extra` field        | `"delegated"`                                                                                                                                              | `"custom"`                                                                                                                          | `"policy"`                                                                              |
 | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
 | `captureAuthorizer`  | REQUIRED — an address the facilitator controls and submits from                                                                                            | REQUIRED — the operator contract                                                                                                    | REQUIRED — the operator contract                                                        |
-| `receiverAuthorizer` | OPTIONAL — zero is collect-only; non-zero unlocks partial `charge` and relayed lifecycle, with the facilitator the only thing that checks the signature | OPTIONAL and read by no relayed settle — naming one still commits the payment to the authorizer the operator checks out of band | REQUIRED, non-zero — the operator verifies its signature onchain                        |
+| `receiverAuthorizer` | OPTIONAL for `authorize`; REQUIRED and non-zero for `charge` and relayed lifecycle, with the facilitator the only thing that checks the signature | OPTIONAL for `authorize`; REQUIRED and non-zero for `charge`, whose signature the facilitator checks before relaying | REQUIRED, non-zero — the operator verifies its signature onchain                        |
 | `policy`             | UNUSED — MUST be absent or zero                                                                                                                            | UNUSED — MUST be absent or zero                                                                                                     | OPTIONAL — zero selects the signature-only operator, non-zero names the policy contract |
 
 
@@ -88,6 +88,7 @@ Every other `extra` field means the same thing in all three, as its [`extra` ent
       "extra": {
         "name": "USDC",
         "version": "2",
+        "authCaptureEscrow": "0x13AC3b34322D12FE27D5e192D0c2b2266d4F29CB",
         "captureAuthorizer": "0xOperatorAddress",
         "operatorType": "custom",
         "receiverAuthorizer": "0xReceiverAuthorizerAddress",
@@ -111,22 +112,40 @@ Every other `extra` field means the same thing in all three, as its [`extra` ent
 | Field                 | Required | Type                           | Description                                                                                                                                                                                                                                                                    |
 | --------------------- | -------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `name`                | Yes      | `string`                       | EIP-712 token-domain name (e.g. `"USDC"`). Used for ERC-3009 signing only.                                                                                                                                                                                                     |
-| `version`             | Yes      | `string`                       | EIP-712 token-domain version (e.g. `"2"`).                                                                                                                                                                                                                                     |
+| `version`             | Yes      | `string`                       | EIP-712 token-domain version (e.g. `"2"`). Not the commerce-payments deployment.                                                                                                                                                                                               |
+| `authCaptureEscrow`   | No       | `address`                      | Canonical `AuthCaptureEscrow` this payment is collected into. Selects the [commerce-payments deployment](#commerce-payments-deployments): the v1.1 escrow (default when omitted) or the v1.0 escrow. New servers SHOULD write the v1.1 address out. Any other value is `invalid_auth_capture_evm_extra`. The matching collectors are not carried on `extra`. |
 | `captureAuthorizer`   | Yes      | `address`                      | The operator, committed onchain as `PaymentInfo.operator`.                                                                                                                                                                                                                     |
-| `receiverAuthorizer`  | Per type | `address`                      | Signer of every `authorizerSignature` on facilitator-relayed `charge` and lifecycle settles, required as [Operator fields per type](#operator-fields-per-type) gives it. MUST be non-zero to relay `charge` for less than the maximum, or to relay `capture` / `void` / `refund`. Non-zero turns [salt binding](#payment-identity) on. MAY equal `captureAuthorizer`. |
+| `receiverAuthorizer`  | Per type | `address`                      | Signer of every `authorizerSignature` on facilitator-relayed `charge` and lifecycle settles, required as [Operator fields per type](#operator-fields-per-type) gives it. MUST be non-zero for every `charge` and every relayed `capture` / `void` / `refund`. Non-zero turns [salt binding](#payment-identity) on. MAY equal `captureAuthorizer`. |
 | `policy`              | Per type | `address`                      | Policy contract governing the payment, permitted as [Operator fields per type](#operator-fields-per-type) gives it. A non-zero value turns [salt binding](#payment-identity) on alongside `receiverAuthorizer`. See [Future operator type: `policy`](#future-operator-type-policy). |
 | `captureDeadline`     | Yes      | `uint48`                       | Absolute Unix seconds; capture must occur before this. Onchain `authorizationExpiry`.                                                                                                                                                                                          |
 | `refundDeadline`      | Yes      | `uint48`                       | Absolute Unix seconds; refunds are allowed until this. Onchain `refundExpiry`.                                                                                                                                                                                                 |
 | `feeRecipient`        | Yes      | `address`                      | Fee recipient, onchain `feeReceiver`.                                                                                                                                                                                                                                          |
-| `minFeeBps`           | Yes      | `uint16`                       | Fee floor in basis points; `0` for none.                                                                                                                                                                                                                                       |
-| `maxFeeBps`           | Yes      | `uint16`                       | Fee ceiling in basis points.                                                                                                                                                                                                                                                   |
+| `minFeeBps`           | Yes      | `uint16`                       | Fee floor in basis points; `0` for none. Onchain `PaymentInfo.minFeeBps` in both deployments. The submitted `charge` / `capture` fee is not this field: v1.1 submits `feeAmount`, v1.0 submits `feeBps`. |
+| `maxFeeBps`           | Yes      | `uint16`                       | Fee ceiling in basis points. Onchain `PaymentInfo.maxFeeBps` in both deployments.                                                                                                                      |
 | `paymentFlow`         | No       | `"escrow"` \| `"authorization"` | Which lifecycle applies, and with it whether the client's payload settles as `authorize` or `charge`. Default `"escrow"`. New servers SHOULD write `"escrow"` out. A server that captures automatically after its own `authorize` is still `"escrow"`; `"authorization"` means the client's payload itself settles as a terminal `charge`. |
-| `captureMode`         | No       | `"sync"` \| `"deferred"`       | Escrow-only resource-server choice for when the post-resource finalize runs. Default `"sync"`: the after-handler `/settle` relays `capture` or `void`. `"deferred"` skips that settle so the server captures later from durable state. MUST NOT be set when `paymentFlow` is `"authorization"`. |
+| `captureMode`         | No       | `"sync"` \| `"deferred"`       | Escrow-only resource-server choice for when the post-resource finalize runs. Default `"sync"`: the after-handler `/settle` relays `capture` or `void`. `"deferred"` skips that settle so the server captures later from durable state. MUST NOT be set when `paymentFlow` is `"authorization"`, and MUST be `"deferred"` on a collect-only route — `operatorType: "custom"`, or `"delegated"` with a zero `receiverAuthorizer` — per [Sync and async finalize](#sync-and-async-finalize). |
 | `operatorType`        | No       | `"delegated"` \| `"custom"`    | Kind of `extra.captureAuthorizer`: an address the facilitator controls and submits from (`"delegated"`, EOA or smart-contract account) or a contract with permissionless collect and an out-of-band lifecycle surface (`"custom"`). Default `"delegated"`. `"policy"` is reserved for the appendix's future type. |
-| `assetTransferMethod` | No       | `"eip3009"` \| `"permit2"`     | Which canonical token collector the client authorizes. Default `"eip3009"`. A server MAY list several `accepts[]` entries differing only here, so clients can pick the method matching their token approvals. The collector address is not carried on `extra`.                  |
+| `assetTransferMethod` | No       | `"eip3009"` \| `"permit2"`     | Which canonical token collector the client authorizes. Default `"eip3009"`. A server MAY list several `accepts[]` entries differing only here, so clients can pick the method matching their token approvals. The collector address is not carried on `extra`; it is the collector of the [resolved deployment](#commerce-payments-deployments) for the chosen method. |
 
 
 Where a description above names an onchain field, that is the `AuthCaptureEscrow` struct field the value becomes; the [PaymentInfo struct](#paymentinfo-struct) appendix gives the full derivation.
+
+## Commerce-payments deployments
+
+`AUTH_CAPTURE_ESCROW_ADDRESS`, `EIP3009_TOKEN_COLLECTOR_ADDRESS`, `PERMIT2_TOKEN_COLLECTOR_ADDRESS`, and `OPERATOR_REFUND_COLLECTOR_ADDRESS` name one canonical CREATE2 set. Two sets are specified. OPTIONAL `extra.authCaptureEscrow` selects between them; the collector addresses are never on `extra`.
+
+Treat an omitted `extra.authCaptureEscrow` as the v1.1 escrow. A facilitator MUST reject any other address with `invalid_auth_capture_evm_extra`. New servers SHOULD write the v1.1 address out. A server that still collects into the v1.0 escrow MUST publish that v1.0 address so a client that defaults to v1.1 does not sign a nonce and collector for the wrong set.
+
+
+| Constant                            | v1.1 (default)                                 | v1.0                                               |
+| ----------------------------------- | ---------------------------------------------- | -------------------------------------------------- |
+| `AUTH_CAPTURE_ESCROW_ADDRESS`       | `0x13AC3b34322D12FE27D5e192D0c2b2266d4F29CB`   | `0xBdEA0D1bcC5966192B070Fdf62aB4EF5b4420cff`       |
+| `EIP3009_TOKEN_COLLECTOR_ADDRESS`   | `0xEA902B37036bcb4944577ec2101ABdEDF56EbD28`   | `0x0E3dF9510de65469C4518D7843919c0b8C7A7757`       |
+| `PERMIT2_TOKEN_COLLECTOR_ADDRESS`   | `0x1aacb38b16a1a8709e80746825E53A0C9Cae9b70`   | `0x992476B9Ee81d52a5BdA0622C333938D0Af0aB26`       |
+| `OPERATOR_REFUND_COLLECTOR_ADDRESS` | `0x6a1ADdEEb4bD9c5811a613e20c172b6CE61A4aaB`   | `0x934907bffd0901b6A21e398B9C53A4A38F02fa5d`       |
+
+
+The client's `signatureNonce` commits to the resolved escrow, and `authorization.to` / `permit2Authorization.spender` MUST be the matching collector. `PaymentInfo` is the same struct in both deployments, including `minFeeBps` / `maxFeeBps`. What differs is the submitted fee on `charge` and `capture`: v1.1 takes an absolute `feeAmount` in atomic units; v1.0 takes `feeBps`. See [Fee system](#fee-system). `PERMIT2_ADDRESS` is the canonical [Uniswap Permit2 contract](https://docs.uniswap.org/contracts/v4/deployments) in both cases.
 
 ## Client payment payload
 
@@ -138,7 +157,7 @@ The collect payload always carries `salt`, which is `PaymentInfo.salt`. It is **
 
 ### EIP-3009 (default)
 
-Unbound (v1.0 wire):
+Unbound (scheme v1.0 wire):
 
 ```json
 {
@@ -177,7 +196,7 @@ Bound — same envelope, `salt` is the commitment and `saltNonce` is added besid
 | Payload field               | Derived from                                                                                         |
 | --------------------------- | ---------------------------------------------------------------------------------------------------- |
 | `authorization.from`        | Client's own address                                                                                 |
-| `authorization.to`          | `EIP3009_TOKEN_COLLECTOR_ADDRESS`                                                                    |
+| `authorization.to`          | `EIP3009_TOKEN_COLLECTOR_ADDRESS` of the [resolved deployment](#commerce-payments-deployments) |
 | `authorization.value`       | `requirements.amount`                                                                                |
 | `authorization.validAfter`  | `0` — the token collector hardcodes the lower bound                                                  |
 | `authorization.validBefore` | `now + requirements.maxTimeoutSeconds`, which is also `PaymentInfo.preApprovalExpiry`                |
@@ -217,7 +236,7 @@ Bound — same envelope, `salt` is the commitment and `saltNonce` is added besid
 | `permit2Authorization.from`             | Client's own address                                                                     |
 | `permit2Authorization.permitted.token`  | `requirements.asset`                                                                     |
 | `permit2Authorization.permitted.amount` | `requirements.amount`                                                                    |
-| `permit2Authorization.spender`          | `PERMIT2_TOKEN_COLLECTOR_ADDRESS`                                                        |
+| `permit2Authorization.spender`          | `PERMIT2_TOKEN_COLLECTOR_ADDRESS` of the [resolved deployment](#commerce-payments-deployments) |
 | `permit2Authorization.nonce`            | The payment's `signatureNonce` as a `uint256`, see [Payment identity](#payment-identity) |
 | `permit2Authorization.deadline`         | `now + requirements.maxTimeoutSeconds`, which is also `PaymentInfo.preApprovalExpiry`    |
 | `salt` / `saltNonce`                    | `salt` always (`PaymentInfo.salt`); `saltNonce` added when bound, as for EIP-3009        |
@@ -256,7 +275,7 @@ signatureNonce    = keccak256(abi.encode(chainId, AUTH_CAPTURE_ESCROW_ADDRESS, p
 paymentInfoHash   = AuthCaptureEscrow.getHash(paymentInfo)
 ```
 
-`signatureNonce` is the nonce inside the client's token authorization, computed with `payer` zeroed and every other field holding the value it will have onchain. `paymentInfoHash` is the escrow's canonical payment identifier, computed over the real payer; it keys the escrow's `paymentState` and appears in every authorizer signature. Both commit to the chain id and the escrow address, so neither crosses chains or deployments.
+`AUTH_CAPTURE_ESCROW_ADDRESS` here is the [resolved deployment](#commerce-payments-deployments)'s escrow. `signatureNonce` is the nonce inside the client's token authorization, computed with `payer` zeroed and every other field holding the value it will have onchain. `paymentInfoHash` is the escrow's canonical payment identifier, computed over the real payer; it keys the escrow's `paymentState` and appears in every authorizer signature. Both commit to the chain id and the escrow address, so neither crosses chains or deployments.
 
 The client's random 32 bytes (`payload.salt` when unbound, `payload.saltNonce` when bound) are what keep `signatureNonce` fresh: two payers signing concurrently, or one payer buying the same resource twice, produce distinct nonces with no collision risk.
 
@@ -264,13 +283,16 @@ The client's random 32 bytes (`payload.salt` when unbound, `payload.saltNonce` w
 
 A payer MAY be a contract account, so a facilitator MUST verify all three signature forms rather than ECDSA alone: a 65-byte ECDSA signature recovered against the payload's `from`, an ERC-1271 signature checked with `isValidSignature` on a deployed wallet, and an EIP-6492 envelope for a wallet that does not exist yet. An EIP-6492 signature carries the wallet's deployment bytecode: the facilitator extracts the inner signature to verify it, and the `ERC6492SignatureHandler` inside the token collector deploys the wallet during settlement.
 
+A facilitator MUST submit `collectorData` with the wrapper intact. The token collector runs `ERC6492SignatureHandler` over those bytes, executes the preparation call through the neutral Multicall3 sender, and only then passes the inner signature to the token or Permit2; unwrapping first would drop the deployment. The bytes stay untrusted and payer-controlled, so a custom operator MUST forward them unchanged.
+
+A counterfactual payer — EIP-6492 envelope, no code at the payer address yet — has no `isValidSignature` to call, so a facilitator MUST defer the signature check to the collect simulation, where the collector deploys the wallet before the token validates. An unknown preparation target can burn arbitrary gas in the facilitator's transaction, so it MUST allowlist the targets it accepts, at verify as well as settle, and reject the rest with `invalid_auth_capture_evm_erc6492_factory_not_allowed`. An empty allowlist admits none.
+
 ### Completing the payload for settlement
 
 - `authorize` **MUST collect the full** `requirements.amount`. The server adds no amount and no `authorizerSignature`: the client's token authorization is the consent for this settle. Collecting less is destructive rather than thrifty — that authorization is single-use, so a smaller collection consumes it and permanently caps the payment below the ceiling the client agreed to.
-- `charge` without a non-zero `receiverAuthorizer` **MUST collect the full** `requirements.amount`. There is no authorizer signature, so the `feeBps` and `feeReceiver` submitted with it come from `extra` under [Fee system](#fee-system) rather than from the payload.
-- `charge` with a non-zero `receiverAuthorizer` **may name any** `amount` greater than zero and at most `requirements.amount`, carried alongside the `feeBps` and `feeReceiver` the escrow requires whenever funds are distributed, plus an `authorizerSignature` over that exact charge. Charging less than the maximum is safe because charge is terminal: the difference simply never leaves the payer.
+- `charge` **requires a non-zero** `receiverAuthorizer` and **may name any** `amount` greater than zero and at most `requirements.amount`, carried alongside the submitted fee and `feeReceiver` the escrow requires whenever funds are distributed, plus an `authorizerSignature` over that exact charge. Charging less than the maximum is safe because charge is terminal: the difference simply never leaves the payer.
 
-That last case is the only one where the server adds fields to the client's payload. It leaves the client's own fields untouched and appends four, and the payload is always bound, because a receiver authorizer is what turns the bind on:
+The charge case is the only one where the server adds fields to the client's payload. It leaves the client's own fields untouched and appends four, and the payload is always bound, because a receiver authorizer is what turns the bind on. The submitted fee field follows the [resolved deployment](#commerce-payments-deployments): `feeAmount` (atomic units, same spelling as `amount`) on v1.1, `feeBps` (`uint16`) on v1.0. A mixed group — `feeBps` on v1.1 extra, or `feeAmount` on v1.0 extra — is `invalid_auth_capture_evm_payload_format`. The default submitted fee on v1.1 is `feeAmount = amount * extra.minFeeBps / 10000`.
 
 ```json
 {
@@ -280,7 +302,7 @@ That last case is the only one where the server adds fields to the client's payl
     "salt": "0x1f0e...9c3a",
     "saltNonce": "0x0000000000000000000000000000000000000000000000000000000000000abc",
     "amount": "750000",
-    "feeBps": 100,
+    "feeAmount": "7500",
     "feeReceiver": "0xFeeRecipientAddress",
     "authorizerSignature": "0x9b1c...44ef"
   }
@@ -291,18 +313,18 @@ That last case is the only one where the server adds fields to the client's payl
 | Added field           | Type      | Description                                                                          |
 | --------------------- | --------- | ------------------------------------------------------------------------------------ |
 | `amount`              | `uint256` | The amount to charge, greater than zero and at most `requirements.amount`.           |
-| `feeBps`              | `uint16`  | Fee submitted with the call, per [Fee system](#fee-system).                          |
+| `feeAmount`           | `uint256` | Fee submitted with the call on v1.1, per [Fee system](#fee-system). On a v1.0 extra pin this field is `feeBps` (`uint16`) instead. |
 | `feeReceiver`         | `address` | Fee recipient submitted with the call, per [Fee system](#fee-system).                |
 | `authorizerSignature` | `bytes`   | EIP-712 `Charge` signature by `extra.receiverAuthorizer` over exactly these values.  |
 
 
-All four are absent on `authorize` and on a `charge` with no receiver authorizer, where the client's payload settles as it arrived.
+All four are absent on `authorize`, where the client's payload settles as it arrived.
 
 Under `escrow` the choice of amount is postponed rather than lost: `capture` and `refund` each name their own amount and each may repeat, bounded by the hold and by the amount already captured. Holding the full ceiling is therefore costless — `capture` takes only what is owed and `void` returns the rest — while a hold set too low can never be raised.
 
 ## Authorizer signatures
 
-`authorizerSignature` is an EIP-712 signature by `extra.receiverAuthorizer` over the parameters of the operation being requested. Both ECDSA and ERC-1271 signatures are valid, so the authorizer MAY itself be a contract. It is required on any facilitator-relayed `charge` with a non-zero `receiverAuthorizer`, whatever the amount, and on lifecycle settles for `"delegated"` (and `"policy"`). It is never required on `authorize`, nor on a `charge` with no receiver authorizer.
+`authorizerSignature` is an EIP-712 signature by `extra.receiverAuthorizer` over the parameters of the operation being requested. Both ECDSA and ERC-1271 signatures are valid, so the authorizer MAY itself be a contract. It is required on every facilitator-relayed `charge`, whatever the amount, and on lifecycle settles for `"delegated"` (and `"policy"`). It is never required on `authorize`.
 
 The server chooses that authorizer: an address it owns — an EOA, or a contract so the signing key can rotate — or an address the facilitator advertises in [`/supported`](#supported), delegating authorization to it. Delegation applies wherever a payload carries `authorizerSignature`, `charge` and lifecycle alike: the server omits the field, and the facilitator produces the signature after authenticating the request out of band, rejecting it with `invalid_auth_capture_evm_unauthenticated_authorizer_request` when it cannot. The signature is then the facilitator's own and no longer evidence of the server's intent, so that authentication is what has to supply the evidence instead.
 
@@ -318,15 +340,18 @@ Every operator type shares one domain, with the capture authorizer as `verifying
 
 ### Types
 
-The two repeatable lifecycle operations carry the single-use element [`auth-capture`](./scheme_auth_capture.md#core-properties) requires by binding both escrow balances the authorizer expects to find.
+The two repeatable lifecycle operations carry the single-use element [`auth-capture`](./scheme_auth_capture.md#core-properties) requires by binding both escrow balances the authorizer expects to find. `Charge` and `Capture` include the submitted fee as the onchain argument: `uint256 feeAmount` on v1.1, `uint16 feeBps` on a v1.0 extra pin.
 
 
-| Operation | Signed type                                                                                                                                           |
-| --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `charge`  | `Charge(bytes32 paymentInfoHash,uint256 amount,address tokenCollector,bytes32 collectorDataHash,uint16 feeBps,address feeReceiver)`                   |
-| `void`    | `Void(bytes32 paymentInfoHash)`                                                                                                                       |
-| `capture` | `Capture(bytes32 paymentInfoHash,uint256 amount,uint16 feeBps,address feeReceiver,uint256 expectedCapturableAmount,uint256 expectedRefundableAmount)` |
-| `refund`  | `Refund(bytes32 paymentInfoHash,uint256 amount,address tokenCollector,uint256 expectedCapturableAmount,uint256 expectedRefundableAmount)`             |
+| Operation | Signed type (v1.1)                                                                                                                                         |
+| --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `charge`  | `Charge(bytes32 paymentInfoHash,uint256 amount,address tokenCollector,bytes32 collectorDataHash,uint256 feeAmount,address feeReceiver)`                    |
+| `void`    | `Void(bytes32 paymentInfoHash)`                                                                                                                            |
+| `capture` | `Capture(bytes32 paymentInfoHash,uint256 amount,uint256 feeAmount,address feeReceiver,uint256 expectedCapturableAmount,uint256 expectedRefundableAmount)`  |
+| `refund`  | `Refund(bytes32 paymentInfoHash,uint256 amount,address tokenCollector,uint256 expectedCapturableAmount,uint256 expectedRefundableAmount)`                  |
+
+
+On a v1.0 extra pin, `Charge` and `Capture` use `uint16 feeBps` in place of `uint256 feeAmount`; `Void` and `Refund` are unchanged. The authorizer MUST sign the fee field that the escrow call will take. Converting `feeBps` to `feeAmount` at encode time on v1.1 is invalid: the digest would not cover the value that executes.
 
 
 `collectorDataHash` is `keccak256(collectorData)`. `Refund` carries no funding address, because the escrow ABI has no such parameter: refund liquidity comes from `paymentInfo.operator` itself, as [Refund funding](#refund-funding) sets out.
@@ -348,7 +373,9 @@ Whether the post-resource finalize runs during the paid request or afterwards is
 - **Sync.** The in-request `/settle` after the resource runs is a `capture`, a partial `capture` with `void` of the remaining balance, or a `void`. No durable payment state is required.
 - **Async.** That second in-request settle does not call the facilitator or broadcast a transaction. The server instead commits enough payment info into durable storage to author lifecycle settles later — at least `paymentInfo`, and when the bind is on the client `saltNonce`.
 
-A later facilitator-relayed `refund` always requires durable state, including after a sync finalize. Both patterns are open to the types that relay lifecycle: `"delegated"` with a non-zero `receiverAuthorizer`, and the appendix's `"policy"` type. The collect-only cases — `"custom"`, and `"delegated"` with no receiver authorizer — are async only, since lifecycle always runs out of band against the stored payment.
+A later facilitator-relayed `refund` always requires durable state, including after a sync finalize. Both patterns are open to the types that relay lifecycle: `"delegated"` with a non-zero `receiverAuthorizer`, and the appendix's `"policy"` type.
+
+The collect-only cases — `"custom"`, and `"delegated"` with no receiver authorizer — are async only, since lifecycle always runs out of band against the stored payment. A resource server MUST NOT publish `captureMode: "sync"` on one of those routes, and because `"sync"` is the default it MUST write `"deferred"` out rather than leave the field off. A route that gets this wrong strands the payment: the collect escrows the payer's funds, the after-handler `capture` or `void` is refused with `invalid_auth_capture_evm_lifecycle_not_relayed` since the facilitator relays no lifecycle for these types, and the hold then sits until the payer calls `reclaim` after the capture deadline.
 
 ## Lifecycle payloads
 
@@ -384,7 +411,7 @@ Lifecycle payloads are bind-on: they carry `saltNonce` next to `paymentInfo.salt
     },
     "saltNonce": "0x0000000000000000000000000000000000000000000000000000000000000abc",
     "amount": "750000",
-    "feeBps": 100,
+    "feeAmount": "7500",
     "feeReceiver": "0xFeeRecipientAddress",
     "expectedCapturableAmount": "1000000",
     "expectedRefundableAmount": "0",
@@ -437,23 +464,25 @@ Lifecycle payloads are bind-on: they carry `saltNonce` next to `paymentInfo.salt
 
 ### Client payment payload
 
-The operation is `authorize` or `charge` according to `extra.paymentFlow`, which defaults to `"escrow"` when omitted. The facilitator performs these checks in order:
+The operation is `authorize` or `charge` according to `extra.paymentFlow`, which defaults to `"escrow"` when omitted. A resource server first sends the client-authored payload to `/verify`; for `charge`, that initial payload omits the four server-authored completion fields. Before `/settle`, the server adds all four fields from [Completing the payload for settlement](#completing-the-payload-for-settlement). A facilitator MUST accept the raw form at `/verify`, but MUST require the completed form at `/settle`. It performs these checks in order:
 
-1. **Shape guard**: the payload matches the EIP-3009 or Permit2 shape above, with `signature` and `salt` always present, and `saltNonce` present if and only if the bind is on. A `charge` with a non-zero `receiverAuthorizer` also carries `amount`, `feeBps`, `feeReceiver`, and `authorizerSignature` — the last omitted when the authorizer is delegated to the facilitator — and every other settle carries none of the four (see [Completing the payload for settlement](#completing-the-payload-for-settlement)). A server that nonce-probes for v1.0 clients is the one exception to the `saltNonce` rule, accepting a bound payment whose `saltNonce` is absent under [Compatibility with v1.0](#compatibility-with-v10).
+1. **Shape guard**: the payload matches the EIP-3009 or Permit2 shape above, with `signature` and `salt` always present, and `saltNonce` present if and only if the bind is on. A completed `charge` carries `amount`, the deployment's fee field (`feeAmount` on v1.1, `feeBps` on a v1.0 extra pin), `feeReceiver`, and `authorizerSignature` together — the last omitted only when the authorizer is delegated to the facilitator — while the raw `/verify` form and every `authorize` carry none of the four. Any partial group is invalid, a mixed fee field for the resolved deployment is invalid, and `/settle` rejects a `charge` that still has none. A server that nonce-probes for v1.0 clients is the one exception to the `saltNonce` rule, accepting a bound payment whose `saltNonce` is absent under [Compatibility with v1.0](#compatibility-with-v10).
 2. **Scheme match**: `requirements.scheme` and `payload.accepted.scheme` are both `auth-capture`.
 3. **Network match**: `payload.accepted.network === requirements.network`, in `eip155:<chainId>` form.
-4. **Extra validation**: `requirements.extra` carries `captureAuthorizer`, `captureDeadline`, `refundDeadline`, `feeRecipient`, `minFeeBps`, `maxFeeBps`, `name`, and `version`; resolved `paymentFlow` is one of the two defined values, and the fee fields satisfy [Fee system](#fee-system).
+4. **Extra validation**: `requirements.extra` carries `captureAuthorizer`, `captureDeadline`, `refundDeadline`, `feeRecipient`, `minFeeBps`, `maxFeeBps`, `name`, and `version`; `extra.authCaptureEscrow` is absent or one of the two canonical escrow addresses in [Commerce-payments deployments](#commerce-payments-deployments); resolved `paymentFlow` is one of the two defined values, and the fee fields satisfy [Fee system](#fee-system).
 5. **Operator**: `extra.operatorType`, `extra.policy`, and `extra.receiverAuthorizer` pass the validation in [Operator types](#validation-before-relaying).
 6. **Method routing**: `extra.assetTransferMethod` (default `"eip3009"`) matches the payload shape.
 7. **Deadline ordering**: `refundDeadline >= captureDeadline`, `now + maxTimeoutSeconds <= captureDeadline` so the whole window a client may sign for fits inside the hold, `captureDeadline > now + 6s` (the 6s figure is a floor; implementations MAY use a larger skew), and `validBefore` (EIP-3009) or `deadline` (Permit2) `<= captureDeadline`.
 8. **Time window**: `validBefore` / `deadline` `> now + 6s` (floor, as in step 7), and `validAfter <= now` (EIP-3009 only).
-9. **Collector match**: `authorization.to === EIP3009_TOKEN_COLLECTOR_ADDRESS`, or `permit2Authorization.spender === PERMIT2_TOKEN_COLLECTOR_ADDRESS`. Do not read a collector from `extra`.
+9. **Collector match**: `authorization.to === EIP3009_TOKEN_COLLECTOR_ADDRESS`, or `permit2Authorization.spender === PERMIT2_TOKEN_COLLECTOR_ADDRESS`, using the collectors of the [resolved deployment](#commerce-payments-deployments). Do not read a collector from `extra`.
 10. **Token match**: `permitted.token === requirements.asset` (Permit2 only; EIP-3009 binds the token through its signing domain).
-11. **Client signature**: verify the signature over the `ReceiveWithAuthorization` or `PermitTransferFrom` digest against the `from` address the payload names, which is the payer. ECDSA, ERC-1271, and EIP-6492 signatures are all valid and a facilitator MUST accept all three, as [Smart-wallet signatures](#smart-wallet-signatures) sets out.
-12. **Amount and fee**: `authorization.value` or `permitted.amount` equals `requirements.amount`, and for `charge`, either there is no receiver authorizer and the charged amount is `requirements.amount`, or `0 < payload.amount <= requirements.amount` with an authorizer signature. The `feeBps` and `feeReceiver` to be submitted satisfy [Fee system](#fee-system) either way.
+11. **Client signature**: verify the signature over the `ReceiveWithAuthorization` or `PermitTransferFrom` digest against the `from` address the payload names, which is the payer. ECDSA, ERC-1271, and EIP-6492 signatures are all valid and a facilitator MUST accept all three, as [Smart-wallet signatures](#smart-wallet-signatures) sets out. For a counterfactual payer this check moves to the simulation in step 15; the allowlist gate on the preparation target replaces it here.
+12. **Amount and fee**: `authorization.value` or `permitted.amount` equals `requirements.amount`; `authorize` settles that full amount. A completed `charge` requires `0 < payload.amount <= requirements.amount`, and its submitted fee (`feeAmount` on v1.1, `feeBps` on a v1.0 extra pin) and `feeReceiver` satisfy [Fee system](#fee-system). For raw `/verify`, use `requirements.amount` and the default fee terms as provisional simulation inputs.
 13. **Nonce match**: reconstruct `PaymentInfo` from `extra`, `payload.salt` as `PaymentInfo.salt`, the payer, and the requirements; recompute `signatureNonce` and assert it equals the nonce on the wire. When bound, also require `payload.salt == uint256(keccak256(abi.encode(SALT_BINDING_TYPEHASH, receiverAuthorizer, policy, saltNonce)))`. This transitively enforces equality on every field encoded in `PaymentInfo` — receiver, token, deadlines, fee bounds, fee recipient, operator, and when bound the receiver authorizer and policy — so none of them needs a check of its own.
-14. **Authorizer signature** (`charge` with a non-zero `receiverAuthorizer` only): the `Charge` signature recovers to `extra.receiverAuthorizer`, whatever the amount, or the facilitator produces it under the delegation rule in [Authorizer signatures](#authorizer-signatures). Skip for `authorize` and for a `charge` with no receiver authorizer.
-15. **Simulate** the settlement call and require success.
+14. **Authorizer signature** (completed `charge` only): the `Charge` signature recovers to the required non-zero `extra.receiverAuthorizer`, whatever the amount, or the facilitator produces it under the delegation rule in [Authorizer signatures](#authorizer-signatures). Skip for `authorize` and the raw `/verify` form; `/settle` cannot use that raw form.
+15. **Simulate** the settlement call and require success. Raw charge verification simulates the provisional full-amount charge from step 12; settlement re-verification simulates the exact authorizer-signed charge it will submit.
+
+Step 15 is materially heavier on RPC for `operatorType: "custom"` than for `"delegated"`, which simulates a single escrow call: the custom outcome assertions in [`/supported`](#supported) need the operator's token store and the pre- and post-call state around the relay.
 
 ### Lifecycle payloads
 
@@ -484,9 +513,9 @@ For an admitted lifecycle payload, the facilitator repeats the scheme, network, 
 
 ## Settlement
 
-1. **Re-verify** the payload, catching anything that expired or was consumed since verification.
-2. **Resolve the target**: the escrow for `operatorType: "delegated"`, `extra.captureAuthorizer` for `"custom"`.
-3. **Encode the call** for the operation, which is `payload.type` on a lifecycle payload and `extra.paymentFlow`'s implied `authorize` or `charge` on a client payload. For `authorize` and `charge`, resolve the collector from `extra.assetTransferMethod` and set `collectorData` to the raw ERC-3009 signature or the ABI-encoded Permit2 signature; `authorize` passes `requirements.amount`, and `charge` passes the payload's `amount` (or `requirements.amount` when there is no receiver authorizer) plus `feeBps` and `feeReceiver`. Those two come from the payload when an authorizer signature covers the call, and otherwise from [Fee system](#fee-system). For `refund`, the collector is `OPERATOR_REFUND_COLLECTOR_ADDRESS` with empty `collectorData`.
+1. **Re-verify** the payload, requiring the completed charge form and catching anything that expired or was consumed since verification.
+2. **Resolve the target**: the resolved `AUTH_CAPTURE_ESCROW_ADDRESS` for `operatorType: "delegated"`, `extra.captureAuthorizer` for `"custom"`.
+3. **Encode the call** for the operation, which is `payload.type` on a lifecycle payload and `extra.paymentFlow`'s implied `authorize` or `charge` on a client payload. For `authorize` and `charge`, resolve the collector from `extra.assetTransferMethod` and the [resolved deployment](#commerce-payments-deployments), and set `collectorData` to the raw ERC-3009 signature or the ABI-encoded Permit2 signature; `authorize` passes `requirements.amount`, and `charge` passes the authorizer-signed payload's `amount`, submitted fee (`feeAmount` on v1.1, `feeBps` on a v1.0 extra pin), and `feeReceiver` with no conversion between the two. For `refund`, the collector is `OPERATOR_REFUND_COLLECTOR_ADDRESS` with empty `collectorData`.
 4. **Capture-and-void**: when `payload.type` is `"capture"` and `voidAuthorizerSignature` is present, drive both legs from this single `/settle`: encode `capture` as above, then `void` with that signature. Submit them in one transaction when the target allows — any batched path the facilitator controls for `"delegated"` — and otherwise as two transactions still under this one request. If a race empties the hold between capture and void, skip `void` and treat the settle as capture-only success.
 5. **Submit**, wait up to 60 s for the receipt, and confirm the transaction succeeded onchain.
 6. **Return** the transaction hash, network, payer, and the amount settled (the captured amount; void releases the rest without changing that figure).
@@ -528,14 +557,16 @@ Facilitator-relayed refunds use `OperatorRefundCollector`, which pulls the refun
 - `extra.captureAuthorizer` is the address the facilitator commits to submitting from on this network. It is REQUIRED unless `extra.operators` is non-empty, which is the relay-only case where the facilitator never acts as operator itself: a kind without it admits nothing but `operatorType: "delegated"`, and a server has no other source for the submitter address, so a kind carrying neither is malformed. A server using that kind for `operatorType: "delegated"` copies it verbatim into its payment requirements. A facilitator that advertises a `captureAuthorizer` MUST submit `"delegated"` calls from it. A facilitator MAY vary which submitter it advertises between `/supported` responses to spread load across its keys. Because the address is committed onchain as `PaymentInfo.operator` and is the only address the escrow accepts for that payment's `capture`, `void`, and `refund`, a facilitator MUST remain able to submit from an address it has advertised until every payment that used it has passed its `refundDeadline`. Retiring a submitter earlier strands outstanding holds: nothing can capture or void them, and the payer recovers the funds only by calling `reclaim` after the capture deadline. A facilitator that rotates submitters and also relays `type: "refund"` for `"delegated"` MUST fund and approve **every** address in the rotation, since `OperatorRefundCollector` pulls with `safeTransferFrom(token, PaymentInfo.operator, tokenStore, amount)`.
 - `extra.receiverAuthorizer` is OPTIONAL: an address the facilitator will sign with on a server's behalf, which a server MAY adopt in place of an authorizer it owns under [Authorizer signatures](#authorizer-signatures). A facilitator MUST NOT advertise one unless it can authenticate those requests out of band, for example with SIWX, a JWT, or an API credential bound at payment creation. A payment commits to both addresses — `receiverAuthorizer` through the salt, `captureAuthorizer` as `PaymentInfo.operator` — so one that delegates both is captive to this facilitator until its `refundDeadline`, and a server changing facilitators SHOULD let outstanding payments finalize first.
 - `extra.feeRecipient`, `extra.minFeeBps`, and `extra.maxFeeBps` are OPTIONAL facilitator fee terms. A server using that supported kind MUST copy all three verbatim into its payment requirements. Equal bounds fix the fee and are what a facilitator SHOULD advertise; unequal bounds ask the server to grant free choice up to `maxFeeBps`, since nothing onchain holds the facilitator to a narrower value. Omission means the facilitator claims no fee, and a `"delegated"` server publishes zero bounds per [Fee system](#fee-system).
-- `extra.operators` is an OPTIONAL allowlist of the contract operators the facilitator will relay for, each entry pairing an address with the type it is admitted as. Omitted or `[]` admits no contract operator at all, leaving only `operatorType: "delegated"` with the facilitator's own submitter. `"address": "*"` admits every contract of that type; the wildcard MUST be written out, and an empty list MUST NOT be read as one.
+- `extra.operators` is an OPTIONAL allowlist of the contract operators the facilitator will relay for, each entry pairing an address with the type it is admitted as. Omitted or `[]` admits no contract operator at all, leaving only `operatorType: "delegated"` with the facilitator's own submitter. `"address": "*"` admits every contract of that type; the wildcard MUST be written out, and an empty list MUST NOT be read as one. A facilitator MAY advertise the wildcard, but it is not recommended: admission then extends to contract code the facilitator has never reviewed, bounded only by the requirements below.
 
 A facilitator that offers `"custom"` is relaying into contract code and MUST:
 
 1. **Cap the gas.** The simulated and submitted calls MUST use a gas limit chosen by the facilitator, so an operator cannot drain its gas budget.
-2. **Assert the outcome, not the absence of a revert.** Before relaying, the facilitator MUST simulate the exact call and confirm that the canonical escrow emitted the expected `PaymentAuthorized` or `PaymentCharged` event with the expected payment hash and arguments, that `paymentState` made the exact intended before-to-after transition, and that the net token movements match the operation. A successful top-level operator call alone is insufficient. No token movement may originate from a facilitator-controlled address.
+2. **Assert the outcome, not the absence of a revert.** Before relaying, the facilitator MUST simulate the exact call and confirm that the canonical escrow of the [resolved deployment](#commerce-payments-deployments) emitted the expected `PaymentAuthorized` or `PaymentCharged` event with the expected payment hash and arguments (`feeAmount` on v1.1 `PaymentCharged`, `feeBps` on v1.0), that `paymentState` made the exact intended before-to-after transition, and that the net token movements match the operation. A successful top-level operator call alone is insufficient. No token movement may originate from a facilitator-controlled address.
 
 The simulation RPC MUST expose nested-call logs and enough pre- and post-call state to establish those conditions, whether through state diffs or stateful follow-up reads. A facilitator without access to those capabilities MUST NOT advertise or accept `"custom"`. After the transaction is confirmed, the facilitator MUST apply the same outcome checks to the actual receipt and resulting onchain state before reporting settlement success; a successful receipt status alone is insufficient.
+
+Admission is by address, not by code: an operator behind a proxy can change implementation after it is admitted. A facilitator SHOULD prefer immutable operators, and MUST apply the assertions above on every relay rather than resting on a review.
 
 ## Error Codes
 
@@ -546,7 +577,7 @@ The scheme uses the standard x402 error codes plus the following. Every reason t
 
 | Error Code                                                   | Description                                                                                                                                          |
 | ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `invalid_auth_capture_evm_payload_format`                    | Payload matches neither the EIP-3009 nor the Permit2 shape, omits `salt`, omits `saltNonce` when bound (unless probing), or carries it unbound.   |
+| `invalid_auth_capture_evm_payload_format`                    | Payload matches neither the EIP-3009 nor the Permit2 shape, omits `salt`, omits `saltNonce` when bound (unless probing), carries it unbound, or carries the wrong fee field for the resolved deployment (`feeBps` on v1.1 extra, or `feeAmount` on a v1.0 extra pin). |
 | `invalid_auth_capture_evm_payload_type`                      | A lifecycle payload's `payload.type` is missing or is not `"capture"`, `"void"`, or `"refund"`.                                                      |
 | `invalid_auth_capture_evm_void_authorizer_signature`         | `voidAuthorizerSignature` is present on a non-capture payload, or does not recover to `extra.receiverAuthorizer` over the `Void` digest.             |
 | `invalid_auth_capture_evm_void_remainder_full_capture`       | `voidAuthorizerSignature` is present but `amount` equals the full `capturableAmount`, leaving nothing to void.                                       |
@@ -554,8 +585,8 @@ The scheme uses the standard x402 error codes plus the following. Every reason t
 | `invalid_auth_capture_evm_scheme`                            | Scheme is not `auth-capture`.                                                                                                                        |
 | `invalid_auth_capture_evm_network_mismatch`                  | Payload network does not match requirements.                                                                                                         |
 | `invalid_network`                                            | Network format is not `eip155:<chainId>`.                                                                                                            |
-| `invalid_auth_capture_evm_extra`                             | Extra is missing required fields, or its fee fields violate [Fee system](#fee-system).                                                               |
-| `invalid_auth_capture_evm_missing_receiver_authorizer`       | `extra.receiverAuthorizer` is absent or zero when this settle requires it non-zero (partial `charge`, or facilitator-relayed lifecycle).             |
+| `invalid_auth_capture_evm_extra`                             | Extra is missing required fields, `authCaptureEscrow` is not a canonical escrow address, or its fee fields violate [Fee system](#fee-system).       |
+| `invalid_auth_capture_evm_missing_receiver_authorizer`       | `extra.receiverAuthorizer` is absent or zero for a `charge` or facilitator-relayed lifecycle settle.                                                |
 | `invalid_auth_capture_evm_unsupported_operator_type`         | `extra.operatorType` is an unknown value, or a type the facilitator does not implement.                                                              |
 | `invalid_auth_capture_evm_policy`                            | `extra.policy` does not fit the declared operator type: non-zero where the zero address is required, or not a policy contract where one is expected. |
 | `invalid_auth_capture_evm_lifecycle_not_relayed`             | A lifecycle payload (`capture`, `void`, or `refund`) was submitted for `operatorType: "custom"`, or for `"delegated"` without a receiver authorizer. |
@@ -575,6 +606,7 @@ The scheme uses the standard x402 error codes plus the following. Every reason t
 | `invalid_auth_capture_evm_authorization_expired`             | EIP-3009 `validBefore` or Permit2 `deadline` is `<= now + 6s` (floor).                                                                               |
 | `invalid_auth_capture_evm_authorization_not_yet_valid`       | EIP-3009 `validAfter > now`.                                                                                                                         |
 | `invalid_auth_capture_evm_signature`                         | Client signature verification failed.                                                                                                                |
+| `invalid_auth_capture_evm_erc6492_factory_not_allowed`       | The payer is counterfactual and its EIP-6492 preparation target is not on the facilitator's allowlist.                                               |
 | `invalid_auth_capture_evm_amount_mismatch`                   | Authorization value does not match `requirements.amount`.                                                                                            |
 | `invalid_auth_capture_evm_token_collector_mismatch`          | `to` or `spender` is not the expected collector for the method.                                                                                      |
 | `invalid_auth_capture_evm_token_mismatch`                    | Permit2 `permitted.token` does not match `requirements.asset`.                                                                                       |
@@ -603,6 +635,7 @@ When simulation reverts with a custom error declared in the call's ABI, the faci
 | `FeeBpsOverflow`                | `invalid_auth_capture_evm_fee_bps`                                                      |
 | `InvalidFeeBpsRange`            | `invalid_auth_capture_evm_fee_bps_range`                                                |
 | `FeeBpsOutOfRange`              | `invalid_auth_capture_evm_fee_bps_out_of_range`                                         |
+| `FeeAmountOutOfRange`           | `invalid_auth_capture_evm_fee_bps_out_of_range`                                         |
 | `ZeroFeeReceiver`               | `invalid_auth_capture_evm_zero_fee_receiver`                                            |
 | `InvalidFeeReceiver`            | `invalid_auth_capture_evm_fee_receiver`                                                 |
 | `AfterAuthorizationExpiry`      | `invalid_auth_capture_evm_capture_deadline_expired`                                     |
@@ -658,41 +691,48 @@ The escrow enforces `preApprovalExpiry <= authorizationExpiry <= refundExpiry`, 
 
 ### Fee system
 
-Fees are enforced onchain by the escrow:
+`PaymentInfo.minFeeBps` and `PaymentInfo.maxFeeBps` are the client-signed bounds in both deployments, each in the range 0–10,000. They stay in basis points so each `charge` or `capture` scales its own `amount`: 100 bps of 750000 is not 100 bps of 1000000. `authorize` has no fee argument.
 
-- `feeBps` submitted at capture or charge must fall within the client-signed `[minFeeBps, maxFeeBps]`, both in the range 0–10,000.
-- `feeAmount = amount * feeBps / 10000`, and the remainder goes to the receiver.
-- If `PaymentInfo.feeReceiver` is non-zero, the submitted `feeReceiver` must equal it; if it is `address(0)`, any non-zero address is accepted.
+The submitted fee on `charge` and `capture` is the onchain argument, and that is what the authorizer signs:
 
-Those three are the guarantee. Who holds the submitter to a narrower value differs per operator type:
+- **v1.1 (default).** The call takes `uint256 feeAmount` in atomic units. The escrow requires `amount * minFeeBps / 10000 <= feeAmount <= amount * maxFeeBps / 10000`. Integer division is the escrow's. The default submitted value is `amount * minFeeBps / 10000`.
+- **v1.0 extra pin.** The call takes `uint16 feeBps`. The escrow requires `minFeeBps <= feeBps <= maxFeeBps` and computes `feeAmount = amount * feeBps / 10000` itself.
 
-- `"delegated"` — the escrow's range and a non-zero `feeReceiver` are the only limits. An `authorizerSignature` over `feeBps` tells a conformant facilitator what to submit, but nothing onchain reads that signature, so the server's exposure is `maxFeeBps` whether the bind is on or off. This is the trust bound [`"delegated"`](#delegated--facilitator-is-the-operator) already states for every operation.
+In both cases the remainder after the fee goes to the receiver. If `PaymentInfo.feeReceiver` is non-zero, the submitted `feeReceiver` must equal it; if it is `address(0)`, any non-zero address is accepted. A zero `feeReceiver` with a non-zero submitted fee (`feeAmount` or `feeBps`) reverts.
+
+Those are the guarantee. Who holds the submitter to a narrower value differs per operator type:
+
+- `"delegated"` — the escrow's range and a non-zero `feeReceiver` are the only limits. An `authorizerSignature` over the submitted fee tells a conformant facilitator what to submit, but nothing onchain reads that signature, so the server's exposure is `maxFeeBps` whether the bind is on or off. This is the trust bound [`"delegated"`](#delegated--facilitator-is-the-operator) already states for every operation.
 - `"custom"` — the operator contract is the enforcement point, so the submitter's discretion is whatever that operator leaves unchecked, within the escrow's range.
-- `"policy"` — the operator verifies the authorizer's digest onchain, so the signed `feeBps` and `feeReceiver` are what executes. That binds every submitter. It binds the authorizer's own choice only where the server holds the authorizer key, or where the policy constrains the fee through the `feeBps` and `feeReceiver` its hooks receive.
+- `"policy"` — the operator verifies the authorizer's digest onchain, so the signed fee and `feeReceiver` are what executes. That binds every submitter. It binds the authorizer's own choice only where the server holds the authorizer key, or where the policy constrains the fee through the fee and `feeReceiver` its hooks receive.
 
 A server therefore MUST read its own published bounds, not any signature, as what it has agreed to:
 
-- **No agreed fee.** `minFeeBps == maxFeeBps == 0`, which is required unless the server has agreed fee terms with the party that ends up choosing the value: the facilitator under `"delegated"`, the operator under `"custom"`. Nothing can then be taken from any payment.
-- **Agreed fixed fee.** `minFeeBps == maxFeeBps` at the agreed value with a non-zero `feeRecipient`, which servers SHOULD prefer: the escrow admits exactly one fee to exactly one address, so the outcome needs no trust. The submitted `feeBps` MUST be that value and the submitted `feeReceiver` MUST be `extra.feeRecipient`, leaving nothing to choose. For `"delegated"` these are the facilitator's `/supported` fee terms copied verbatim; for `"custom"` they come from the server's agreement with the operator.
+- **No agreed fee.** `minFeeBps == maxFeeBps == 0`, which is required unless the server has agreed fee terms with the party that ends up choosing the value: the facilitator under `"delegated"`, the operator under `"custom"`. Nothing can then be taken from any payment. The submitted fee MUST be `0`.
+- **Agreed fixed fee.** `minFeeBps == maxFeeBps` at the agreed value with a non-zero `feeRecipient`, which servers SHOULD prefer: the escrow admits exactly one fee to exactly one address, so the outcome needs no trust. On v1.1 the submitted `feeAmount` MUST be `amount * that value / 10000` and the submitted `feeReceiver` MUST be `extra.feeRecipient`. On a v1.0 extra pin the submitted `feeBps` MUST be that value. For `"delegated"` these are the facilitator's `/supported` fee terms copied verbatim; for `"custom"` they come from the server's agreement with the operator.
 - **Agreed range.** `minFeeBps < maxFeeBps` is permitted only where the server has agreed that range with the same party, and it grants that party free choice inside it. Publishing a range is granting the discretion, not reserving it.
 - **Zero fee receiver.** A zero `PaymentInfo.feeReceiver` lets the submitter name any non-zero recipient, so under `"delegated"` and `"custom"` it MUST come with `minFeeBps == maxFeeBps == 0`. A zero fee on the submitted call is not sufficient, since the submitter can send another value within the signed range. Under `"policy"` the authorizer's signature over `feeReceiver` is verified onchain, which supplies the missing constraint.
 
 ### Compatibility with v1.0
 
-The unbound collect path is byte-identical to v1.0: `extra.captureAuthorizer`, payload `salt`, `PaymentInfo.salt = payload.salt`. Clients MUST ignore unrecognized `extra` keys. New servers that omit `receiverAuthorizer` and `policy` remain payable by v1.0 clients. New clients that treat omitted `receiverAuthorizer` / `policy` as unbound remain able to pay v1.0 servers.
+This section is the x402 scheme v1.0 collect path (unbound salt, `autoCapture`), not the commerce-payments contract deployment. For the latter see [Commerce-payments deployments](#commerce-payments-deployments) and the paragraph below.
+
+The unbound collect path is byte-identical to scheme v1.0: `extra.captureAuthorizer`, payload `salt`, `PaymentInfo.salt = payload.salt`. Clients MUST ignore unrecognized `extra` keys. New servers that omit `receiverAuthorizer` and `policy` remain payable by scheme-v1.0 clients that still target the same commerce deployment. New clients that treat omitted `receiverAuthorizer` / `policy` as unbound remain able to pay scheme-v1.0 servers on that deployment.
 
 v1.0's `extra.autoCapture` is removed, and `paymentFlow` is the only flow selector. `autoCapture: false` agrees with the default and needs no handling, but a facilitator that receives `autoCapture: true` MUST reject with `invalid_auth_capture_evm_unsupported_payment_flow` rather than fall through to `"escrow"`, because settling a hold where the server asked for a terminal `charge` is a different onchain outcome and no later error would report it.
 
-Turning the bind on (non-zero `receiverAuthorizer` or `policy`) changes `signatureNonce` and requires `saltNonce` beside `salt`. A v1.0 client then emits only `salt` (the random value, not the hash), so verification fails with `invalid_auth_capture_evm_payload_format` or `invalid_auth_capture_evm_nonce_mismatch` unless the server probes.
+Turning the bind on (non-zero `receiverAuthorizer` or `policy`) changes `signatureNonce` and requires `saltNonce` beside `salt`. A scheme-v1.0 client then emits only `salt` (the random value, not the hash), so verification fails with `invalid_auth_capture_evm_payload_format` or `invalid_auth_capture_evm_nonce_mismatch` unless the server probes.
 
-A server that turns the bind on while still serving v1.0 clients MAY nonce-probe: if `saltNonce` is absent, treat `payload.salt` as the nonce, recompute `signatureNonce` for the raw value and for the commitment over it, and accept whichever matches. It MUST persist the matching `uint256` (and the nonce, if any) for the life of the payment so later `capture` / `void` / `refund` reuse that salt and do not re-hash. A probed v1.0 payment is unbound onchain even though extra advertised an authorizer — the authorizer is then an HTTP check only. Pin `receiverAuthorizer` and `policy` per (`captureAuthorizer`, chain) and never rotate them mid-flight.
+A server that turns the bind on while still serving scheme-v1.0 clients MAY nonce-probe: if `saltNonce` is absent, treat `payload.salt` as the nonce, recompute `signatureNonce` for the raw value and for the commitment over it, and accept whichever matches. It MUST persist the matching `uint256` (and the nonce, if any) for the life of the payment so later `capture` / `void` / `refund` reuse that salt and do not re-hash. A probed scheme-v1.0 payment is unbound onchain even though extra advertised an authorizer — the authorizer is then an HTTP check only. Pin `receiverAuthorizer` and `policy` per (`captureAuthorizer`, chain) and never rotate them mid-flight.
+
+A scheme-v1.0 client also ignores `extra.authCaptureEscrow` and signs the collectors and escrow it was built with (the v1.0 set). It cannot pay a server that collects into the v1.1 escrow: `signatureNonce` and `authorization.to` / `permit2Authorization.spender` will not match. A new client pays a v1.0 commerce deployment if and only if `extra.authCaptureEscrow` is that v1.0 escrow; omitted extra selects v1.1. Charge and capture payloads on that pin keep `feeBps`; the v1.1 wire uses `feeAmount`.
 
 
 ### Future operator type: `policy`
 
 `"delegated"` and `"custom"` sit at opposite ends of a trade-off. `"delegated"` with a receiver authorizer relays the whole lifecycle but rests on trusting the facilitator; `"custom"` needs no trust in the facilitator, but everything past collect also leaves the protocol. A third type, `operatorType: "policy"`, is a planned addition that closes the gap, and it buys two things:
 
-1. **Trustless relay.** The operator contract, not the facilitator, is what gates the escrow. It checks the payment's binding, verifies the receiver authorizer's EIP-712 signature onchain for `charge` and lifecycle, and compares the signed balances against `paymentState` before calling the escrow. That is also what makes the signed `feeBps` and `feeReceiver` enforceable rather than advisory, so a range may be published without granting the submitter discretion over it (see [Fee system](#fee-system)). The facilitator's HTTP checks stop being the thing that protects the server: a request the facilitator would refuse also reverts when anyone else submits it directly, and a request the facilitator relays cannot deviate from what the authorizer signed.
+1. **Trustless relay.** The operator contract, not the facilitator, is what gates the escrow. It checks the payment's binding, verifies the receiver authorizer's EIP-712 signature onchain for `charge` and lifecycle, and compares the signed balances against `paymentState` before calling the escrow. That is also what makes the signed fee and `feeReceiver` enforceable rather than advisory, so a range may be published without granting the submitter discretion over it (see [Fee system](#fee-system)). The facilitator's HTTP checks stop being the thing that protects the server: a request the facilitator would refuse also reverts when anyone else submits it directly, and a request the facilitator relays cannot deviate from what the authorizer signed.
 2. **Capture and void stay in the protocol.** They remain ordinary relayed `/settle` calls even when a contract enforces conditions on them, so the server keeps the gasless, RPC-free path it has under `"delegated"` without the trust. The conditions come from a separate policy contract consulted through read-only hooks, which is what makes relaying into unreviewed policy code safe for the facilitator.
 
 Everything this type needs on the wire already exists: `extra.operatorType: "policy"`, `extra.policy` naming the policy contract, and `PaymentInfo.salt` committing to it. Because the salt commits to the policy, the client's own signature commits to it too — a payer knows which rules govern its money before it pays, and a collected payment cannot be re-pointed at a different policy afterwards. `extra.policy` MAY be the zero address here, which selects the signature-only operator of step 1 below; `receiverAuthorizer` MUST be non-zero, so the bind is on. No payload, digest, or `extra` field changes. As with `"delegated"`, `authorize` needs no authorizer signature — only the salt-binding trailing parameters.
@@ -724,7 +764,7 @@ At its simplest the operator adds nothing but the checks the facilitator was tru
 function capture(
     IAuthCaptureEscrow.PaymentInfo calldata paymentInfo,
     uint256 amount,
-    uint16 feeBps,
+    uint256 feeAmount,
     address feeReceiver,
     address authorizer,
     address policy,
@@ -736,11 +776,11 @@ function capture(
     // and salt == keccak256(SALT_BINDING_TYPEHASH, authorizer, policy, saltNonce)
     bytes32 paymentInfoHash = _checkBinding(paymentInfo, authorizer, policy, saltNonce);
     _checkSignature(
-        authorizer, getCaptureDigest(paymentInfoHash, amount, feeBps, feeReceiver, expected), authorizerSignature
+        authorizer, getCaptureDigest(paymentInfoHash, amount, feeAmount, feeReceiver, expected), authorizerSignature
     );
     _checkExpectedBalances(paymentInfoHash, expected);
 
-    ESCROW.capture(paymentInfo, amount, feeBps, feeReceiver);
+    ESCROW.capture(paymentInfo, amount, feeAmount, feeReceiver);
 }
 ```
 
@@ -755,14 +795,14 @@ Instead the rule lives in a separate contract, named by `extra.policy` and consu
 ```solidity
     bytes32 paymentInfoHash = _checkBinding(paymentInfo, authorizer, policy, saltNonce);
     _checkSignature(
-        authorizer, getCaptureDigest(paymentInfoHash, amount, feeBps, feeReceiver, expected), authorizerSignature
+        authorizer, getCaptureDigest(paymentInfoHash, amount, feeAmount, feeReceiver, expected), authorizerSignature
     );
-    if (!ICaptureAuthorizer(policy).authorizeCapture(paymentInfo, amount, feeBps, feeReceiver, "")) {
+    if (!ICaptureAuthorizer(policy).authorizeCapture(paymentInfo, amount, feeAmount, feeReceiver, "")) {
         revert AuthorizationDenied();
     }
     _checkExpectedBalances(paymentInfoHash, expected);
 
-    ESCROW.capture(paymentInfo, amount, feeBps, feeReceiver);
+    ESCROW.capture(paymentInfo, amount, feeAmount, feeReceiver);
 ```
 
 This is a separate deployment with the same call ABI and a stricter binding: `_checkBinding` here requires `policy` to be non-zero and to advertise `ICaptureAuthorizer` through ERC-165, so a plain address cannot be passed off as a policy, while the step 1 operator requires `policy` to be zero.
@@ -788,7 +828,7 @@ contract DelayedCapturePolicy is ICaptureAuthorizer, ERC165 {
     function authorizeCapture(
         IAuthCaptureEscrow.PaymentInfo calldata paymentInfo,
         uint256,
-        uint16,
+        uint256,
         address,
         bytes calldata
     ) external view returns (bool) {
@@ -832,16 +872,16 @@ The operator declares typed errors that a facilitator decodes from a reverted si
 
 ### Contract addresses
 
-`AUTH_CAPTURE_ESCROW_ADDRESS`, `EIP3009_TOKEN_COLLECTOR_ADDRESS`, `PERMIT2_TOKEN_COLLECTOR_ADDRESS`, and `OPERATOR_REFUND_COLLECTOR_ADDRESS` resolve to the [Base commerce-payments contracts](https://github.com/base/commerce-payments/releases/tag/v1.0.0). `PERMIT2_ADDRESS` resolves to the canonical [Uniswap Permit2 contract](https://docs.uniswap.org/contracts/v4/deployments).
+The two canonical CREATE2 sets, and how `extra.authCaptureEscrow` selects between them, are in [Commerce-payments deployments](#commerce-payments-deployments). `PERMIT2_ADDRESS` is the canonical [Uniswap Permit2 contract](https://docs.uniswap.org/contracts/v4/deployments).
 
 No operator or policy address is canonical, and none is named above. `extra.captureAuthorizer` and `extra.policy` are per-deployment values with no protocol-level meaning: a facilitator MUST NOT treat either as trusted because its bytecode matches one of the shapes sketched here, and admission goes through the [`/supported`](#supported) rules in every case. The Solidity in the appendix illustrates a future addition rather than audited or deployed code, and anyone building on it is responsible for reviewing, auditing, and deploying their own.
 
 ## Version History
 
 
-| Version | Date       | Changes                                    | Authors   |
-| ------- | ---------- | ------------------------------------------ | --------- |
-| v1.1    | 2026-08-18 | Payment flow lifecycles and operator types | @phdargen |
-| v1.0    | 2026-05-13 | Initial draft                              | @A1igator |
+| Version | Date       | Changes                                                                                         | Authors   |
+| ------- | ---------- | ----------------------------------------------------------------------------------------------- | --------- |
+| v1.1    | 2026-08-26 | Payment flow lifecycles, operator types and commerce-payments v1.1 | @phdargen |
+| v1.0    | 2026-05-13 | Initial draft                                                                                   | @A1igator |
 
 

--- a/typescript/.changeset/auth-capture-v1.1.md
+++ b/typescript/.changeset/auth-capture-v1.1.md
@@ -1,0 +1,7 @@
+---
+"@x402/evm": minor
+---
+
+Align the EVM auth-capture **client** with the v1.1 spec: commerce-payments deployment selection via optional `extra.authCaptureEscrow` (v1.1 default), salt binding when `extra.receiverAuthorizer` or `extra.policy` is non-zero, and v1.0/v1.1 canonical addresses in `@x402/evm/auth-capture/client`. 
+
+**Breaking (client):** the default commerce-payments deployment is now v1.1 (escrow + token collectors), so PaymentInfo hashes and signatures differ from the previous v1.0-only client unless the server sets `extra.authCaptureEscrow` to the v1.0 escrow. When `extra.receiverAuthorizer` or `extra.policy` is non-zero, collect payloads also include `saltNonce` alongside the derived `salt` (salt binding).

--- a/typescript/packages/mechanisms/evm/src/auth-capture/README.md
+++ b/typescript/packages/mechanisms/evm/src/auth-capture/README.md
@@ -16,6 +16,10 @@ See the [scheme specification](https://github.com/x402-foundation/x402/blob/main
 
 Register `AuthCaptureEvmScheme` with an `x402Client`. The client validates the requirement's `extra` fields, reconstructs the PaymentInfo struct, computes the payer-agnostic hash, and emits an ERC-3009 (default) or Permit2 payload.
 
+When `extra.receiverAuthorizer` or `extra.policy` is non-zero, salt binding is on: the client emits a random `saltNonce` and a keccak `salt` committing to those addresses. Otherwise the wire is the unbound shape (`salt` is random 32 bytes, no `saltNonce`).
+
+The client resolves the commerce-payments deployment from optional `extra.authCaptureEscrow` (v1.1 default when omitted). That selects the escrow bound into the signature nonce and the collector used for `authorization.to` / `permit2Authorization.spender`.
+
 ```typescript
 import { x402Client } from "@x402/core/client";
 import { AuthCaptureEvmScheme } from "@x402/evm/auth-capture/client";
@@ -51,6 +55,9 @@ Optional:
 | Field | Default | Notes |
 | --- | --- | --- |
 | `assetTransferMethod` | `"eip3009"` | `"eip3009"` (ERC-3009) or `"permit2"` (Uniswap Permit2). See below. |
+| `authCaptureEscrow` | v1.1 escrow | Escrow address selecting the commerce-payments deployment (v1.0 or v1.1). |
+| `receiverAuthorizer` | `address(0)` | When non-zero, enables salt binding. |
+| `policy` | `address(0)` | When non-zero, enables salt binding. |
 
 ## Asset transfer methods
 
@@ -74,7 +81,9 @@ Canonical `AuthCaptureEscrow` and EIP-3009 / Permit2 token collector addresses l
 
 ## Examples
 
-- [Client example](../../../../../examples/clients/auth-capture)
+- [`@x402/fetch` client example](../../../../../examples/typescript/clients/fetch/)
+- [`@x402/axios` client example](../../../../../examples/typescript/clients/axios/)
+- [Go HTTP client example](../../../../../examples/go/clients/http/)
 
 ## See also
 

--- a/typescript/packages/mechanisms/evm/src/auth-capture/client/scheme.ts
+++ b/typescript/packages/mechanisms/evm/src/auth-capture/client/scheme.ts
@@ -14,20 +14,19 @@ import type {
 } from "@x402/core/types";
 import type { ClientEvmSigner } from "../../signer";
 import { hexToBigInt } from "viem";
-import {
-  AUTH_CAPTURE_SCHEME,
-  EIP3009_TOKEN_COLLECTOR_ADDRESS,
-  PERMIT2_TOKEN_COLLECTOR_ADDRESS,
-} from "../constants";
+import { AUTH_CAPTURE_SCHEME, resolveAuthCaptureDeployment } from "../constants";
 import {
   computePayerAgnosticPaymentInfoHash,
+  deriveBoundSalt,
+  extraAddress,
   generateSalt,
+  isSaltBindingOn,
   signERC3009,
   signPermit2,
 } from "../nonce";
 import type { AuthCaptureExtra, Eip3009Payload, PaymentInfoStruct, Permit2Payload } from "../types";
 import { findDefaultAsset } from "../../defaultAssets";
-import { parseChainId } from "../utils";
+import { getEvmChainId } from "../../utils";
 
 /**
  * Client-side implementation of the auth-capture scheme: derives the canonical
@@ -105,12 +104,25 @@ export class AuthCaptureEvmScheme implements SchemeNetworkClient {
       );
     }
 
-    const chainId = parseChainId(requirements.network);
+    const chainId = getEvmChainId(requirements.network);
+    const deployment = resolveAuthCaptureDeployment(extra.authCaptureEscrow);
+    if (!deployment) {
+      throw new Error(`Invalid authCaptureEscrow in payment requirements extra`);
+    }
     const maxAmount = requirements.amount;
     const nowSeconds = Math.floor(Date.now() / 1000);
     const preApprovalExpiry = nowSeconds + requirements.maxTimeoutSeconds;
-    const salt = generateSalt();
     const assetTransferMethod = extra.assetTransferMethod ?? "eip3009";
+
+    const bindOn = isSaltBindingOn(extra);
+    const saltNonce = generateSalt();
+    const salt = bindOn
+      ? deriveBoundSalt(
+          extraAddress(extra.receiverAuthorizer),
+          extraAddress(extra.policy),
+          saltNonce,
+        )
+      : saltNonce;
 
     // Build the canonical PaymentInfo struct (Solidity field names — do not rename).
     const paymentInfo: PaymentInfoStruct = {
@@ -129,7 +141,7 @@ export class AuthCaptureEvmScheme implements SchemeNetworkClient {
     };
 
     // Payer-agnostic PaymentInfo hash — used as ERC-3009 nonce or Permit2 nonce.
-    const nonce = computePayerAgnosticPaymentInfoHash(chainId, paymentInfo);
+    const nonce = computePayerAgnosticPaymentInfoHash(chainId, paymentInfo, deployment.escrow);
 
     if (assetTransferMethod === "permit2") {
       const permit2Authorization: Permit2Payload["permit2Authorization"] = {
@@ -138,19 +150,21 @@ export class AuthCaptureEvmScheme implements SchemeNetworkClient {
           token: requirements.asset as `0x${string}`,
           amount: maxAmount,
         },
-        spender: PERMIT2_TOKEN_COLLECTOR_ADDRESS,
+        spender: deployment.permit2Collector,
         nonce: hexToBigInt(nonce).toString(),
         deadline: String(preApprovalExpiry),
       };
       const signature = await signPermit2(this.signer, permit2Authorization, chainId);
-      const payload: Permit2Payload = { permit2Authorization, signature, salt };
+      const payload: Permit2Payload = bindOn
+        ? { permit2Authorization, signature, salt, saltNonce }
+        : { permit2Authorization, signature, salt };
       return { x402Version, payload: payload as unknown as Record<string, unknown> };
     }
 
     // Default: EIP-3009 ReceiveWithAuthorization to the canonical EIP-3009 token collector.
     const authorization: Eip3009Payload["authorization"] = {
       from: this.signer.address,
-      to: EIP3009_TOKEN_COLLECTOR_ADDRESS,
+      to: deployment.eip3009Collector,
       value: maxAmount,
       validAfter: "0",
       validBefore: String(preApprovalExpiry),
@@ -163,7 +177,9 @@ export class AuthCaptureEvmScheme implements SchemeNetworkClient {
       requirements.asset as `0x${string}`,
       chainId,
     );
-    const payload: Eip3009Payload = { authorization, signature, salt };
+    const payload: Eip3009Payload = bindOn
+      ? { authorization, signature, salt, saltNonce }
+      : { authorization, signature, salt };
     return { x402Version, payload: payload as unknown as Record<string, unknown> };
   }
 }

--- a/typescript/packages/mechanisms/evm/src/auth-capture/constants.ts
+++ b/typescript/packages/mechanisms/evm/src/auth-capture/constants.ts
@@ -30,13 +30,13 @@ export const OPERATOR_REFUND_COLLECTOR_V1_0_ADDRESS =
 
 // commerce-payments v1.1 (default)
 export const AUTH_CAPTURE_ESCROW_V1_1_ADDRESS =
-  "0x215Ebf02d98A792de612B888aFbcc4ddF1F02F06" as const satisfies `0x${string}`;
+  "0x13AC3b34322D12FE27D5e192D0c2b2266d4F29CB" as const satisfies `0x${string}`;
 export const EIP3009_TOKEN_COLLECTOR_V1_1_ADDRESS =
-  "0xb57Db6Cd58D880ee5A271Fa25aB5daAcF5444a81" as const satisfies `0x${string}`;
+  "0xEA902B37036bcb4944577ec2101ABdEDF56EbD28" as const satisfies `0x${string}`;
 export const PERMIT2_TOKEN_COLLECTOR_V1_1_ADDRESS =
-  "0xA058A1088a96D95EC08d2d66F456208199eD2D68" as const satisfies `0x${string}`;
+  "0x1aacb38b16a1a8709e80746825E53A0C9Cae9b70" as const satisfies `0x${string}`;
 export const OPERATOR_REFUND_COLLECTOR_V1_1_ADDRESS =
-  "0x1babb602099e4Ebcf6F7fCd41c787Bd3BeF1A618" as const satisfies `0x${string}`;
+  "0x6a1ADdEEb4bD9c5811a613e20c172b6CE61A4aaB" as const satisfies `0x${string}`;
 
 /** Default deployment aliases (v1.1). */
 export const AUTH_CAPTURE_ESCROW_ADDRESS = AUTH_CAPTURE_ESCROW_V1_1_ADDRESS;

--- a/typescript/packages/mechanisms/evm/src/auth-capture/constants.ts
+++ b/typescript/packages/mechanisms/evm/src/auth-capture/constants.ts
@@ -1,3 +1,5 @@
+import { getAddress, isAddress, isAddressEqual, keccak256, toBytes } from "viem";
+
 // Scheme identifier for the auth-capture payment scheme.
 export const AUTH_CAPTURE_SCHEME = "auth-capture" as const;
 
@@ -5,13 +7,104 @@ export const AUTH_CAPTURE_SCHEME = "auth-capture" as const;
 // base/commerce-payments (https://github.com/base/commerce-payments). These are
 // the audited, live addresses listed in the upstream README and are the source
 // of truth for this scheme. They are universal constants, not configurable per
-// merchant.
-export const AUTH_CAPTURE_ESCROW_ADDRESS =
+// merchant. Two CREATE2 sets are specified; default exports point at v1.1.
+export type AuthCaptureDeploymentVersion = "v1.0" | "v1.1";
+
+export type AuthCaptureDeployment = {
+  version: AuthCaptureDeploymentVersion;
+  escrow: `0x${string}`;
+  eip3009Collector: `0x${string}`;
+  permit2Collector: `0x${string}`;
+  operatorRefundCollector: `0x${string}`;
+};
+
+// commerce-payments v1.0 (tag v1.0.0)
+export const AUTH_CAPTURE_ESCROW_V1_0_ADDRESS =
   "0xBdEA0D1bcC5966192B070Fdf62aB4EF5b4420cff" as const satisfies `0x${string}`;
-export const EIP3009_TOKEN_COLLECTOR_ADDRESS =
+export const EIP3009_TOKEN_COLLECTOR_V1_0_ADDRESS =
   "0x0E3dF9510de65469C4518D7843919c0b8C7A7757" as const satisfies `0x${string}`;
-export const PERMIT2_TOKEN_COLLECTOR_ADDRESS =
+export const PERMIT2_TOKEN_COLLECTOR_V1_0_ADDRESS =
   "0x992476B9Ee81d52a5BdA0622C333938D0Af0aB26" as const satisfies `0x${string}`;
+export const OPERATOR_REFUND_COLLECTOR_V1_0_ADDRESS =
+  "0x934907bffd0901b6A21e398B9C53A4A38F02fa5d" as const satisfies `0x${string}`;
+
+// commerce-payments v1.1 (default)
+export const AUTH_CAPTURE_ESCROW_V1_1_ADDRESS =
+  "0x215Ebf02d98A792de612B888aFbcc4ddF1F02F06" as const satisfies `0x${string}`;
+export const EIP3009_TOKEN_COLLECTOR_V1_1_ADDRESS =
+  "0xb57Db6Cd58D880ee5A271Fa25aB5daAcF5444a81" as const satisfies `0x${string}`;
+export const PERMIT2_TOKEN_COLLECTOR_V1_1_ADDRESS =
+  "0xA058A1088a96D95EC08d2d66F456208199eD2D68" as const satisfies `0x${string}`;
+export const OPERATOR_REFUND_COLLECTOR_V1_1_ADDRESS =
+  "0x1babb602099e4Ebcf6F7fCd41c787Bd3BeF1A618" as const satisfies `0x${string}`;
+
+/** Default deployment aliases (v1.1). */
+export const AUTH_CAPTURE_ESCROW_ADDRESS = AUTH_CAPTURE_ESCROW_V1_1_ADDRESS;
+export const EIP3009_TOKEN_COLLECTOR_ADDRESS = EIP3009_TOKEN_COLLECTOR_V1_1_ADDRESS;
+export const PERMIT2_TOKEN_COLLECTOR_ADDRESS = PERMIT2_TOKEN_COLLECTOR_V1_1_ADDRESS;
+export const OPERATOR_REFUND_COLLECTOR_ADDRESS = OPERATOR_REFUND_COLLECTOR_V1_1_ADDRESS;
+
+export const AUTH_CAPTURE_DEPLOYMENT_V1_0: AuthCaptureDeployment = {
+  version: "v1.0",
+  escrow: AUTH_CAPTURE_ESCROW_V1_0_ADDRESS,
+  eip3009Collector: EIP3009_TOKEN_COLLECTOR_V1_0_ADDRESS,
+  permit2Collector: PERMIT2_TOKEN_COLLECTOR_V1_0_ADDRESS,
+  operatorRefundCollector: OPERATOR_REFUND_COLLECTOR_V1_0_ADDRESS,
+};
+
+export const AUTH_CAPTURE_DEPLOYMENT_V1_1: AuthCaptureDeployment = {
+  version: "v1.1",
+  escrow: AUTH_CAPTURE_ESCROW_V1_1_ADDRESS,
+  eip3009Collector: EIP3009_TOKEN_COLLECTOR_V1_1_ADDRESS,
+  permit2Collector: PERMIT2_TOKEN_COLLECTOR_V1_1_ADDRESS,
+  operatorRefundCollector: OPERATOR_REFUND_COLLECTOR_V1_1_ADDRESS,
+};
+
+/**
+ * Resolve the commerce-payments deployment from optional `extra.authCaptureEscrow`.
+ * Absent or the v1.1 escrow selects v1.1; the v1.0 escrow selects v1.0.
+ *
+ * @param escrow - Optional escrow address from extra (`authCaptureEscrow`).
+ * @returns Known v1.0 or v1.1 deployment, or undefined when the address is unknown.
+ */
+export function resolveAuthCaptureDeployment(escrow?: string): AuthCaptureDeployment | undefined {
+  if (escrow === undefined || escrow === "") {
+    return AUTH_CAPTURE_DEPLOYMENT_V1_1;
+  }
+  if (!isAddress(escrow)) {
+    return undefined;
+  }
+  const normalized = getAddress(escrow);
+  if (
+    isAddressEqual(normalized, AUTH_CAPTURE_ESCROW_V1_1_ADDRESS) ||
+    isAddressEqual(normalized, AUTH_CAPTURE_ESCROW_ADDRESS)
+  ) {
+    return AUTH_CAPTURE_DEPLOYMENT_V1_1;
+  }
+  if (isAddressEqual(normalized, AUTH_CAPTURE_ESCROW_V1_0_ADDRESS)) {
+    return AUTH_CAPTURE_DEPLOYMENT_V1_0;
+  }
+  return undefined;
+}
+
+/** Default max gas for a custom-operator collect relay (`authorize` or `charge`). */
+export const DEFAULT_CUSTOM_OPERATOR_AUTHORIZE_GAS_LIMIT = 1_000_000n;
+
+// Domain tag for the bound-salt derivation. Encoded as the first word of
+// `abi.encode(SALT_BINDING_TYPEHASH, receiverAuthorizer, policy, saltNonce)`
+// so a value produced as a salt commitment can never be read as a signature nonce.
+export const SALT_BINDING_TYPEHASH = keccak256(
+  toBytes(
+    "x402AuthCaptureSaltBinding(address receiverAuthorizer,address policy,uint256 saltNonce)",
+  ),
+);
+
+// Shared EIP-712 domain for every operator type. `verifyingContract` is the
+// capture authorizer (PaymentInfo.operator), not a scheme-wide address.
+export const OPERATOR_EIP712_DOMAIN = {
+  name: "x402 Auth Capture Operator",
+  version: "1",
+} as const;
 
 // ERC-3009 ReceiveWithAuthorization EIP-712 types
 export const RECEIVE_AUTHORIZATION_TYPES = {
@@ -38,3 +131,99 @@ export const PERMIT2_TRANSFER_FROM_TYPES = {
     { name: "amount", type: "uint256" },
   ],
 } as const;
+
+// Operator EIP-712 types for facilitator-relayed charge and lifecycle.
+// v1.0 operator EIP-712 types (feeBps on charge/capture).
+export const CHARGE_TYPES_V1_0 = {
+  Charge: [
+    { name: "paymentInfoHash", type: "bytes32" },
+    { name: "amount", type: "uint256" },
+    { name: "tokenCollector", type: "address" },
+    { name: "collectorDataHash", type: "bytes32" },
+    { name: "feeBps", type: "uint16" },
+    { name: "feeReceiver", type: "address" },
+  ],
+} as const;
+
+export const CAPTURE_TYPES_V1_0 = {
+  Capture: [
+    { name: "paymentInfoHash", type: "bytes32" },
+    { name: "amount", type: "uint256" },
+    { name: "feeBps", type: "uint16" },
+    { name: "feeReceiver", type: "address" },
+    { name: "expectedCapturableAmount", type: "uint256" },
+    { name: "expectedRefundableAmount", type: "uint256" },
+  ],
+} as const;
+
+// v1.1 operator EIP-712 types (absolute feeAmount on charge/capture).
+export const CHARGE_TYPES_V1_1 = {
+  Charge: [
+    { name: "paymentInfoHash", type: "bytes32" },
+    { name: "amount", type: "uint256" },
+    { name: "tokenCollector", type: "address" },
+    { name: "collectorDataHash", type: "bytes32" },
+    { name: "feeAmount", type: "uint256" },
+    { name: "feeReceiver", type: "address" },
+  ],
+} as const;
+
+export const CAPTURE_TYPES_V1_1 = {
+  Capture: [
+    { name: "paymentInfoHash", type: "bytes32" },
+    { name: "amount", type: "uint256" },
+    { name: "feeAmount", type: "uint256" },
+    { name: "feeReceiver", type: "address" },
+    { name: "expectedCapturableAmount", type: "uint256" },
+    { name: "expectedRefundableAmount", type: "uint256" },
+  ],
+} as const;
+
+/** Default v1.1 charge/capture EIP-712 types. */
+export const CHARGE_TYPES = CHARGE_TYPES_V1_1;
+export const CAPTURE_TYPES = CAPTURE_TYPES_V1_1;
+
+export const VOID_TYPES = {
+  Void: [{ name: "paymentInfoHash", type: "bytes32" }],
+} as const;
+
+export const REFUND_TYPES = {
+  Refund: [
+    { name: "paymentInfoHash", type: "bytes32" },
+    { name: "amount", type: "uint256" },
+    { name: "tokenCollector", type: "address" },
+    { name: "expectedCapturableAmount", type: "uint256" },
+    { name: "expectedRefundableAmount", type: "uint256" },
+  ],
+} as const;
+
+/**
+ * Operator Charge EIP-712 types for a resolved deployment.
+ *
+ * @param deployment - Resolved escrow addresses and version.
+ * @returns Charge typed-data fields matching the deployment fee encoding.
+ */
+export function chargeTypesForDeployment(deployment: AuthCaptureDeployment) {
+  return deployment.version === "v1.0" ? CHARGE_TYPES_V1_0 : CHARGE_TYPES_V1_1;
+}
+
+/**
+ * Operator Capture EIP-712 types for a resolved deployment.
+ *
+ * @param deployment - Resolved escrow addresses and version.
+ * @returns Capture typed-data fields matching the deployment fee encoding.
+ */
+export function captureTypesForDeployment(deployment: AuthCaptureDeployment) {
+  return deployment.version === "v1.0" ? CAPTURE_TYPES_V1_0 : CAPTURE_TYPES_V1_1;
+}
+
+/**
+ * Integer fee from amount and bps (same division the escrow uses).
+ *
+ * @param amount - Principal amount in atomic token units.
+ * @param feeBps - Fee in basis points.
+ * @returns Absolute fee amount using escrow integer division.
+ */
+export function feeAmountFromBps(amount: bigint, feeBps: number): bigint {
+  return (amount * BigInt(feeBps)) / 10_000n;
+}

--- a/typescript/packages/mechanisms/evm/src/auth-capture/nonce.ts
+++ b/typescript/packages/mechanisms/evm/src/auth-capture/nonce.ts
@@ -2,13 +2,23 @@
  * Nonce computation, salt generation, and signing helpers.
  */
 
-import { encodeAbiParameters, getAddress, keccak256, toHex, zeroAddress } from "viem";
-import type { ClientEvmSigner } from "../signer";
+import {
+  encodeAbiParameters,
+  getAddress,
+  isAddress,
+  isAddressEqual,
+  keccak256,
+  toHex,
+  zeroAddress,
+} from "viem";
+import type { ClientEvmSigner, FacilitatorEvmSigner } from "../signer";
+import { verifyTypedDataSignature } from "../shared/verifySignature";
 import { PERMIT2_ADDRESS } from "../constants";
 import {
   AUTH_CAPTURE_ESCROW_ADDRESS,
   PERMIT2_TRANSFER_FROM_TYPES,
   RECEIVE_AUTHORIZATION_TYPES,
+  SALT_BINDING_TYPEHASH,
 } from "./constants";
 import type { AuthCaptureExtra, Eip3009Payload, PaymentInfoStruct, Permit2Payload } from "./types";
 
@@ -22,23 +32,21 @@ const PAYMENT_INFO_TYPEHASH = keccak256(
 );
 
 /**
- * Compute the payer-agnostic PaymentInfo hash that auth-capture uses as both
- * the ERC-3009 nonce (`bytes32`) and the Permit2 nonce (`uint256`, via the
- * same 32 bytes interpreted as an integer). The payer field is zeroed before
- * hashing so the facilitator can reconstruct the same hash on the verify side
- * without knowing payer identity in advance.
- *
- * Freshness comes from `paymentInfo.salt`; generate a new salt per signing
- * call via `generateSalt`. Identical extras + same salt would collide across
- * payers.
+ * Encode PaymentInfo the way AuthCaptureEscrow.getHash does: typehash plus
+ * struct fields, then wrap with chain id and escrow address.
  *
  * @param chainId - EVM chain id; binds the hash to a specific chain.
- * @param paymentInfo - The reconstructed PaymentInfo struct (canonical Solidity field names).
- * @returns The 32-byte hash to use as the nonce on the wire.
+ * @param paymentInfo - Canonical PaymentInfo struct.
+ * @param payer - Payer encoded in the struct hash. Pass `zeroAddress` for the
+ *   payer-agnostic signature nonce.
+ * @param escrowAddress - AuthCaptureEscrow bound into the outer hash.
+ * @returns The 32-byte hash.
  */
-export function computePayerAgnosticPaymentInfoHash(
+function hashPaymentInfo(
   chainId: number,
   paymentInfo: PaymentInfoStruct,
+  payer: `0x${string}`,
+  escrowAddress: `0x${string}` = AUTH_CAPTURE_ESCROW_ADDRESS,
 ): `0x${string}` {
   const paymentInfoEncoded = encodeAbiParameters(
     [
@@ -59,7 +67,7 @@ export function computePayerAgnosticPaymentInfoHash(
     [
       PAYMENT_INFO_TYPEHASH,
       paymentInfo.operator,
-      zeroAddress,
+      payer,
       paymentInfo.receiver,
       paymentInfo.token,
       BigInt(paymentInfo.maxAmount),
@@ -80,10 +88,51 @@ export function computePayerAgnosticPaymentInfoHash(
       { name: "escrow", type: "address" },
       { name: "paymentInfoHash", type: "bytes32" },
     ],
-    [BigInt(chainId), AUTH_CAPTURE_ESCROW_ADDRESS, paymentInfoHash],
+    [BigInt(chainId), escrowAddress, paymentInfoHash],
   );
 
   return keccak256(outerEncoded);
+}
+
+/**
+ * Compute the payer-agnostic PaymentInfo hash that auth-capture uses as both
+ * the ERC-3009 nonce (`bytes32`) and the Permit2 nonce (`uint256`, via the
+ * same 32 bytes interpreted as an integer). The payer field is zeroed before
+ * hashing so the facilitator can reconstruct the same hash on the verify side
+ * without knowing payer identity in advance.
+ *
+ * Freshness comes from `paymentInfo.salt`; generate a new salt per signing
+ * call via `generateSalt`. Identical extras + same salt would collide across
+ * payers.
+ *
+ * @param chainId - EVM chain id; binds the hash to a specific chain.
+ * @param paymentInfo - The reconstructed PaymentInfo struct (canonical Solidity field names).
+ * @param escrowAddress - AuthCaptureEscrow bound into the outer hash.
+ * @returns The 32-byte hash to use as the nonce on the wire.
+ */
+export function computePayerAgnosticPaymentInfoHash(
+  chainId: number,
+  paymentInfo: PaymentInfoStruct,
+  escrowAddress: `0x${string}` = AUTH_CAPTURE_ESCROW_ADDRESS,
+): `0x${string}` {
+  return hashPaymentInfo(chainId, paymentInfo, zeroAddress, escrowAddress);
+}
+
+/**
+ * Compute AuthCaptureEscrow.getHash(paymentInfo) locally. Differs from the
+ * signature nonce by encoding the real payer rather than address(0).
+ *
+ * @param chainId - EVM chain id.
+ * @param paymentInfo - PaymentInfo with the real payer.
+ * @param escrowAddress - AuthCaptureEscrow bound into the outer hash.
+ * @returns The escrow payment identifier (`paymentInfoHash`).
+ */
+export function computePaymentInfoHash(
+  chainId: number,
+  paymentInfo: PaymentInfoStruct,
+  escrowAddress: `0x${string}` = AUTH_CAPTURE_ESCROW_ADDRESS,
+): `0x${string}` {
+  return hashPaymentInfo(chainId, paymentInfo, paymentInfo.payer, escrowAddress);
 }
 
 /**
@@ -131,6 +180,52 @@ export async function signERC3009(
 }
 
 /**
+ * Verify an ERC-3009 `ReceiveWithAuthorization` signature against the supplied
+ * authorization fields. Mirrors `signERC3009`: the EIP-712 domain is bound to
+ * the **token contract**, with `name`/`version` from `extra`.
+ *
+ * Routed through {@link verifyTypedDataSignature} rather than
+ * `signer.verifyTypedData` so pre-verify matches on-chain SignatureChecker
+ * semantics: no ECDSA fallback when EIP-1271 returns failure, which otherwise
+ * accepts signatures the token contract rejects for any payer with code.
+ *
+ * @param signer - Facilitator signer used for `eth_getCode` / `isValidSignature`.
+ * @param authorization - The ERC-3009 authorization to verify.
+ * @param signature - The signature blob from the payer.
+ * @param extra - Carries the token EIP-712 domain `name`, `version`, and the chain id.
+ * @param tokenAddress - Address of the token contract (verifyingContract in the domain).
+ * @returns True if the signature is valid for `authorization.from`; false otherwise.
+ */
+export async function verifyERC3009Signature(
+  signer: FacilitatorEvmSigner,
+  authorization: Eip3009Payload["authorization"],
+  signature: `0x${string}`,
+  extra: AuthCaptureExtra & { chainId: number },
+  tokenAddress: `0x${string}`,
+): Promise<boolean> {
+  return verifyTypedDataSignature(signer, {
+    address: getAddress(authorization.from),
+    domain: {
+      name: extra.name,
+      version: extra.version,
+      chainId: extra.chainId,
+      verifyingContract: getAddress(tokenAddress),
+    },
+    types: RECEIVE_AUTHORIZATION_TYPES,
+    primaryType: "ReceiveWithAuthorization",
+    message: {
+      from: getAddress(authorization.from),
+      to: getAddress(authorization.to),
+      value: BigInt(authorization.value),
+      validAfter: BigInt(authorization.validAfter),
+      validBefore: BigInt(authorization.validBefore),
+      nonce: authorization.nonce,
+    },
+    signature,
+  });
+}
+
+/**
  * Sign a Permit2 `PermitTransferFrom` over the supplied permit fields. Domain
  * is bound to the canonical Permit2 contract. No witness struct is needed —
  * the deterministic nonce (the payer-agnostic PaymentInfo hash, packed into
@@ -172,6 +267,46 @@ export async function signPermit2(
 }
 
 /**
+ * Verify a Permit2 `PermitTransferFrom` signature against the supplied permit
+ * fields. Mirrors `signPermit2`: domain bound to the canonical Permit2
+ * contract. Routed through {@link verifyTypedDataSignature} so pre-verify
+ * matches Permit2's own `SignatureVerification` semantics.
+ *
+ * @param signer - Facilitator signer used for `eth_getCode` / `isValidSignature`.
+ * @param permit - The Permit2 PermitTransferFrom message to verify.
+ * @param signature - The signature blob from the payer.
+ * @param chainId - EVM chain id (chainId in the Permit2 domain).
+ * @returns True if the signature is valid for `permit.from`; false otherwise.
+ */
+export async function verifyPermit2Signature(
+  signer: FacilitatorEvmSigner,
+  permit: Permit2Payload["permit2Authorization"],
+  signature: `0x${string}`,
+  chainId: number,
+): Promise<boolean> {
+  return verifyTypedDataSignature(signer, {
+    address: getAddress(permit.from),
+    domain: {
+      name: "Permit2",
+      chainId,
+      verifyingContract: PERMIT2_ADDRESS,
+    },
+    types: PERMIT2_TRANSFER_FROM_TYPES,
+    primaryType: "PermitTransferFrom",
+    message: {
+      permitted: {
+        token: getAddress(permit.permitted.token),
+        amount: BigInt(permit.permitted.amount),
+      },
+      spender: getAddress(permit.spender),
+      nonce: BigInt(permit.nonce),
+      deadline: BigInt(permit.deadline),
+    },
+    signature,
+  });
+}
+
+/**
  * Generate a fresh cryptographically-random 32-byte salt. MUST be called once
  * per signing request — never reuse across requests. Freshness is required
  * because the nonce derivation zeroes the payer field; identical extras with
@@ -183,4 +318,79 @@ export function generateSalt(): `0x${string}` {
   const bytes = new Uint8Array(32);
   crypto.getRandomValues(bytes);
   return toHex(bytes);
+}
+
+/**
+ * Zero-pad a 0x-prefixed hex integer to a full 32-byte word.
+ *
+ * @param value - Hex string, with or without `0x`.
+ * @returns 66-character `0x`-prefixed hex.
+ */
+export function normalizeBytes32(value: string): `0x${string}` {
+  const hex = value.startsWith("0x") || value.startsWith("0X") ? value.slice(2) : value;
+  if (!/^[0-9a-fA-F]+$/.test(hex) || hex.length === 0 || hex.length > 64) {
+    throw new Error(`Invalid bytes32: ${value}`);
+  }
+  return `0x${hex.padStart(64, "0").toLowerCase()}` as `0x${string}`;
+}
+
+/**
+ * Treat absent or invalid values as the zero address; otherwise checksum.
+ *
+ * @param value - Candidate address from extra or config.
+ * @returns Checksummed address, or the zero address when absent.
+ */
+export function extraAddress(value: string | undefined): `0x${string}` {
+  if (!value || !isAddress(value)) return zeroAddress;
+  return getAddress(value);
+}
+
+/**
+ * Whether `value` is a non-zero EVM address.
+ *
+ * @param value - Candidate address.
+ * @returns True when `value` is a valid address other than address(0).
+ */
+export function isNonZeroAddress(value: string | undefined): boolean {
+  if (!value || !isAddress(value)) return false;
+  return !isAddressEqual(getAddress(value), zeroAddress);
+}
+
+/**
+ * Salt binding is on when either `receiverAuthorizer` or `policy` is non-zero.
+ * Absent fields are the zero address.
+ *
+ * @param extra - Wire extra (or a subset with the two address fields).
+ * @param extra.receiverAuthorizer - Optional receiver authorizer; absent is the zero address.
+ * @param extra.policy - Optional policy contract; absent is the zero address.
+ * @returns True when the client must emit `saltNonce` and a keccak salt.
+ */
+export function isSaltBindingOn(extra: { receiverAuthorizer?: string; policy?: string }): boolean {
+  return isNonZeroAddress(extra.receiverAuthorizer) || isNonZeroAddress(extra.policy);
+}
+
+/**
+ * Bound PaymentInfo.salt: keccak256(abi.encode(SALT_BINDING_TYPEHASH,
+ * receiverAuthorizer, policy, saltNonce)).
+ *
+ * @param receiverAuthorizer - extra.receiverAuthorizer, or the zero address.
+ * @param policy - extra.policy, or the zero address.
+ * @param saltNonce - Client's random 32-byte contribution.
+ * @returns 32-byte salt commitment.
+ */
+export function deriveBoundSalt(
+  receiverAuthorizer: `0x${string}`,
+  policy: `0x${string}`,
+  saltNonce: `0x${string}`,
+): `0x${string}` {
+  const encoded = encodeAbiParameters(
+    [
+      { name: "typehash", type: "bytes32" },
+      { name: "receiverAuthorizer", type: "address" },
+      { name: "policy", type: "address" },
+      { name: "saltNonce", type: "uint256" },
+    ],
+    [SALT_BINDING_TYPEHASH, receiverAuthorizer, policy, BigInt(saltNonce)],
+  );
+  return keccak256(encoded);
 }

--- a/typescript/packages/mechanisms/evm/src/auth-capture/types.ts
+++ b/typescript/packages/mechanisms/evm/src/auth-capture/types.ts
@@ -2,44 +2,175 @@
  * auth-capture wire-format types.
  *
  * Spec-level field names (captureAuthorizer, captureDeadline, refundDeadline,
- * feeRecipient) live here at the extra/wire layer. The on-chain PaymentInfo
+ * feeRecipient) live here at the extra/wire layer. The onchain PaymentInfo
  * struct keeps the canonical Solidity field names (operator, authorizationExpiry,
  * refundExpiry, feeReceiver) so the EIP-712 typehash stays byte-identical with
  * the AuthCaptureEscrow contract.
  *
  * Salt is NOT in extra. It is generated client-side per signing call and rides
- * on the payload alongside the signature.
+ * on the payload alongside the signature. When salt binding is on, `saltNonce`
+ * is added beside `salt`.
  */
 
+import type { PendingSettlementStore } from "@x402/core/facilitator";
+import type { TypedData } from "viem";
 import type { AssetTransferMethod } from "../types";
 
-// AuthCaptureExtra — fields in PaymentRequirements.extra.
-//
-// Fee-policy fields (minFeeBps, maxFeeBps, feeRecipient) are all required.
-// No implicit defaults: a merchant who wants no minimum fee writes
-// `minFeeBps: 0` explicitly. This forces fee policy to be a conscious choice
-// on the wire and avoids "did they mean 0 or did they forget?" ambiguity.
-export interface AuthCaptureExtra {
-  // Required
-  // The only address allowed to call authorize/capture/void/refund/charge on
-  // AuthCaptureEscrow (each of those is gated by onlySender(paymentInfo.operator))
-  // — i.e., it must be msg.sender of the "Authorize" call. In x402's
-  // facilitator-submits flow that means either the facilitator's EOA, or any
-  // smart contract that ultimately calls escrow (arbiter with dispute logic,
-  // multisig, etc.). Independent of assetTransferMethod — applies to both
-  // EIP-3009 and Permit2.
-  captureAuthorizer: `0x${string}`; // formerly `operator` in commerce-payments
-  captureDeadline: number; // absolute Unix seconds; capture must occur before this
-  refundDeadline: number; // absolute Unix seconds; refunds allowed until this
-  feeRecipient: `0x${string}`; // address that receives the fee portion (renamed from feeReceiver)
-  minFeeBps: number; // floor on the captureAuthorizer's fee; 0 = no minimum
-  maxFeeBps: number; // cap on the captureAuthorizer's fee
-  name: string; // EIP-712 token-domain name (e.g., "USDC")
-  version: string; // EIP-712 token-domain version (e.g., "2")
-  // Optional
-  autoCapture?: boolean; // default: false. true → facilitator calls charge(), false → authorize()
-  assetTransferMethod?: AssetTransferMethod; // default: 'eip3009'
+export type AuthCapturePaymentFlow = "escrow" | "authorization";
+export type AuthCaptureCaptureMode = "sync" | "deferred";
+export type AuthCaptureOperatorType = "delegated" | "custom" | "policy";
+
+export interface AuthorizerSigner {
+  address: `0x${string}`;
+  signTypedData(params: {
+    domain: Record<string, unknown>;
+    types: TypedData;
+    primaryType: string;
+    message: Record<string, unknown>;
+  }): Promise<`0x${string}`>;
 }
+
+type AuthCaptureLifecycleExtra =
+  | {
+      paymentFlow?: "escrow";
+      captureMode?: AuthCaptureCaptureMode;
+      receiverAuthorizer?: `0x${string}`;
+    }
+  | { paymentFlow: "authorization"; captureMode?: never; receiverAuthorizer?: `0x${string}` };
+
+type AuthCaptureDeadlineExtra =
+  | {
+      captureDeadline: number;
+      refundDeadline: number;
+      captureDeadlineSeconds?: never;
+      refundDeadlineSeconds?: never;
+    }
+  | {
+      captureDeadlineSeconds: number;
+      refundDeadlineSeconds: number;
+      captureDeadline?: never;
+      refundDeadline?: never;
+    };
+
+type AuthCaptureMerchantFeesExtra = {
+  feeRecipient: `0x${string}`;
+  minFeeBps: number;
+  maxFeeBps: number;
+  name: string;
+  version: string;
+  policy?: `0x${string}`;
+  assetTransferMethod?: AssetTransferMethod;
+};
+
+type AuthCaptureDelegatedRouteExtra = AuthCaptureMerchantFeesExtra & {
+  operatorType?: "delegated";
+  /** Omitted for delegated routes when the facilitator advertises it on `/supported` extra. */
+  captureAuthorizer?: `0x${string}`;
+};
+
+type AuthCaptureCustomRouteExtra = AuthCaptureMerchantFeesExtra & {
+  operatorType: "custom";
+  captureAuthorizer: `0x${string}`;
+  /** Collect-only: the facilitator relays no lifecycle, so sync has nothing to finalize with. */
+  captureMode?: "deferred";
+};
+
+/**
+ * Merchant-authored route extra. Correlated optionals are unions so forbidden
+ * combinations (captureMode on an authorization route, sync capture on a custom
+ * operator, mixed absolute/relative deadlines) are unrepresentable when the
+ * literal is checked with `satisfies AuthCaptureRouteExtra`. Escrow sync derives
+ * `receiverAuthorizer` from the scheme signer when the route omits it.
+ */
+export type AuthCaptureRouteExtra = (AuthCaptureDelegatedRouteExtra | AuthCaptureCustomRouteExtra) &
+  AuthCaptureLifecycleExtra &
+  AuthCaptureDeadlineExtra;
+
+/**
+ * Wire extra after `enhancePaymentRequirements`. Deadlines are always absolute.
+ * `paymentFlow` / `captureMode` / `receiverAuthorizer` are independent optionals
+ * here because the facilitator validates untrusted `Record<string, unknown>`.
+ */
+export interface AuthCaptureExtra {
+  captureAuthorizer: `0x${string}`;
+  captureDeadline: number;
+  refundDeadline: number;
+  feeRecipient: `0x${string}`;
+  minFeeBps: number;
+  maxFeeBps: number;
+  name: string;
+  version: string;
+  authCaptureEscrow?: `0x${string}`;
+  paymentFlow?: AuthCapturePaymentFlow;
+  captureMode?: AuthCaptureCaptureMode;
+  receiverAuthorizer?: `0x${string}`;
+  policy?: `0x${string}`;
+  operatorType?: AuthCaptureOperatorType;
+  assetTransferMethod?: AssetTransferMethod;
+}
+
+export type AuthCaptureFeeTerms = {
+  feeRecipient: `0x${string}`;
+  minFeeBps: number;
+  maxFeeBps: number;
+};
+
+export type OperatorAllowlistEntry = {
+  address: "*" | `0x${string}`;
+  operatorType: "custom";
+};
+
+export type AuthCaptureFacilitatorConfig = {
+  feeTerms?: AuthCaptureFeeTerms;
+  operators?: OperatorAllowlistEntry[];
+  receiverAuthorizer?: `0x${string}`;
+  /**
+   * Max gas for a custom-operator collect relay (`authorize` or `charge`).
+   * Used as the verify reject threshold and as a hard broadcast ceiling.
+   *
+   * @default DEFAULT_CUSTOM_OPERATOR_AUTHORIZE_GAS_LIMIT (1_000_000)
+   */
+  customOperatorAuthorizeGasLimit?: bigint;
+  /**
+   * Allowlist of ERC-6492 preparation targets (hex strings, case-insensitive) the
+   * facilitator accepts for an undeployed payer wallet.
+   *
+   * A counterfactual payer has no `isValidSignature` to call, so its signature can only
+   * be validated by the onchain simulation, where the canonical token collector deploys
+   * the wallet before checking the inner signature. The collector makes that preparation
+   * call through Multicall3, so the facilitator is never its sender; the allowlist exists
+   * to bound the gas an unknown preparation target can burn. An empty or omitted list
+   * rejects every counterfactual payment.
+   *
+   * @default []
+   */
+  eip6492AllowedFactories?: string[];
+  /**
+   * When true, the facilitator relays `type: "refund"` for `"delegated"`
+   * operators. Requires an out-of-band funding agreement: refunds pull tokens
+   * from `PaymentInfo.operator`. With a rotated submitter set, every address
+   * in the rotation must be funded and approved — `OperatorRefundCollector`
+   * pulls with `safeTransferFrom(token, PaymentInfo.operator, ...)`.
+   *
+   * Each submitter also gets its own CREATE2 `TokenStore` on first authorize,
+   * so N keys mean N deployment costs and escrow-held balances split N ways.
+   */
+  refundFunding?: boolean;
+  /**
+   * Lets a retried settle for the same payload reconcile against an
+   * already-broadcast transaction instead of re-verifying and
+   * re-broadcasting (see {@link PendingSettlementStore}). Defaults to a
+   * fresh in-memory store shared across all settle calls on this scheme
+   * instance.
+   */
+  pendingSettlementStore?: PendingSettlementStore;
+};
+
+export type CaptureOptions = {
+  feeReceiver?: `0x${string}`;
+  feeBps?: number;
+  feeAmount?: string;
+} & ({ amount?: string; voidRemainder?: false } | { amount: string; voidRemainder: true });
 
 /**
  * Type guard for AuthCaptureExtra. Checks the structural shape an auth-capture
@@ -64,109 +195,389 @@ export function isAuthCaptureExtra(value: unknown): value is AuthCaptureExtra {
   );
 }
 
-// EIP-3009 payload — ReceiveWithAuthorization to the canonical EIP-3009 token collector.
-export interface Eip3009Payload {
-  authorization: {
-    from: `0x${string}`;
-    to: `0x${string}`; // EIP3009_TOKEN_COLLECTOR_ADDRESS
-    value: string;
-    validAfter: string;
-    validBefore: string; // = preApprovalExpiry
-    nonce: `0x${string}`; // = payer-agnostic PaymentInfo hash
+type ChargeCompletionV1_0 = {
+  amount: string;
+  feeBps: number;
+  feeReceiver: `0x${string}`;
+  authorizerSignature: `0x${string}`;
+};
+
+type ChargeCompletionV1_1 = {
+  amount: string;
+  feeAmount: string;
+  feeReceiver: `0x${string}`;
+  authorizerSignature: `0x${string}`;
+};
+
+type ChargeCompletion = ChargeCompletionV1_0 | ChargeCompletionV1_1;
+
+type NoChargeCompletion = {
+  amount?: never;
+  feeBps?: never;
+  feeAmount?: never;
+  feeReceiver?: never;
+  authorizerSignature?: never;
+};
+
+type CollectEnvelope<TAuth> =
+  | (TAuth & { salt: `0x${string}`; saltNonce?: never; type?: never } & NoChargeCompletion)
+  | (TAuth & { salt: `0x${string}`; saltNonce: `0x${string}`; type?: never } & NoChargeCompletion)
+  | (TAuth & { salt: `0x${string}`; saltNonce: `0x${string}`; type?: never } & ChargeCompletion);
+
+export type Eip3009Authorization = {
+  from: `0x${string}`;
+  to: `0x${string}`;
+  value: string;
+  validAfter: string;
+  validBefore: string;
+  nonce: `0x${string}`;
+};
+
+export type Permit2Authorization = {
+  from: `0x${string}`;
+  permitted: {
+    token: `0x${string}`;
+    amount: string;
   };
+  spender: `0x${string}`;
+  nonce: string;
+  deadline: string;
+};
+
+export type Eip3009Payload = CollectEnvelope<{
+  authorization: Eip3009Authorization;
   signature: `0x${string}`;
-  salt: `0x${string}`; // bytes32, fresh per request, used to reconstruct PaymentInfo
+}>;
+
+export type Permit2Payload = CollectEnvelope<{
+  permit2Authorization: Permit2Authorization;
+  signature: `0x${string}`;
+}>;
+
+export type AuthCaptureCollectPayload = Eip3009Payload | Permit2Payload;
+
+type LifecycleBase = {
+  paymentInfo: PaymentInfoStruct;
+  saltNonce: `0x${string}`;
+  authorizerSignature: `0x${string}`;
+};
+
+export type CapturePayload = LifecycleBase & {
+  type: "capture";
+  amount: string;
+  feeReceiver: `0x${string}`;
+  expectedCapturableAmount: string;
+  expectedRefundableAmount: string;
+  voidAuthorizerSignature?: `0x${string}`;
+} & ({ feeBps: number; feeAmount?: never } | { feeAmount: string; feeBps?: never });
+
+export type VoidPayload = LifecycleBase & {
+  type: "void";
+  voidAuthorizerSignature?: never;
+};
+
+export type RefundPayload = LifecycleBase & {
+  type: "refund";
+  amount: string;
+  expectedCapturableAmount: string;
+  expectedRefundableAmount: string;
+  voidAuthorizerSignature?: never;
+};
+
+export type AuthCaptureLifecyclePayload = CapturePayload | VoidPayload | RefundPayload;
+
+export type AuthCapturePayload = AuthCaptureCollectPayload | AuthCaptureLifecyclePayload;
+
+/**
+ * True when `value` has a collect-payload `type` discriminant of `capture` /
+ * `void` / `refund`. Field-level validation happens in the lifecycle verifier.
+ *
+ * @param value - Candidate payment payload from the wire.
+ * @returns True if `value` names a lifecycle operation.
+ */
+export function isLifecyclePayload(value: unknown): value is AuthCaptureLifecyclePayload {
+  if (typeof value !== "object" || value === null) return false;
+  const type = (value as Record<string, unknown>).type;
+  return type === "capture" || type === "void" || type === "refund";
 }
 
 /**
- * Type guard for an EIP-3009-shaped auth-capture payload. Checks for an
- * `authorization` object plus the required `signature` and `salt` fields;
- * field-level validation happens later in `verify()`.
+ * Type guard for a capture lifecycle payload.
  *
  * @param value - Candidate payment payload from the wire.
- * @returns True if `value` has the EIP-3009 envelope shape.
+ * @returns True if `value` is a capture envelope with the required fields.
  */
-export function isEip3009Payload(value: unknown): value is Eip3009Payload {
+export function isCapturePayload(value: unknown): value is CapturePayload {
+  if (!isLifecyclePayload(value) || value.type !== "capture") return false;
+  const v = value as Record<string, unknown>;
+  const hasFeeBps = typeof v.feeBps === "number";
+  const hasFeeAmount = typeof v.feeAmount === "string";
+  if (hasFeeBps === hasFeeAmount) return false;
+  return (
+    isPaymentInfoStruct(v.paymentInfo) &&
+    typeof v.saltNonce === "string" &&
+    typeof v.amount === "string" &&
+    typeof v.feeReceiver === "string" &&
+    typeof v.expectedCapturableAmount === "string" &&
+    typeof v.expectedRefundableAmount === "string" &&
+    typeof v.authorizerSignature === "string" &&
+    (v.voidAuthorizerSignature === undefined || typeof v.voidAuthorizerSignature === "string")
+  );
+}
+
+/**
+ * Type guard for a void lifecycle payload.
+ *
+ * @param value - Candidate payment payload from the wire.
+ * @returns True if `value` is a void envelope with the required fields.
+ */
+export function isVoidPayload(value: unknown): value is VoidPayload {
+  if (!isLifecyclePayload(value) || value.type !== "void") return false;
+  const v = value as Record<string, unknown>;
+  return (
+    isPaymentInfoStruct(v.paymentInfo) &&
+    typeof v.saltNonce === "string" &&
+    typeof v.authorizerSignature === "string" &&
+    v.voidAuthorizerSignature === undefined
+  );
+}
+
+/**
+ * Type guard for a refund lifecycle payload.
+ *
+ * @param value - Candidate payment payload from the wire.
+ * @returns True if `value` is a refund envelope with the required fields.
+ */
+export function isRefundPayload(value: unknown): value is RefundPayload {
+  if (!isLifecyclePayload(value) || value.type !== "refund") return false;
+  const v = value as Record<string, unknown>;
+  return (
+    isPaymentInfoStruct(v.paymentInfo) &&
+    typeof v.saltNonce === "string" &&
+    typeof v.amount === "string" &&
+    typeof v.expectedCapturableAmount === "string" &&
+    typeof v.expectedRefundableAmount === "string" &&
+    typeof v.authorizerSignature === "string" &&
+    v.voidAuthorizerSignature === undefined
+  );
+}
+
+/**
+ * Type guard for the onchain PaymentInfo struct shape.
+ *
+ * @param value - Candidate struct from a lifecycle payload.
+ * @returns True if every PaymentInfo field is present with the expected type.
+ */
+function isPaymentInfoStruct(value: unknown): value is PaymentInfoStruct {
   if (typeof value !== "object" || value === null) return false;
   const v = value as Record<string, unknown>;
   return (
-    "authorization" in v &&
-    typeof v.authorization === "object" &&
-    v.authorization !== null &&
-    typeof v.signature === "string" &&
+    typeof v.operator === "string" &&
+    typeof v.payer === "string" &&
+    typeof v.receiver === "string" &&
+    typeof v.token === "string" &&
+    typeof v.maxAmount === "string" &&
+    typeof v.preApprovalExpiry === "number" &&
+    typeof v.authorizationExpiry === "number" &&
+    typeof v.refundExpiry === "number" &&
+    typeof v.minFeeBps === "number" &&
+    typeof v.maxFeeBps === "number" &&
+    typeof v.feeReceiver === "string" &&
     typeof v.salt === "string"
   );
 }
 
-// Permit2 payload — PermitTransferFrom to the canonical Permit2 token collector.
-export interface Permit2Payload {
-  permit2Authorization: {
-    from: `0x${string}`;
-    permitted: {
-      token: `0x${string}`;
-      amount: string;
-    };
-    spender: `0x${string}`; // PERMIT2_TOKEN_COLLECTOR_ADDRESS
-    nonce: string; // uint256 string, = uint256(payer-agnostic PaymentInfo hash)
-    deadline: string; // = preApprovalExpiry
-  };
-  signature: `0x${string}`;
-  salt: `0x${string}`; // bytes32, fresh per request, used to reconstruct PaymentInfo
+/**
+ * Whether `value` is a 0x-prefixed hex string.
+ *
+ * @param value - Candidate wire field.
+ * @returns True when `value` is hex.
+ */
+function isHexString(value: unknown): value is `0x${string}` {
+  return typeof value === "string" && value.startsWith("0x");
 }
 
 /**
- * Type guard for a Permit2-shaped auth-capture payload. Checks for the
- * `permit2Authorization` envelope (with `from`, `spender`, `nonce`,
- * `deadline`, `permitted`) plus the required `signature` and `salt` fields.
+ * Parse the four charge-completion fields as an all-or-none group.
+ *
+ * @param v - Collect payload fields.
+ * @returns ChargeCompletion when all four are present and well-typed; undefined when all are absent.
+ */
+function readChargeCompletion(v: Record<string, unknown>): ChargeCompletion | undefined {
+  const hasAny =
+    "amount" in v ||
+    "feeBps" in v ||
+    "feeAmount" in v ||
+    "feeReceiver" in v ||
+    "authorizerSignature" in v;
+  if (!hasAny) return undefined;
+  if (
+    typeof v.amount === "string" &&
+    typeof v.feeBps === "number" &&
+    v.feeAmount === undefined &&
+    typeof v.feeReceiver === "string" &&
+    typeof v.authorizerSignature === "string"
+  ) {
+    return {
+      amount: v.amount,
+      feeBps: v.feeBps,
+      feeReceiver: v.feeReceiver as `0x${string}`,
+      authorizerSignature: v.authorizerSignature as `0x${string}`,
+    };
+  }
+  if (
+    typeof v.amount === "string" &&
+    typeof v.feeAmount === "string" &&
+    v.feeBps === undefined &&
+    typeof v.feeReceiver === "string" &&
+    typeof v.authorizerSignature === "string"
+  ) {
+    return {
+      amount: v.amount,
+      feeAmount: v.feeAmount,
+      feeReceiver: v.feeReceiver as `0x${string}`,
+      authorizerSignature: v.authorizerSignature as `0x${string}`,
+    };
+  }
+  return undefined;
+}
+
+/**
+ * Parse collect `salt` and optional `saltNonce`.
+ *
+ * @param v - Collect payload fields.
+ * @returns Unbound or bound salt pair, or undefined when malformed.
+ */
+function collectExtras(
+  v: Record<string, unknown>,
+):
+  | { salt: `0x${string}`; saltNonce?: never }
+  | { salt: `0x${string}`; saltNonce: `0x${string}` }
+  | undefined {
+  if (!isHexString(v.salt)) return undefined;
+  if (v.saltNonce === undefined) {
+    return { salt: v.salt };
+  }
+  if (!isHexString(v.saltNonce)) return undefined;
+  return { salt: v.salt, saltNonce: v.saltNonce };
+}
+
+/**
+ * Type guard for an EIP-3009-shaped auth-capture collect payload. Rejects
+ * lifecycle envelopes (`payload.type` set) so `payload.type` remains the
+ * discriminant the facilitator dispatches on.
  *
  * @param value - Candidate payment payload from the wire.
- * @returns True if `value` has the Permit2 envelope shape.
+ * @returns True if `value` has the EIP-3009 collect envelope shape.
+ */
+export function isEip3009Payload(value: unknown): value is Eip3009Payload {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  if (v.type !== undefined) return false;
+  if (
+    typeof v.authorization !== "object" ||
+    v.authorization === null ||
+    typeof v.signature !== "string"
+  ) {
+    return false;
+  }
+  const saltFields = collectExtras(v);
+  if (!saltFields) return false;
+  const hasAnyCharge =
+    "amount" in v ||
+    "feeBps" in v ||
+    "feeAmount" in v ||
+    "feeReceiver" in v ||
+    "authorizerSignature" in v;
+  if (hasAnyCharge) {
+    if (!saltFields.saltNonce) return false;
+    return readChargeCompletion(v) !== undefined;
+  }
+  return true;
+}
+
+/**
+ * Type guard for a Permit2-shaped auth-capture collect payload.
+ *
+ * @param value - Candidate payment payload from the wire.
+ * @returns True if `value` has the Permit2 collect envelope shape.
  */
 export function isPermit2Payload(value: unknown): value is Permit2Payload {
   if (typeof value !== "object" || value === null) return false;
   const v = value as Record<string, unknown>;
-  if (typeof v.signature !== "string" || typeof v.salt !== "string") return false;
+  if (v.type !== undefined) return false;
+  if (typeof v.signature !== "string") return false;
   if (typeof v.permit2Authorization !== "object" || v.permit2Authorization === null) return false;
   const a = v.permit2Authorization as Record<string, unknown>;
-  return (
-    typeof a.from === "string" &&
-    typeof a.spender === "string" &&
-    typeof a.nonce === "string" &&
-    typeof a.deadline === "string" &&
-    typeof a.permitted === "object" &&
-    a.permitted !== null
-  );
+  if (
+    typeof a.from !== "string" ||
+    typeof a.spender !== "string" ||
+    typeof a.nonce !== "string" ||
+    typeof a.deadline !== "string" ||
+    typeof a.permitted !== "object" ||
+    a.permitted === null
+  ) {
+    return false;
+  }
+  const saltFields = collectExtras(v);
+  if (!saltFields) return false;
+  const hasAnyCharge =
+    "amount" in v ||
+    "feeBps" in v ||
+    "feeAmount" in v ||
+    "feeReceiver" in v ||
+    "authorizerSignature" in v;
+  if (hasAnyCharge) {
+    if (!saltFields.saltNonce) return false;
+    return readChargeCompletion(v) !== undefined;
+  }
+  return true;
 }
 
-// Discriminated union of all auth-capture payload shapes.
-export type AuthCapturePayload = Eip3009Payload | Permit2Payload;
-
 /**
- * Type guard for any auth-capture payload. Returns true if `value` matches
- * either the EIP-3009 envelope or the Permit2 envelope.
+ * Type guard for a collect (authorize/charge) payload of either envelope.
  *
  * @param value - Candidate payment payload from the wire.
- * @returns True if `value` is a valid auth-capture envelope of either shape.
+ * @returns True if `value` is an EIP-3009 or Permit2 collect envelope.
  */
-export function isAuthCapturePayload(value: unknown): value is AuthCapturePayload {
+export function isAuthCaptureCollectPayload(value: unknown): value is AuthCaptureCollectPayload {
   return isEip3009Payload(value) || isPermit2Payload(value);
 }
 
 /**
- * On-chain PaymentInfo struct (canonical Solidity names — DO NOT RENAME).
+ * Type guard for any auth-capture payload: collect or lifecycle.
+ *
+ * @param value - Candidate payment payload from the wire.
+ * @returns True if `value` is a valid auth-capture envelope.
+ */
+export function isAuthCapturePayload(value: unknown): value is AuthCapturePayload {
+  if (isLifecyclePayload(value)) {
+    return isCapturePayload(value) || isVoidPayload(value) || isRefundPayload(value);
+  }
+  return isAuthCaptureCollectPayload(value);
+}
+
+/**
+ * Onchain PaymentInfo struct (canonical Solidity names — DO NOT RENAME).
  * Reconstructed by the facilitator from extra + payload.salt + payer + receiver/asset/amount.
  */
 export interface PaymentInfoStruct {
-  operator: `0x${string}`; // = extra.captureAuthorizer
+  operator: `0x${string}`;
   payer: `0x${string}`;
-  receiver: `0x${string}`; // = requirements.payTo
-  token: `0x${string}`; // = requirements.asset
-  maxAmount: string; // = requirements.amount
+  receiver: `0x${string}`;
+  token: `0x${string}`;
+  maxAmount: string;
   preApprovalExpiry: number;
-  authorizationExpiry: number; // = extra.captureDeadline
-  refundExpiry: number; // = extra.refundDeadline
+  authorizationExpiry: number;
+  refundExpiry: number;
   minFeeBps: number;
   maxFeeBps: number;
-  feeReceiver: `0x${string}`; // = extra.feeRecipient
-  salt: `0x${string}`; // = payload.salt
+  feeReceiver: `0x${string}`;
+  salt: `0x${string}`;
+}
+
+export interface PaymentState {
+  hasCollectedPayment: boolean;
+  capturableAmount: bigint;
+  refundableAmount: bigint;
 }

--- a/typescript/packages/mechanisms/evm/src/auth-capture/utils.ts
+++ b/typescript/packages/mechanisms/evm/src/auth-capture/utils.ts
@@ -1,17 +1,102 @@
+import type { PaymentRequirements } from "@x402/core/types";
+import type { AuthCaptureDeployment } from "./constants";
+import type {
+  AuthCaptureCollectPayload,
+  AuthCaptureExtra,
+  Eip3009Payload,
+  PaymentInfoStruct,
+  Permit2Payload,
+} from "./types";
+
 /**
- * Parse chainId from CAIP-2 network identifier
+ * Reconstruct the onchain PaymentInfo struct from the inputs the facilitator
+ * has after verifying a wire payload. Wire-only inputs: `payer` and `salt`
+ * (both from the payload). `preApprovalExpiry` is computed by the caller from
+ * the payload (ERC-3009 `validBefore` or Permit2 `deadline`). The remaining
+ * fields come from `requirements` (receiver/token/maxAmount) and
+ * `requirements.extra` (capture/refund deadlines, fee policy, captureAuthorizer).
  *
- * @param network - CAIP-2 network identifier (e.g., 'eip155:84532')
- * @returns The chain ID as a number
+ * @param payer - Address recovered from the wire payload's signature.
+ * @param preApprovalExpiry - Pre-approval expiry in Unix seconds (from the wire payload).
+ * @param salt - 32-byte salt from the wire payload (PaymentInfo.salt).
+ * @param requirements - The payment requirements published by the server.
+ * @param extra - The validated `AuthCaptureExtra` subset of `requirements.extra`.
+ * @param maxAmount - Client-signed maximum; defaults to `requirements.amount`.
+ * @returns A PaymentInfo struct ready to hand to the escrow contract.
  */
-export function parseChainId(network: string): number {
-  const parts = network.split(":");
-  if (parts.length !== 2 || parts[0] !== "eip155") {
-    throw new Error(`Invalid network format: ${network}. Expected 'eip155:<chainId>'`);
+export function reconstructPaymentInfo(
+  payer: `0x${string}`,
+  preApprovalExpiry: number,
+  salt: `0x${string}`,
+  requirements: PaymentRequirements,
+  extra: AuthCaptureExtra,
+  maxAmount: string = requirements.amount,
+): PaymentInfoStruct {
+  return {
+    operator: extra.captureAuthorizer,
+    payer,
+    receiver: requirements.payTo as `0x${string}`,
+    token: requirements.asset as `0x${string}`,
+    maxAmount,
+    preApprovalExpiry,
+    authorizationExpiry: extra.captureDeadline,
+    refundExpiry: extra.refundDeadline,
+    minFeeBps: extra.minFeeBps,
+    maxFeeBps: extra.maxFeeBps,
+    feeReceiver: extra.feeRecipient,
+    salt,
+  };
+}
+
+/**
+ * Convert a JS-side PaymentInfo struct (string `maxAmount` and `salt`) into
+ * the bigint-typed form viem expects when encoding the onchain tuple.
+ *
+ * @param p - PaymentInfo with string-form numeric fields.
+ * @returns The same struct with `maxAmount` and `salt` coerced to bigint.
+ */
+export function paymentInfoToContractTuple(p: PaymentInfoStruct) {
+  return { ...p, maxAmount: BigInt(p.maxAmount), salt: BigInt(p.salt) };
+}
+
+/**
+ * Unpack the per-method inputs the escrow needs at collect settle time.
+ *
+ * `collectorData` is the client's signature exactly as it arrived, ERC-6492 wrapper and
+ * all. Both canonical collectors pass it through `ERC6492SignatureHandler`, which strips
+ * the wrapper, runs the preparation call via Multicall3, and hands only the inner
+ * signature to the token or Permit2. Unwrapping here would therefore drop the deployment
+ * step an undeployed payer wallet depends on.
+ *
+ * @param wirePayload - The verified collect payload (EIP-3009 or Permit2).
+ * @param assetTransferMethod - Which envelope the payload uses.
+ * @param deployment - Resolved commerce-payments deployment.
+ * @returns `preApprovalExpiry`, signed `amount`, `tokenCollector`, and `collectorData`.
+ */
+export function unpackForSettle(
+  wirePayload: AuthCaptureCollectPayload,
+  assetTransferMethod: "eip3009" | "permit2",
+  deployment: AuthCaptureDeployment,
+): {
+  preApprovalExpiry: number;
+  amount: bigint;
+  tokenCollector: `0x${string}`;
+  collectorData: `0x${string}`;
+} {
+  if (assetTransferMethod === "eip3009") {
+    const p = wirePayload as Eip3009Payload;
+    return {
+      preApprovalExpiry: Number(p.authorization.validBefore),
+      amount: BigInt(p.authorization.value),
+      tokenCollector: deployment.eip3009Collector,
+      collectorData: p.signature,
+    };
   }
-  const chainId = parseInt(parts[1], 10);
-  if (isNaN(chainId)) {
-    throw new Error(`Invalid chainId in network: ${network}`);
-  }
-  return chainId;
+  const p = wirePayload as Permit2Payload;
+  return {
+    preApprovalExpiry: Number(p.permit2Authorization.deadline),
+    amount: BigInt(p.permit2Authorization.permitted.amount),
+    tokenCollector: deployment.permit2Collector,
+    collectorData: p.signature,
+  };
 }

--- a/typescript/packages/mechanisms/evm/src/index.ts
+++ b/typescript/packages/mechanisms/evm/src/index.ts
@@ -134,7 +134,12 @@ export { isAuthCaptureExtra, isAuthCapturePayload } from "./auth-capture/types";
 // AuthCapture constants
 export {
   AUTH_CAPTURE_ESCROW_ADDRESS,
+  AUTH_CAPTURE_ESCROW_V1_0_ADDRESS,
+  AUTH_CAPTURE_ESCROW_V1_1_ADDRESS,
   AUTH_CAPTURE_SCHEME,
   EIP3009_TOKEN_COLLECTOR_ADDRESS,
+  EIP3009_TOKEN_COLLECTOR_V1_0_ADDRESS,
+  OPERATOR_REFUND_COLLECTOR_ADDRESS,
   PERMIT2_TOKEN_COLLECTOR_ADDRESS,
+  resolveAuthCaptureDeployment,
 } from "./auth-capture/constants";

--- a/typescript/packages/mechanisms/evm/test/unit/auth-capture/client.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/auth-capture/client.test.ts
@@ -163,13 +163,29 @@ describe("AuthCaptureEvmScheme", () => {
       const b = (await scheme.createPaymentPayload(2, mockRequirements))
         .payload as unknown as Eip3009Payload;
       expect(a.salt).not.toBe(b.salt);
+      expect(a.saltNonce).toBeUndefined();
+    });
+
+    it("should emit saltNonce and a bound salt when receiverAuthorizer is set", async () => {
+      const scheme = new AuthCaptureEvmScheme(mockSigner);
+      const result = await scheme.createPaymentPayload(2, {
+        ...mockRequirements,
+        extra: {
+          ...mockRequirements.extra,
+          receiverAuthorizer: "0x1111111111111111111111111111111111111111" as `0x${string}`,
+        },
+      });
+      const payload = result.payload as unknown as Eip3009Payload;
+      expect(payload.saltNonce).toMatch(/^0x[a-fA-F0-9]{64}$/);
+      expect(payload.salt).toMatch(/^0x[a-fA-F0-9]{64}$/);
+      expect(payload.salt).not.toBe(payload.saltNonce);
     });
 
     it("should throw for invalid network format", async () => {
       const scheme = new AuthCaptureEvmScheme(mockSigner);
       const badNetworkRequirements = { ...mockRequirements, network: "solana:mainnet" };
       await expect(scheme.createPaymentPayload(2, badNetworkRequirements)).rejects.toThrow(
-        "Invalid network format",
+        "Unsupported network format: solana:mainnet (expected eip155:CHAIN_ID)",
       );
     });
 

--- a/typescript/packages/mechanisms/evm/test/unit/auth-capture/nonce.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/auth-capture/nonce.test.ts
@@ -1,6 +1,15 @@
 import { describe, it, expect } from "vitest";
-import { zeroAddress } from "viem";
-import { computePayerAgnosticPaymentInfoHash, generateSalt } from "../../../src/auth-capture/nonce";
+import { keccak256, zeroAddress } from "viem";
+import {
+  AUTH_CAPTURE_ESCROW_V1_0_ADDRESS,
+  SALT_BINDING_TYPEHASH,
+} from "../../../src/auth-capture/constants";
+import {
+  computePayerAgnosticPaymentInfoHash,
+  deriveBoundSalt,
+  generateSalt,
+  isSaltBindingOn,
+} from "../../../src/auth-capture/nonce";
 import type { PaymentInfoStruct } from "../../../src/auth-capture/types";
 
 describe("nonce utilities", () => {
@@ -23,6 +32,29 @@ describe("nonce utilities", () => {
     it("should produce a 32-byte hex string", () => {
       const nonce = computePayerAgnosticPaymentInfoHash(84532, mockPaymentInfo);
       expect(nonce).toMatch(/^0x[a-fA-F0-9]{64}$/);
+    });
+
+    it("should produce fixed hashes for the default and v1.0 escrow domains", () => {
+      expect(computePayerAgnosticPaymentInfoHash(84532, mockPaymentInfo)).toBe(
+        "0xabfa4347d9119b8da1991d399233436d6f556a502312f784c38d080a1e49f993",
+      );
+      expect(computePayerAgnosticPaymentInfoHash(8453, mockPaymentInfo)).toBe(
+        "0x9c63347600c217bfe7b607adfdef36a85d764610f1bdb19ed12fda5704b91528",
+      );
+      expect(
+        computePayerAgnosticPaymentInfoHash(
+          84532,
+          mockPaymentInfo,
+          AUTH_CAPTURE_ESCROW_V1_0_ADDRESS,
+        ),
+      ).toBe("0x19de8ffcb747e5caadb3dda7435cf54992e87cdf0c90e5315ffa129dbb22461e");
+      expect(
+        computePayerAgnosticPaymentInfoHash(
+          8453,
+          mockPaymentInfo,
+          AUTH_CAPTURE_ESCROW_V1_0_ADDRESS,
+        ),
+      ).toBe("0x198bbfeaab2f8e36302c662ae41bceaef47a1eb4bf2549cb87aa8daa7f7bb43a");
     });
 
     it("should produce deterministic results for same inputs", () => {
@@ -92,6 +124,57 @@ describe("nonce utilities", () => {
       const salt = generateSalt();
       const hexPart = salt.slice(2);
       expect(hexPart).toMatch(/^[0-9a-f]+$/);
+    });
+  });
+
+  describe("salt binding", () => {
+    const authorizer = "0x1111111111111111111111111111111111111111" as `0x${string}`;
+    const policy = "0x0000000000000000000000000000000000000000" as `0x${string}`;
+    const nonce =
+      "0x0000000000000000000000000000000000000000000000000000000000000abc" as `0x${string}`;
+
+    it("is off when receiverAuthorizer and policy are absent or zero", () => {
+      expect(isSaltBindingOn({})).toBe(false);
+      expect(isSaltBindingOn({ receiverAuthorizer: policy, policy })).toBe(false);
+    });
+
+    it("is on when receiverAuthorizer is non-zero", () => {
+      expect(isSaltBindingOn({ receiverAuthorizer: authorizer })).toBe(true);
+    });
+
+    it("derives a deterministic 32-byte salt from the typehash, addresses, and nonce", () => {
+      const a = deriveBoundSalt(authorizer, policy, nonce);
+      const b = deriveBoundSalt(authorizer, policy, nonce);
+      expect(a).toBe(b);
+      expect(a).toMatch(/^0x[a-fA-F0-9]{64}$/);
+      expect(a).toBe("0xd0967e09b6c8fccf96277d95a03e98583e8605ab10858b1349aa50ea6d78132c");
+    });
+
+    it("should hash the salt-binding and PaymentInfo type strings to stable values", () => {
+      expect(SALT_BINDING_TYPEHASH).toBe(
+        "0x8a2a7e41a0bda000ded071ff38b79401d2603e1826516ff2635b11fe9e30877f",
+      );
+      expect(
+        keccak256(
+          new TextEncoder().encode(
+            "PaymentInfo(address operator,address payer,address receiver,address token,uint120 maxAmount,uint48 preApprovalExpiry,uint48 authorizationExpiry,uint48 refundExpiry,uint16 minFeeBps,uint16 maxFeeBps,address feeReceiver,uint256 salt)",
+          ),
+        ),
+      ).toBe("0xae68ac7ce30c86ece8196b61a7c486d8f0061f575037fbd34e7fe4e2820c6591");
+    });
+
+    it("changes when any bound input changes", () => {
+      const base = deriveBoundSalt(authorizer, policy, nonce);
+      expect(deriveBoundSalt("0x2222222222222222222222222222222222222222", policy, nonce)).not.toBe(
+        base,
+      );
+      expect(
+        deriveBoundSalt(
+          authorizer,
+          policy,
+          "0x0000000000000000000000000000000000000000000000000000000000000abd",
+        ),
+      ).not.toBe(base);
     });
   });
 });

--- a/typescript/packages/mechanisms/evm/test/unit/auth-capture/nonce.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/auth-capture/nonce.test.ts
@@ -36,10 +36,10 @@ describe("nonce utilities", () => {
 
     it("should produce fixed hashes for the default and v1.0 escrow domains", () => {
       expect(computePayerAgnosticPaymentInfoHash(84532, mockPaymentInfo)).toBe(
-        "0xabfa4347d9119b8da1991d399233436d6f556a502312f784c38d080a1e49f993",
+        "0x341988b065a5131b3a82818eb7aba9010135f326af1af7695fce4d2bbebd0b76",
       );
       expect(computePayerAgnosticPaymentInfoHash(8453, mockPaymentInfo)).toBe(
-        "0x9c63347600c217bfe7b607adfdef36a85d764610f1bdb19ed12fda5704b91528",
+        "0xa393f8f76a2327a7678488b2d504bda611b7586bb3f334b255a11bb5a75e79ca",
       );
       expect(
         computePayerAgnosticPaymentInfoHash(

--- a/typescript/packages/mechanisms/evm/test/unit/auth-capture/types.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/auth-capture/types.test.ts
@@ -128,6 +128,19 @@ describe("type guards", () => {
       expect(isEip3009Payload(rest)).toBe(false);
     });
 
+    it("accepts a bound payload that also carries saltNonce", () => {
+      expect(
+        isEip3009Payload({
+          ...validEip3009,
+          saltNonce: "0x0000000000000000000000000000000000000000000000000000000000000abc",
+        }),
+      ).toBe(true);
+    });
+
+    it("rejects a lifecycle payload even if authorization is present", () => {
+      expect(isEip3009Payload({ ...validEip3009, type: "capture" })).toBe(false);
+    });
+
     it("rejects a Permit2 payload (no authorization field)", () => {
       expect(isEip3009Payload(validPermit2)).toBe(false);
     });


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

Align the EVM auth-capture client (TS/Go) with the v1.1 spec and update scheme_auth_capture_evm.md accordingly. The client now defaults to commerce-payments v1.1 deployments, supports optional extra.authCaptureEscrow to pin v1.0, and implements salt binding when receiverAuthorizer or policy is set. 

**Breaking:** default signatures target v1.1 escrow/collector addresses; bound payments add saltNonce on the wire.

Server/facilitator implementation will follow in https://github.com/x402-foundation/x402/pull/3203

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [ ] I have formatted and linted my code
- [ ] All new and existing tests pass
- [ ] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [ ] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 