### PR TITLE
fix(core): validate CAIP-2 network syntax

### DIFF
--- a/typescript/.changeset/validate-caip2-networks.md
+++ b/typescript/.changeset/validate-caip2-networks.md
@@ -1,0 +1,5 @@
+---
+"@x402/core": patch
+---
+
+Reject malformed V2 network identifiers that do not match CAIP-2 syntax.

--- a/typescript/packages/core/src/schemas/index.ts
+++ b/typescript/packages/core/src/schemas/index.ts
@@ -38,14 +38,11 @@ export type NetworkV1 = z.infer<typeof NetworkSchemaV1>;
 
 /**
  * Network identifier schema for V2 - CAIP-2 format validation.
- * V2 requires minimum length of 3 and a colon separator (e.g., "eip155:84532", "solana:devnet").
+ * V2 requires a CAIP-2 namespace and reference (e.g., "eip155:84532", "solana:devnet").
  */
-export const NetworkSchemaV2 = z
-  .string()
-  .min(3)
-  .refine(val => val.includes(":"), {
-    message: "Network must be in CAIP-2 format (e.g., 'eip155:84532')",
-  });
+export const NetworkSchemaV2 = z.string().regex(/^[-a-z0-9]{3,8}:[-_a-zA-Z0-9]{1,32}$/, {
+  message: "Network must be in CAIP-2 format (e.g., 'eip155:84532')",
+});
 export type NetworkV2 = z.infer<typeof NetworkSchemaV2>;
 
 /**

--- a/typescript/packages/core/test/unit/schemas/schemas.test.ts
+++ b/typescript/packages/core/test/unit/schemas/schemas.test.ts
@@ -653,10 +653,27 @@ describe("x402 Schemas", () => {
       it("should accept minimum valid CAIP-2 for V2", () => {
         const v2Minimal = {
           ...validPaymentRequirementsV2,
-          network: "a:b",
+          network: "abc:d",
         };
         const result = PaymentRequirementsV2Schema.safeParse(v2Minimal);
         expect(result.success).toBe(true);
+      });
+
+      it.each([
+        "a:b",
+        "EIP155:84532",
+        "123456789:1",
+        "eip155:",
+        `eip155:${"a".repeat(33)}`,
+        "eip155:base.mainnet",
+        ":84532",
+        "eip155:84532:extra",
+      ])("should reject malformed CAIP-2 network %s for V2", network => {
+        const result = PaymentRequirementsV2Schema.safeParse({
+          ...validPaymentRequirementsV2,
+          network,
+        });
+        expect(result.success).toBe(false);
       });
     });
   });


### PR DESCRIPTION
## Description

`NetworkSchemaV2` currently checks only for a minimum length and the presence of a colon, so malformed values such as `a:b`, `eip155:`, and `eip155:84532:extra` pass the shared V2 schema.

x402 V2 defines `network` as CAIP-2. This change applies the [CAIP-2 grammar](https://standards.chainagnostic.org/CAIPs/caip-2) at that schema boundary and adds rejection cases for invalid namespace length/case, reference length/characters, missing parts, and extra separators. The exported TypeScript type remains `string`.

This contribution was prepared with substantial AI assistance and independently checked against the x402 V2 spec, the CAIP-2 specification, the surrounding schema code, and the test suite. It is opened as a draft so the account holder can personally review it before maintainer review is requested.

## Tests

- `pnpm -C typescript test` (55/55 tasks across 28 packages)
- `pnpm -C typescript lint:check` (27/27 tasks)
- `pnpm -C typescript format:check` (27/27 tasks)

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commit is signed and verified by GitHub
- [x] I added a changelog fragment for the `@x402/core` behavior change
