### PR TITLE
test(stellar): disable spend controls in integration test

### DIFF
--- a/typescript/packages/mechanisms/stellar/test/integrations/exact-stellar.test.ts
+++ b/typescript/packages/mechanisms/stellar/test/integrations/exact-stellar.test.ts
@@ -191,7 +191,11 @@ describe.skipIf(missingEnvVars)("Stellar Integration Tests", () => {
 
     beforeEach(async () => {
       const stellarClient = new ExactStellarClient(clientSigner);
-      client = new x402Client().register(STELLAR_TESTNET_CAIP2, stellarClient);
+      // Default spend controls reject the XLM test asset before the payment reaches the
+      // Stellar scheme; this test covers the scheme and facilitator, not spend controls.
+      client = new x402Client()
+        .setSpendControls(false)
+        .register(STELLAR_TESTNET_CAIP2, stellarClient);
 
       const stellarFacilitator = new ExactStellarFacilitator([facilitatorSigner]);
       const facilitator = new x402Facilitator().register(STELLAR_TESTNET_CAIP2, stellarFacilitator);
@@ -290,7 +294,10 @@ describe.skipIf(missingEnvVars)("Stellar Integration Tests", () => {
       const facilitatorClient = new StellarFacilitatorClient(facilitator);
 
       const stellarClient = new ExactStellarClient(clientSigner);
-      const paymentClient = new x402Client().register(STELLAR_TESTNET_CAIP2, stellarClient);
+      // Default spend controls reject the XLM test asset; see the exact-payment suite above.
+      const paymentClient = new x402Client()
+        .setSpendControls(false)
+        .register(STELLAR_TESTNET_CAIP2, stellarClient);
       client = new x402HTTPClient(paymentClient) as x402HTTPClient;
 
       // Create resource server and register schemes (composition pattern)


### PR DESCRIPTION
## Description

Fixes 2 Stellar integration tests that are currently broken on `main`.

- Broken since #3124 added default spend controls to `x402Client`: the default policy rejects the XLM test asset before the payment reaches the Stellar scheme, so the two end-to-end cases (`x402Client` → facilitator, `x402HTTPClient` → resource server) fail with a spend-controls error on every branch.
- Fix: build the test `x402Client` with `.setSpendControls(false)`, matching what the e2e client already does.
- Safe to disable here: these tests cover the Stellar scheme and facilitator; spend controls have their own coverage in `@x402/core`.

Test-only change; no changeset (not user-facing).

## Tests

- `pnpm --filter @x402/stellar test:integration` (testnet): 8/8 pass, was 6/8 on `main`. Settled txs: https://stellar.expert/explorer/testnet/tx/45f1f67ab687b1fcc51b0a92777b7a0097b915753a50a3a544679d332e86a42f, https://stellar.expert/explorer/testnet/tx/b85ad41288dbdfb46ac4fa0d5d3783b558587c28ad78e602993e7a0a212210c6
- `pnpm test` from `/typescript`: 27 packages, 6,221 tests, 0 failures.
- e2e `--families=stellar` (express/hono/next × axios/fetch, typescript facilitator): 12/12.
- `pnpm format && pnpm lint` on `@x402/stellar`: clean.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [ ] I added a changelog fragment for user-facing changes (docs-only changes can skip) — N/A, test-only