### PR TITLE
docs: add qWICKpay to the facilitators list

### DIFF
--- a/docs/dev-tools/facilitators.md
+++ b/docs/dev-tools/facilitators.md
@@ -31,6 +31,7 @@ If you are evaluating a mainnet EVM route, decide on your production facilitator
 | [NEAR x402 Facilitator](https://x402.mikedotexe.com/) | Independent open-source facilitator for exact Circle USDC payments on NEAR and Base, with sponsored gas and durable settlement recovery |
 | [PayAI Facilitator](https://facilitator.payai.network) | Multi-network facilitator supporting all tokens. No API keys required |
 | [Polygon Facilitator](https://docs.polygon.technology/payment-services/agentic-payments/x402/intro/) | Production-grade x402 facilitator for Polygon Mainnet and Amoy testnet |
+| [qWICKpay](https://pay.wick.pics) | Free public facilitator for EVM chains — `exact` (EIP-3009) plus `upto`/permit2 on Ethereum, Base, Arbitrum, Polygon, BNB and PulseChain; no account required |
 | [Solvador](https://solvador.com) | Multi-network facilitator with broad mainnet coverage across EVM plus Solana and NEAR, supporting multiple schemes and extensions |
 | [T54 XRPL Facilitator](https://xrpl-x402.t54.ai) | x402 facilitator for the XRP Ledger, covering mainnet and testnet with XRP and RLUSD support |
 

--- a/docs/dev-tools/facilitators.md
+++ b/docs/dev-tools/facilitators.md
@@ -31,7 +31,7 @@ If you are evaluating a mainnet EVM route, decide on your production facilitator
 | [NEAR x402 Facilitator](https://x402.mikedotexe.com/) | Independent open-source facilitator for exact Circle USDC payments on NEAR and Base, with sponsored gas and durable settlement recovery |
 | [PayAI Facilitator](https://facilitator.payai.network) | Multi-network facilitator supporting all tokens. No API keys required |
 | [Polygon Facilitator](https://docs.polygon.technology/payment-services/agentic-payments/x402/intro/) | Production-grade x402 facilitator for Polygon Mainnet and Amoy testnet |
-| [qWICKpay](https://pay.wick.pics) | Free public facilitator for EVM chains — `exact` (EIP-3009) plus `upto`/permit2 on Ethereum, Base, Arbitrum, Polygon, BNB and PulseChain; no account required |
+| [qWICKpay](https://pay.wick.pics) | Multi-EVM facilitator — `exact` (EIP-3009) plus `upto`/permit2 on Ethereum, Base, Arbitrum, Polygon, BNB and PulseChain; flat per-settlement merchant fee ([public price list](https://pay.wick.pics/about), from $0.0009 on Base, first 3 free) — never a percentage, never a payer fee |
 | [Solvador](https://solvador.com) | Multi-network facilitator with broad mainnet coverage across EVM plus Solana and NEAR, supporting multiple schemes and extensions |
 | [T54 XRPL Facilitator](https://xrpl-x402.t54.ai) | x402 facilitator for the XRP Ledger, covering mainnet and testnet with XRP and RLUSD support |
 


### PR DESCRIPTION
Adds [qWICKpay](https://pay.wick.pics) to the production facilitators table.

qWICKpay is a public facilitator for EVM chains: `exact` (EIP-3009) plus `upto`/permit2 schemes across Ethereum, Base, Arbitrum, Polygon, BNB and PulseChain today, expanding toward all EVM chains. Pricing is a flat per-settlement fee charged to the merchant (public price list: https://pay.wick.pics/about — from $0.0009 on Base, first 3 settlements free) — never a percentage of the payment and never a fee to the payer. Live endpoint: https://402.wick.pics (`GET /supported`). Settlements are reconciled nightly against chain state.