### PR TITLE
fix(go): return EXTENSION-RESPONSES on verify and settle

### DIFF
--- a/go/.changes/unreleased/fixed-20260830-124914.yaml
+++ b/go/.changes/unreleased/fixed-20260830-124914.yaml
@@ -1,0 +1,3 @@
+kind: fixed
+body: Return EXTENSION-RESPONSES data from facilitator verify and settle requests when response bodies omit extensions.
+time: 2026-08-30T12:49:14.025505+09:00

--- a/go/.changes/unreleased/fixed-20260830-124914.yaml
+++ b/go/.changes/unreleased/fixed-20260830-124914.yaml
@@ -1,3 +1,3 @@
 kind: fixed
-body: Return EXTENSION-RESPONSES data from facilitator verify and settle requests when response bodies omit extensions.
+body: Expose EXTENSION-RESPONSES data to resource servers without forwarding it to buyers.
 time: 2026-08-30T12:49:14.025505+09:00

--- a/go/http/client_test.go
+++ b/go/http/client_test.go
@@ -614,6 +614,26 @@ func TestEncodePaymentResponseHeader_ChannelStateOrder(t *testing.T) {
 	}
 }
 
+func TestEncodePaymentResponseHeaderOmitsExtensionResponses(t *testing.T) {
+	encoded, err := encodePaymentResponseHeader(x402.SettleResponse{
+		Success:            true,
+		Transaction:        "0xtx",
+		Network:            "eip155:1",
+		ExtensionResponses: map[string]interface{}{"bazaar": map[string]interface{}{"status": "accepted"}},
+	})
+	if err != nil {
+		t.Fatalf("encodePaymentResponseHeader: %v", err)
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if strings.Contains(string(decoded), "extensionResponses") || strings.Contains(string(decoded), "bazaar") {
+		t.Fatalf("extension responses leaked into PAYMENT-RESPONSE: %s", decoded)
+	}
+}
+
 func TestPaymentRoundTripper(t *testing.T) {
 	// Create a test server that returns 402 first, then 200
 	callCount := 0

--- a/go/http/facilitator_client.go
+++ b/go/http/facilitator_client.go
@@ -182,19 +182,27 @@ func parseSettleSuccessResponse(body []byte) (*x402.SettleResponse, error) {
 
 var extensionResponseLogFieldAllowlist = []string{"status", "rejectedReason", "reason", "code"}
 
-// logExtensionResponsesHeader reads the EXTENSION-RESPONSES header from an HTTP response
-// and logs allowlisted fields. Silently ignores malformed headers.
-func logExtensionResponsesHeader(resp *http.Response) {
+// extractExtensionResponsesHeader decodes an EXTENSION-RESPONSES header into an object.
+// Missing or malformed headers are ignored.
+func extractExtensionResponsesHeader(resp *http.Response) map[string]interface{} {
 	header := resp.Header.Get("EXTENSION-RESPONSES")
 	if header == "" {
-		return
+		return nil
 	}
 	decoded, err := base64.StdEncoding.DecodeString(header)
 	if err != nil {
-		return
+		return nil
 	}
 	var headerExtensions map[string]interface{}
 	if err := json.Unmarshal(decoded, &headerExtensions); err != nil {
+		return nil
+	}
+	return headerExtensions
+}
+
+// logExtensionResponses logs allowlisted fields from decoded extension responses.
+func logExtensionResponses(headerExtensions map[string]interface{}) {
+	if headerExtensions == nil {
 		return
 	}
 	sanitized := make(map[string]map[string]interface{}, len(headerExtensions))
@@ -469,7 +477,11 @@ func (c *HTTPFacilitatorClient) verifyHTTP(ctx context.Context, version int, pay
 	if err != nil {
 		return nil, err
 	}
-	logExtensionResponsesHeader(resp)
+	headerExtensions := extractExtensionResponsesHeader(resp)
+	logExtensionResponses(headerExtensions)
+	if result.Extensions == nil {
+		result.Extensions = headerExtensions
+	}
 	return result, nil
 }
 
@@ -551,6 +563,10 @@ func (c *HTTPFacilitatorClient) settleHTTP(ctx context.Context, version int, pay
 	if err != nil {
 		return nil, err
 	}
-	logExtensionResponsesHeader(resp)
+	headerExtensions := extractExtensionResponsesHeader(resp)
+	logExtensionResponses(headerExtensions)
+	if result.Extensions == nil {
+		result.Extensions = headerExtensions
+	}
 	return result, nil
 }

--- a/go/http/facilitator_client.go
+++ b/go/http/facilitator_client.go
@@ -479,9 +479,7 @@ func (c *HTTPFacilitatorClient) verifyHTTP(ctx context.Context, version int, pay
 	}
 	headerExtensions := extractExtensionResponsesHeader(resp)
 	logExtensionResponses(headerExtensions)
-	if result.Extensions == nil {
-		result.Extensions = headerExtensions
-	}
+	result.ExtensionResponses = headerExtensions
 	return result, nil
 }
 
@@ -565,8 +563,6 @@ func (c *HTTPFacilitatorClient) settleHTTP(ctx context.Context, version int, pay
 	}
 	headerExtensions := extractExtensionResponsesHeader(resp)
 	logExtensionResponses(headerExtensions)
-	if result.Extensions == nil {
-		result.Extensions = headerExtensions
-	}
+	result.ExtensionResponses = headerExtensions
 	return result, nil
 }

--- a/go/http/facilitator_client_test.go
+++ b/go/http/facilitator_client_test.go
@@ -399,39 +399,42 @@ func TestHTTPFacilitatorClientExtensionResponses(t *testing.T) {
 	validHeader := base64.StdEncoding.EncodeToString(headerJSON)
 
 	tests := []struct {
-		name               string
-		endpoint           string
-		body               string
-		header             string
-		expectedExtensions map[string]interface{}
+		name                       string
+		endpoint                   string
+		body                       string
+		header                     string
+		expectedExtensions         map[string]interface{}
+		expectedExtensionResponses map[string]interface{}
 	}{
 		{
-			name:               "verify attaches valid header when body omits extensions",
-			endpoint:           "/verify",
-			body:               `{"isValid":true}`,
-			header:             validHeader,
-			expectedExtensions: headerExtensions,
+			name:                       "verify attaches valid header to sidechannel",
+			endpoint:                   "/verify",
+			body:                       `{"isValid":true}`,
+			header:                     validHeader,
+			expectedExtensionResponses: headerExtensions,
 		},
 		{
-			name:               "settle attaches valid header when body omits extensions",
-			endpoint:           "/settle",
-			body:               `{"success":true,"transaction":"0xabc","network":"eip155:8453"}`,
-			header:             validHeader,
-			expectedExtensions: headerExtensions,
+			name:                       "settle attaches valid header to sidechannel",
+			endpoint:                   "/settle",
+			body:                       `{"success":true,"transaction":"0xabc","network":"eip155:8453"}`,
+			header:                     validHeader,
+			expectedExtensionResponses: headerExtensions,
 		},
 		{
-			name:               "body extensions override header",
-			endpoint:           "/verify",
-			body:               `{"isValid":true,"extensions":{"bazaar":{"status":"from-body"}}}`,
-			header:             validHeader,
-			expectedExtensions: map[string]interface{}{"bazaar": map[string]interface{}{"status": "from-body"}},
+			name:                       "body extensions remain separate from sidechannel",
+			endpoint:                   "/verify",
+			body:                       `{"isValid":true,"extensions":{"bazaar":{"status":"from-body"}}}`,
+			header:                     validHeader,
+			expectedExtensions:         map[string]interface{}{"bazaar": map[string]interface{}{"status": "from-body"}},
+			expectedExtensionResponses: headerExtensions,
 		},
 		{
-			name:               "empty body extensions override header",
-			endpoint:           "/settle",
-			body:               `{"success":true,"transaction":"0xabc","network":"eip155:8453","extensions":{}}`,
-			header:             validHeader,
-			expectedExtensions: map[string]interface{}{},
+			name:                       "empty body extensions remain separate from sidechannel",
+			endpoint:                   "/settle",
+			body:                       `{"success":true,"transaction":"0xabc","network":"eip155:8453","extensions":{}}`,
+			header:                     validHeader,
+			expectedExtensions:         map[string]interface{}{},
+			expectedExtensionResponses: headerExtensions,
 		},
 		{
 			name:     "missing header leaves extensions nil",
@@ -479,23 +482,28 @@ func TestHTTPFacilitatorClientExtensionResponses(t *testing.T) {
 			defer server.Close()
 
 			client := NewHTTPFacilitatorClient(&FacilitatorConfig{URL: server.URL})
-			var extensions map[string]interface{}
+			var extensions, extensionResponses map[string]interface{}
 			if tt.endpoint == "/verify" {
 				response, err := client.Verify(ctx, payloadBytes, requirementsBytes)
 				if err != nil {
 					t.Fatalf("Unexpected verify error: %v", err)
 				}
 				extensions = response.Extensions
+				extensionResponses = response.ExtensionResponses
 			} else {
 				response, err := client.Settle(ctx, payloadBytes, requirementsBytes)
 				if err != nil {
 					t.Fatalf("Unexpected settle error: %v", err)
 				}
 				extensions = response.Extensions
+				extensionResponses = response.ExtensionResponses
 			}
 
 			if !reflect.DeepEqual(extensions, tt.expectedExtensions) {
 				t.Fatalf("Expected extensions %#v, got %#v", tt.expectedExtensions, extensions)
+			}
+			if !reflect.DeepEqual(extensionResponses, tt.expectedExtensionResponses) {
+				t.Fatalf("Expected extension responses %#v, got %#v", tt.expectedExtensionResponses, extensionResponses)
 			}
 		})
 	}

--- a/go/http/facilitator_client_test.go
+++ b/go/http/facilitator_client_test.go
@@ -1,12 +1,16 @@
 package http
 
 import (
+	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -356,6 +360,178 @@ func TestHTTPFacilitatorClientSettleInvalidResponse(t *testing.T) {
 	}
 	if !strings.Contains(responseErr.Error(), "facilitator settle returned invalid data") {
 		t.Errorf("Expected invalid data message, got %q", responseErr.Error())
+	}
+}
+
+func TestHTTPFacilitatorClientExtensionResponses(t *testing.T) {
+	ctx := context.Background()
+	requirements := x402.PaymentRequirements{
+		Scheme:  "exact",
+		Network: "eip155:1",
+		Asset:   "USDC",
+		Amount:  "1000000",
+		PayTo:   "0xrecipient",
+	}
+	payload := x402.PaymentPayload{
+		X402Version: 2,
+		Accepted:    requirements,
+		Payload:     map[string]interface{}{"sig": "test"},
+	}
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("Failed to marshal payload: %v", err)
+	}
+	requirementsBytes, err := json.Marshal(requirements)
+	if err != nil {
+		t.Fatalf("Failed to marshal requirements: %v", err)
+	}
+
+	headerExtensions := map[string]interface{}{
+		"bazaar": map[string]interface{}{
+			"status":    "accepted",
+			"catalogId": "cat-1",
+		},
+	}
+	headerJSON, err := json.Marshal(headerExtensions)
+	if err != nil {
+		t.Fatalf("Failed to marshal header extensions: %v", err)
+	}
+	validHeader := base64.StdEncoding.EncodeToString(headerJSON)
+
+	tests := []struct {
+		name               string
+		endpoint           string
+		body               string
+		header             string
+		expectedExtensions map[string]interface{}
+	}{
+		{
+			name:               "verify attaches valid header when body omits extensions",
+			endpoint:           "/verify",
+			body:               `{"isValid":true}`,
+			header:             validHeader,
+			expectedExtensions: headerExtensions,
+		},
+		{
+			name:               "settle attaches valid header when body omits extensions",
+			endpoint:           "/settle",
+			body:               `{"success":true,"transaction":"0xabc","network":"eip155:8453"}`,
+			header:             validHeader,
+			expectedExtensions: headerExtensions,
+		},
+		{
+			name:               "body extensions override header",
+			endpoint:           "/verify",
+			body:               `{"isValid":true,"extensions":{"bazaar":{"status":"from-body"}}}`,
+			header:             validHeader,
+			expectedExtensions: map[string]interface{}{"bazaar": map[string]interface{}{"status": "from-body"}},
+		},
+		{
+			name:               "empty body extensions override header",
+			endpoint:           "/settle",
+			body:               `{"success":true,"transaction":"0xabc","network":"eip155:8453","extensions":{}}`,
+			header:             validHeader,
+			expectedExtensions: map[string]interface{}{},
+		},
+		{
+			name:     "missing header leaves extensions nil",
+			endpoint: "/verify",
+			body:     `{"isValid":true}`,
+		},
+		{
+			name:     "malformed base64 is ignored",
+			endpoint: "/verify",
+			body:     `{"isValid":true}`,
+			header:   "not-valid-base64!!!",
+		},
+		{
+			name:     "malformed JSON is ignored",
+			endpoint: "/settle",
+			body:     `{"success":true,"transaction":"0xabc","network":"eip155:8453"}`,
+			header:   base64.StdEncoding.EncodeToString([]byte("not-json")),
+		},
+		{
+			name:     "null is ignored",
+			endpoint: "/verify",
+			body:     `{"isValid":true}`,
+			header:   base64.StdEncoding.EncodeToString([]byte("null")),
+		},
+		{
+			name:     "array is ignored",
+			endpoint: "/settle",
+			body:     `{"success":true,"transaction":"0xabc","network":"eip155:8453"}`,
+			header:   base64.StdEncoding.EncodeToString([]byte(`[{"status":"accepted"}]`)),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != tt.endpoint {
+					t.Errorf("Expected path %s, got %s", tt.endpoint, r.URL.Path)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				if tt.header != "" {
+					w.Header().Set("EXTENSION-RESPONSES", tt.header)
+				}
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+
+			client := NewHTTPFacilitatorClient(&FacilitatorConfig{URL: server.URL})
+			var extensions map[string]interface{}
+			if tt.endpoint == "/verify" {
+				response, err := client.Verify(ctx, payloadBytes, requirementsBytes)
+				if err != nil {
+					t.Fatalf("Unexpected verify error: %v", err)
+				}
+				extensions = response.Extensions
+			} else {
+				response, err := client.Settle(ctx, payloadBytes, requirementsBytes)
+				if err != nil {
+					t.Fatalf("Unexpected settle error: %v", err)
+				}
+				extensions = response.Extensions
+			}
+
+			if !reflect.DeepEqual(extensions, tt.expectedExtensions) {
+				t.Fatalf("Expected extensions %#v, got %#v", tt.expectedExtensions, extensions)
+			}
+		})
+	}
+}
+
+func TestLogExtensionResponsesSanitizesFields(t *testing.T) {
+	headerJSON := []byte(`{"bazaar":{"status":"rejected","rejectedReason":"invalid schema","catalogId":"cat-1"},"other":{"reason":"ok","code":"ready","secret":"hidden"}}`)
+	response := &http.Response{Header: http.Header{
+		"Extension-Responses": []string{base64.StdEncoding.EncodeToString(headerJSON)},
+	}}
+	headerExtensions := extractExtensionResponsesHeader(response)
+
+	var output bytes.Buffer
+	originalWriter := log.Writer()
+	originalFlags := log.Flags()
+	originalPrefix := log.Prefix()
+	log.SetOutput(&output)
+	log.SetFlags(0)
+	log.SetPrefix("")
+	t.Cleanup(func() {
+		log.SetOutput(originalWriter)
+		log.SetFlags(originalFlags)
+		log.SetPrefix(originalPrefix)
+	})
+
+	logExtensionResponses(headerExtensions)
+
+	for _, allowed := range []string{`"status":"rejected"`, `"rejectedReason":"invalid schema"`, `"reason":"ok"`, `"code":"ready"`} {
+		if !strings.Contains(output.String(), allowed) {
+			t.Errorf("Expected log output to contain %s, got %q", allowed, output.String())
+		}
+	}
+	for _, disallowed := range []string{"catalogId", "cat-1", "secret", "hidden"} {
+		if strings.Contains(output.String(), disallowed) {
+			t.Errorf("Expected log output to omit %q, got %q", disallowed, output.String())
+		}
 	}
 }
 

--- a/go/types.go
+++ b/go/types.go
@@ -121,7 +121,9 @@ type VerifyResponse struct {
 	InvalidMessage string                 `json:"invalidMessage,omitempty"`
 	Payer          string                 `json:"payer,omitempty"`
 	Extensions     map[string]interface{} `json:"extensions,omitempty"`
-	Extra          map[string]interface{} `json:"extra,omitempty"`
+	// ExtensionResponses is a facilitator sidechannel for resource-server hooks.
+	ExtensionResponses map[string]interface{} `json:"-"`
+	Extra              map[string]interface{} `json:"extra,omitempty"`
 
 	// SkipHandler is an in-process directive set by an AfterVerifyHook that wants
 	// the HTTP layer to bypass the resource handler and settle inline. It is never
@@ -140,7 +142,9 @@ type SettleResponse struct {
 	Network      Network                `json:"network"`
 	Amount       string                 `json:"amount,omitempty"`
 	Extensions   map[string]interface{} `json:"extensions,omitempty"`
-	Extra        map[string]interface{} `json:"extra,omitempty"`
+	// ExtensionResponses is a facilitator sidechannel for resource-server hooks.
+	ExtensionResponses map[string]interface{} `json:"-"`
+	Extra              map[string]interface{} `json:"extra,omitempty"`
 }
 
 // SettlementOverrides allows overriding settlement parameters.


### PR DESCRIPTION
## Description

Refs #3270. Go parity follow-up to #3278 and #3306.

The HTTP facilitator client decoded `EXTENSION-RESPONSES` only for logging, so resource-server hooks could not consume facilitator extension outcomes. This change stores valid header data in the server-internal `VerifyResponse.ExtensionResponses` and `SettleResponse.ExtensionResponses` sidechannel, keeps response-body `Extensions` independent, and excludes the sidechannel from JSON serialization so it cannot reach buyers through `PAYMENT-RESPONSE`.

Missing, malformed, `null`, and non-object header payloads remain ignored. Decoded values are reused for the existing allowlisted logging.

## Tests

- `make verify`
- `make build`
- `go test ./http -run 'TestHTTPFacilitatorClientExtensionResponses|TestLogExtensionResponsesSanitizesFields|TestEncodePaymentResponseHeaderOmitsExtensionResponses' -count=1`

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed
- [x] I added a changelog fragment for the user-facing change

## AI assistance

AI assistance was used to draft and review parts of this change; the output was manually verified.