### PR TITLE
fix(py):  add server-only extension_responses sidechannel

### DIFF
--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -8,7 +8,7 @@ Examples for the x402 Python SDK.
 cd clients/httpx
 cp .env-local .env
 # Edit .env with your EVM_PRIVATE_KEY and/or SVM_PRIVATE_KEY
-uv sync
+uv sync --reinstall-package x402
 uv run python main.py
 ```
 

--- a/examples/python/clients/README.md
+++ b/examples/python/clients/README.md
@@ -21,7 +21,7 @@ This directory contains examples demonstrating how to use the x402 v2 SDK with d
 cd httpx
 cp .env-local .env
 # Edit .env with your EVM_PRIVATE_KEY and/or SVM_PRIVATE_KEY
-uv sync
+uv sync --reinstall-package x402
 uv run python main.py
 ```
 
@@ -31,7 +31,7 @@ uv run python main.py
 cd requests
 cp .env-local .env
 # Edit .env with your EVM_PRIVATE_KEY and/or SVM_PRIVATE_KEY
-uv sync
+uv sync --reinstall-package x402
 uv run python main.py
 ```
 

--- a/examples/python/clients/advanced/README.md
+++ b/examples/python/clients/advanced/README.md
@@ -20,7 +20,7 @@ To fund your TVM payer wallet, request testnet TON from [@testgiver_ton_bot](htt
 
    ```bash
    cd examples/python/clients/advanced
-   uv sync
+   uv sync --reinstall-package x402
    ```
 
 2. **Configure environment:**
@@ -34,7 +34,7 @@ To fund your TVM payer wallet, request testnet TON from [@testgiver_ton_bot](htt
 
    ```bash
    cd examples/python/servers/fastapi
-   uv sync && uv run uvicorn main:app --port 4021
+   uv sync --reinstall-package x402 && uv run uvicorn main:app --port 4021
    ```
 
 ## Running Examples

--- a/examples/python/clients/batch-settlement/README.md
+++ b/examples/python/clients/batch-settlement/README.md
@@ -9,7 +9,7 @@ at the end to claw back any unused channel balance.
 ## Setup
 
 ```bash
-uv sync
+uv sync --reinstall-package x402
 ```
 
 ## Environment

--- a/examples/python/clients/builder-code/README.md
+++ b/examples/python/clients/builder-code/README.md
@@ -30,7 +30,7 @@ async with x402HttpxClient(client) as http:
 1. Install dependencies:
 
 ```bash
-uv sync
+uv sync --reinstall-package x402
 ```
 
 2. Copy `.env-local` to `.env` and set required variables:
@@ -56,12 +56,12 @@ Optional:
 # Terminal 1: facilitator
 cd ../../facilitator/builder-code
 cp .env-local .env
-uv sync && uv run python main.py
+uv sync --reinstall-package x402 && uv run python main.py
 
 # Terminal 2: server
 cd ../../servers/builder-code
 cp .env-local .env
-uv sync && uv run python main.py
+uv sync --reinstall-package x402 && uv run python main.py
 ```
 
 4. Run the client:

--- a/examples/python/clients/custom/README.md
+++ b/examples/python/clients/custom/README.md
@@ -62,7 +62,7 @@ Use this approach when you need:
 
 3. Install dependencies:
    ```bash
-   uv sync
+   uv sync --reinstall-package x402
    ```
 
 ## Running

--- a/examples/python/clients/httpx/uv.lock
+++ b/examples/python/clients/httpx/uv.lock
@@ -1748,7 +1748,7 @@ wheels = [
 
 [[package]]
 name = "x402"
-version = "2.19.0"
+version = "2.21.0"
 source = { editable = "../../../../python/x402" }
 dependencies = [
     { name = "nest-asyncio" },

--- a/examples/python/clients/mcp-chatbot/README.md
+++ b/examples/python/clients/mcp-chatbot/README.md
@@ -37,7 +37,7 @@ cp .env-local .env
 3. Install dependencies:
 
 ```bash
-uv sync
+uv sync --reinstall-package x402
 ```
 
 ## Running

--- a/examples/python/clients/mcp/README.md
+++ b/examples/python/clients/mcp/README.md
@@ -25,7 +25,7 @@ cp .env-local .env
 3. Install dependencies:
 
 ```bash
-uv sync
+uv sync --reinstall-package x402
 ```
 
 ## Running

--- a/examples/python/clients/payment-identifier/README.md
+++ b/examples/python/clients/payment-identifier/README.md
@@ -51,7 +51,7 @@ async with x402HttpxClient(client) as http:
 1. Install dependencies:
 
 ```bash
-uv sync
+uv sync --reinstall-package x402
 ```
 
 2. Copy `.env-local` to `.env` and add your private key:

--- a/examples/python/clients/sign-in-with-x/README.md
+++ b/examples/python/clients/sign-in-with-x/README.md
@@ -82,7 +82,7 @@ uv sync --reinstall-package x402
 
 ```bash
 cd ../../servers/sign-in-with-x
-uv sync
+uv sync --reinstall-package x402
 uv run python main.py
 ```
 

--- a/examples/python/facilitator/advanced/README.md
+++ b/examples/python/facilitator/advanced/README.md
@@ -39,7 +39,7 @@ cp .env-local .env
 3. Install dependencies:
 
 ```bash
-uv sync
+uv sync --reinstall-package x402
 ```
 
 4. Run the server:

--- a/examples/python/facilitator/advanced/bazaar.py
+++ b/examples/python/facilitator/advanced/bazaar.py
@@ -17,6 +17,7 @@ from pydantic import BaseModel
 from solders.keypair import Keypair
 
 from x402 import x402Facilitator
+from x402.http.extension_responses import EXTENSION_RESPONSES_HEADER
 from x402.extensions.bazaar import (
     DiscoveryResource,
     extract_discovery_info,
@@ -30,7 +31,7 @@ from x402.mechanisms.svm.exact.facilitator import ExactSvmScheme
 load_dotenv()
 
 # Configuration
-PORT = int(os.environ.get("PORT", "4022"))
+PORT = int(os.environ.get("PORT") or "4022")
 
 # Configuration - optional per network
 evm_private_key = os.environ.get("EVM_PRIVATE_KEY")
@@ -103,11 +104,10 @@ class BazaarCatalog:
 
 bazaar_catalog = BazaarCatalog()
 
-EXTENSION_RESPONSES_HEADER = "EXTENSION-RESPONSES"
-
 
 def _set_extension_responses_header(response: Response) -> None:
-    """Attach an example bazaar extension response header for client readback."""
+    """Attach bazaar extension outcomes on the facilitator sidechannel.
+    """
     extension_responses = {"bazaar": {"status": "success"}}
     encoded = base64.b64encode(json.dumps(extension_responses).encode("utf-8")).decode("ascii")
     response.headers[EXTENSION_RESPONSES_HEADER] = encoded

--- a/examples/python/facilitator/advanced/uv.lock
+++ b/examples/python/facilitator/advanced/uv.lock
@@ -2,6 +2,19 @@ version = 1
 revision = 3
 requires-python = ">=3.10"
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P3D"
+
+[[package]]
+name = "abnf"
+version = "2.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/55/5514e564539e23a4948795695d5f25c184f0e02ac18695db1c8d5e6f3d05/abnf-2.9.0.tar.gz", hash = "sha256:45af3643da2281e34b03fba467bdeb09797f5552d140907a578c2d8ec10fcdd5", size = 1088572, upload-time = "2026-08-27T11:12:45.963Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/4c/cb77419f4dd5e6086550a05f4bce9eb521c80a2b877215065331c2b476b7/abnf-2.9.0-py3-none-any.whl", hash = "sha256:8592e174c05cc6010f5250f2292b832993f92e2ae136d7618368ee89d649435e", size = 78100, upload-time = "2026-08-27T11:12:44.185Z" },
+]
+
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
@@ -2914,6 +2927,24 @@ wheels = [
 ]
 
 [[package]]
+name = "signinwithethereum"
+version = "5.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "abnf" },
+    { name = "eth-account" },
+    { name = "eth-utils" },
+    { name = "pydantic" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "web3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/9c/5bca1085418726e08c333b4b97891c2d03f12b99973418acf7357dd76a54/signinwithethereum-5.0.1.tar.gz", hash = "sha256:9661ac2020cb659cc7c3fc1f9b8a9ff59f2018e259f7a4e1ae641f126a475fa3", size = 165980, upload-time = "2026-04-24T12:16:09.533Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/22/ac218e503a9634757c09ab66e50a6dc3c9bfaaa877163a744516d33c85ce/signinwithethereum-5.0.1-py3-none-any.whl", hash = "sha256:53551a1073209f4f011589a957efb8603650af7be24433f966bf897405c0ebd3", size = 19342, upload-time = "2026-04-24T12:16:08.072Z" },
+]
+
+[[package]]
 name = "solana"
 version = "0.36.11"
 source = { registry = "https://pypi.org/simple" }
@@ -3349,7 +3380,7 @@ wheels = [
 
 [[package]]
 name = "x402"
-version = "2.5.0"
+version = "2.21.0"
 source = { editable = "../../../../python/x402" }
 dependencies = [
     { name = "nest-asyncio" },
@@ -3366,7 +3397,10 @@ evm = [
     { name = "web3" },
 ]
 extensions = [
+    { name = "idna" },
     { name = "jsonschema" },
+    { name = "pynacl" },
+    { name = "signinwithethereum" },
 ]
 fastapi = [
     { name = "fastapi", extra = ["standard"] },
@@ -3393,14 +3427,17 @@ requires-dist = [
     { name = "flask", marker = "extra == 'flask'", specifier = ">=3.0.0" },
     { name = "httpx", marker = "extra == 'httpx'", specifier = ">=0.28.1" },
     { name = "httpx", marker = "extra == 'tvm'", specifier = ">=0.28.1" },
+    { name = "idna", marker = "extra == 'extensions'", specifier = ">=3.4" },
     { name = "jsonschema", marker = "extra == 'extensions'", specifier = ">=4.0.0" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0.0" },
     { name = "nest-asyncio", specifier = ">=1.6.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
+    { name = "pynacl", marker = "extra == 'extensions'", specifier = ">=1.5.0" },
     { name = "pynacl", marker = "extra == 'tvm'", specifier = ">=1.5.0" },
     { name = "pytoniq", marker = "extra == 'tvm'", specifier = ">=0.1.39" },
     { name = "pytoniq-core", marker = "extra == 'tvm'", specifier = ">=0.1.36" },
     { name = "requests", marker = "extra == 'requests'", specifier = ">=2.31.0" },
+    { name = "signinwithethereum", marker = "extra == 'extensions'", specifier = ">=5.0.1" },
     { name = "solana", marker = "extra == 'svm'", specifier = ">=0.36.0" },
     { name = "solders", marker = "extra == 'svm'", specifier = ">=0.27.0" },
     { name = "starlette", marker = "extra == 'fastapi'", specifier = ">=0.27.0" },
@@ -3423,6 +3460,7 @@ dev = [
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.0" },
     { name = "flask", specifier = ">=3.0.0" },
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "idna", specifier = ">=3.4" },
     { name = "jsonschema", specifier = ">=4.0.0" },
     { name = "mcp", specifier = ">=1.26.0" },
     { name = "mypy", specifier = ">=1.0.0" },
@@ -3434,6 +3472,7 @@ dev = [
     { name = "pytoniq-core", specifier = ">=0.1.36" },
     { name = "requests", specifier = ">=2.31.0" },
     { name = "ruff", specifier = ">=0.1.0" },
+    { name = "signinwithethereum", specifier = "==5.0.1" },
     { name = "solana", specifier = ">=0.36.0" },
     { name = "solders", specifier = ">=0.27.0" },
     { name = "starlette", specifier = ">=0.27.0" },

--- a/examples/python/facilitator/basic/README.md
+++ b/examples/python/facilitator/basic/README.md
@@ -29,7 +29,7 @@ and fill required environment variables:
 2. Install dependencies:
 
 ```bash
-uv sync
+uv sync --reinstall-package x402
 ```
 
 3. Run the server:

--- a/examples/python/facilitator/batch-settlement/README.md
+++ b/examples/python/facilitator/batch-settlement/README.md
@@ -7,7 +7,7 @@ client examples in this repo.
 ## Setup
 
 ```bash
-uv sync
+uv sync --reinstall-package x402
 ```
 
 ## Environment

--- a/examples/python/facilitator/builder-code/README.md
+++ b/examples/python/facilitator/builder-code/README.md
@@ -28,7 +28,7 @@ and fill required environment variables:
 2. Install dependencies:
 
 ```bash
-uv sync
+uv sync --reinstall-package x402
 ```
 
 3. Run the server:

--- a/examples/python/servers/advanced/README.md
+++ b/examples/python/servers/advanced/README.md
@@ -64,7 +64,7 @@ cp .env-local .env
 3. Install dependencies:
 
 ```bash
-uv sync
+uv sync --reinstall-package x402
 ```
 
 4. Run the server:

--- a/examples/python/servers/advanced/bazaar.py
+++ b/examples/python/servers/advanced/bazaar.py
@@ -1,5 +1,7 @@
 """Bazaar discovery extension example."""
 
+import json
+import logging
 import os
 
 from dotenv import load_dotenv
@@ -16,9 +18,12 @@ from x402.http.middleware.fastapi import PaymentMiddlewareASGI
 from x402.http.types import RouteConfig
 from x402.mechanisms.evm.exact import ExactEvmServerScheme
 from x402.schemas import Network
+from x402.schemas.hooks import SettleResultContext, VerifyResultContext
 from x402.server import x402ResourceServer
 
 load_dotenv()
+
+logging.basicConfig(level=logging.INFO)
 
 # Config
 EVM_ADDRESS = os.getenv("EVM_ADDRESS")
@@ -44,6 +49,34 @@ facilitator = HTTPFacilitatorClient(FacilitatorConfig(url=FACILITATOR_URL))
 server = x402ResourceServer(facilitator)
 server.register(EVM_NETWORK, ExactEvmServerScheme())
 server.register_extension(bazaar_resource_server_extension)
+
+
+def _log_extension_responses(phase: str, ctx: VerifyResultContext | SettleResultContext) -> None:
+    """Process facilitator extension sidechannel metadata."""
+    extension_responses = ctx.extension_responses
+    if not extension_responses:
+        print(f"\n=== {phase}: no facilitator extension responses ===")
+        return
+
+    print(f"\n=== {phase}: facilitator extension responses (sidechannel) ===")
+    print(json.dumps(extension_responses, indent=2))
+
+    bazaar = extension_responses.get("bazaar")
+    if not isinstance(bazaar, dict):
+        return
+
+    status = bazaar.get("status")
+    if status == "success":
+        print("   ✅ Bazaar cataloging confirmed by facilitator")
+    elif status == "processing":
+        print("   ⏳ Bazaar cataloging in progress")
+    elif status == "rejected":
+        reason = bazaar.get("rejectedReason", "unknown")
+        print(f"   ⚠️  Bazaar rejected: {reason}")
+
+
+server.on_after_verify(lambda ctx: _log_extension_responses("After verify", ctx))
+server.on_after_settle(lambda ctx: _log_extension_responses("After settle", ctx))
 
 routes = {
     "GET /weather": RouteConfig(

--- a/examples/python/servers/advanced/uv.lock
+++ b/examples/python/servers/advanced/uv.lock
@@ -2,6 +2,19 @@ version = 1
 revision = 3
 requires-python = ">=3.10"
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P3D"
+
+[[package]]
+name = "abnf"
+version = "2.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/55/5514e564539e23a4948795695d5f25c184f0e02ac18695db1c8d5e6f3d05/abnf-2.9.0.tar.gz", hash = "sha256:45af3643da2281e34b03fba467bdeb09797f5552d140907a578c2d8ec10fcdd5", size = 1088572, upload-time = "2026-08-27T11:12:45.963Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/4c/cb77419f4dd5e6086550a05f4bce9eb521c80a2b877215065331c2b476b7/abnf-2.9.0-py3-none-any.whl", hash = "sha256:8592e174c05cc6010f5250f2292b832993f92e2ae136d7618368ee89d649435e", size = 78100, upload-time = "2026-08-27T11:12:44.185Z" },
+]
+
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
@@ -2914,6 +2927,24 @@ wheels = [
 ]
 
 [[package]]
+name = "signinwithethereum"
+version = "5.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "abnf" },
+    { name = "eth-account" },
+    { name = "eth-utils" },
+    { name = "pydantic" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "web3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/9c/5bca1085418726e08c333b4b97891c2d03f12b99973418acf7357dd76a54/signinwithethereum-5.0.1.tar.gz", hash = "sha256:9661ac2020cb659cc7c3fc1f9b8a9ff59f2018e259f7a4e1ae641f126a475fa3", size = 165980, upload-time = "2026-04-24T12:16:09.533Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/22/ac218e503a9634757c09ab66e50a6dc3c9bfaaa877163a744516d33c85ce/signinwithethereum-5.0.1-py3-none-any.whl", hash = "sha256:53551a1073209f4f011589a957efb8603650af7be24433f966bf897405c0ebd3", size = 19342, upload-time = "2026-04-24T12:16:08.072Z" },
+]
+
+[[package]]
 name = "solana"
 version = "0.36.11"
 source = { registry = "https://pypi.org/simple" }
@@ -3349,7 +3380,7 @@ wheels = [
 
 [[package]]
 name = "x402"
-version = "2.5.0"
+version = "2.21.0"
 source = { editable = "../../../../python/x402" }
 dependencies = [
     { name = "nest-asyncio" },
@@ -3366,7 +3397,10 @@ evm = [
     { name = "web3" },
 ]
 extensions = [
+    { name = "idna" },
     { name = "jsonschema" },
+    { name = "pynacl" },
+    { name = "signinwithethereum" },
 ]
 fastapi = [
     { name = "fastapi", extra = ["standard"] },
@@ -3393,14 +3427,17 @@ requires-dist = [
     { name = "flask", marker = "extra == 'flask'", specifier = ">=3.0.0" },
     { name = "httpx", marker = "extra == 'httpx'", specifier = ">=0.28.1" },
     { name = "httpx", marker = "extra == 'tvm'", specifier = ">=0.28.1" },
+    { name = "idna", marker = "extra == 'extensions'", specifier = ">=3.4" },
     { name = "jsonschema", marker = "extra == 'extensions'", specifier = ">=4.0.0" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0.0" },
     { name = "nest-asyncio", specifier = ">=1.6.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
+    { name = "pynacl", marker = "extra == 'extensions'", specifier = ">=1.5.0" },
     { name = "pynacl", marker = "extra == 'tvm'", specifier = ">=1.5.0" },
     { name = "pytoniq", marker = "extra == 'tvm'", specifier = ">=0.1.39" },
     { name = "pytoniq-core", marker = "extra == 'tvm'", specifier = ">=0.1.36" },
     { name = "requests", marker = "extra == 'requests'", specifier = ">=2.31.0" },
+    { name = "signinwithethereum", marker = "extra == 'extensions'", specifier = ">=5.0.1" },
     { name = "solana", marker = "extra == 'svm'", specifier = ">=0.36.0" },
     { name = "solders", marker = "extra == 'svm'", specifier = ">=0.27.0" },
     { name = "starlette", marker = "extra == 'fastapi'", specifier = ">=0.27.0" },
@@ -3423,6 +3460,7 @@ dev = [
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.0" },
     { name = "flask", specifier = ">=3.0.0" },
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "idna", specifier = ">=3.4" },
     { name = "jsonschema", specifier = ">=4.0.0" },
     { name = "mcp", specifier = ">=1.26.0" },
     { name = "mypy", specifier = ">=1.0.0" },
@@ -3434,6 +3472,7 @@ dev = [
     { name = "pytoniq-core", specifier = ">=0.1.36" },
     { name = "requests", specifier = ">=2.31.0" },
     { name = "ruff", specifier = ">=0.1.0" },
+    { name = "signinwithethereum", specifier = "==5.0.1" },
     { name = "solana", specifier = ">=0.36.0" },
     { name = "solders", specifier = ">=0.27.0" },
     { name = "starlette", specifier = ">=0.27.0" },

--- a/examples/python/servers/batch-settlement/README.md
+++ b/examples/python/servers/batch-settlement/README.md
@@ -15,7 +15,7 @@ For Flask or other sync servers, use `HTTPFacilitatorClientSync` with
 ## Setup
 
 ```bash
-uv sync
+uv sync --reinstall-package x402
 ```
 
 ## Environment

--- a/examples/python/servers/bazaar/README.md
+++ b/examples/python/servers/bazaar/README.md
@@ -67,7 +67,7 @@ cp .env-local .env
 3. Install dependencies:
 
 ```bash
-uv sync
+uv sync --reinstall-package x402
 ```
 
 4. Run the server:

--- a/examples/python/servers/builder-code/README.md
+++ b/examples/python/servers/builder-code/README.md
@@ -33,7 +33,7 @@ routes = {
 1. Install dependencies:
 
 ```bash
-uv sync
+uv sync --reinstall-package x402
 ```
 
 2. Copy `.env-local` to `.env` and fill required environment variables:
@@ -62,7 +62,7 @@ You can test the server using the example client:
 cd ../../clients/builder-code
 cp .env-local .env
 # Fill in EVM_PRIVATE_KEY and CLIENT_BUILDER_CODE
-uv sync
+uv sync --reinstall-package x402
 uv run python main.py
 ```
 

--- a/examples/python/servers/custom/README.md
+++ b/examples/python/servers/custom/README.md
@@ -50,7 +50,7 @@ and fill required environment variables:
 2. Install dependencies:
 
 ```bash
-uv sync
+uv sync --reinstall-package x402
 ```
 
 3. Run the server:

--- a/examples/python/servers/fastapi/README.md
+++ b/examples/python/servers/fastapi/README.md
@@ -57,7 +57,7 @@ cp .env-local .env
 3. Install dependencies:
 
 ```bash
-uv sync
+uv sync --reinstall-package x402
 ```
 
 4. Run the server:

--- a/examples/python/servers/flask/README.md
+++ b/examples/python/servers/flask/README.md
@@ -59,7 +59,7 @@ cp .env-local .env
 3. Install dependencies:
 
 ```bash
-uv sync
+uv sync --reinstall-package x402
 ```
 
 4. Run the server:

--- a/examples/python/servers/mcp/README.md
+++ b/examples/python/servers/mcp/README.md
@@ -26,7 +26,7 @@ cp .env-local .env
 3. Install dependencies:
 
 ```bash
-uv sync
+uv sync --reinstall-package x402
 ```
 
 ## Running

--- a/examples/python/servers/payment-identifier/README.md
+++ b/examples/python/servers/payment-identifier/README.md
@@ -49,7 +49,7 @@ server.on_after_settle(after_settle)
 1. Install dependencies:
 
 ```bash
-uv sync
+uv sync --reinstall-package x402
 ```
 
 2. Copy `.env-local` to `.env` and add your EVM address:

--- a/examples/python/servers/sign-in-with-x/README.md
+++ b/examples/python/servers/sign-in-with-x/README.md
@@ -66,7 +66,7 @@ At least one of `EVM_ADDRESS` or `SVM_ADDRESS` is required.
 2. Install dependencies:
 
 ```bash
-uv sync
+uv sync --reinstall-package x402
 ```
 
 3. Run the server:
@@ -84,7 +84,7 @@ Start the SIWX client to test:
 ```bash
 cd ../../clients/sign-in-with-x
 # Ensure .env is setup with EVM_PRIVATE_KEY or SVM_PRIVATE_KEY
-uv sync
+uv sync --reinstall-package x402
 uv run python main.py
 ```
 

--- a/examples/python/servers/upfront/README.md
+++ b/examples/python/servers/upfront/README.md
@@ -48,7 +48,7 @@ and fill required environment variables:
 2. Install dependencies:
 
 ```bash
-uv sync
+uv sync --reinstall-package x402
 ```
 
 3. Run the server:

--- a/python/x402/changelog.d/extension-responses-sidechannel.feature.md
+++ b/python/x402/changelog.d/extension-responses-sidechannel.feature.md
@@ -1,0 +1,1 @@
+Added optional `extension_responses` on `VerifyResponse` and `SettleResponse`. The HTTP facilitator client populates it from the `EXTENSION-RESPONSES` header. `encode_payment_response_header` excludes the sidechannel from buyer-facing `PAYMENT-RESPONSE` encoding.

--- a/python/x402/http/extension_responses.py
+++ b/python/x402/http/extension_responses.py
@@ -1,0 +1,50 @@
+"""Utilities for facilitator EXTENSION-RESPONSES sidechannel on HTTP."""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+from typing import Any
+
+EXTENSION_RESPONSES_HEADER = "EXTENSION-RESPONSES"
+
+_logger = logging.getLogger("x402")
+
+
+def extract_extension_responses_header(http_response: Any) -> dict[str, Any] | None:
+    """Decode the EXTENSION-RESPONSES header into a keyed extension map.
+
+    Silently returns None when the header is absent or malformed.
+
+    Args:
+        http_response: HTTP response object with a ``headers`` mapping.
+
+    Returns:
+        Decoded extension responses keyed by extension name, or None.
+    """
+    header = http_response.headers.get(EXTENSION_RESPONSES_HEADER) or http_response.headers.get(
+        "extension-responses"
+    )
+    if not header:
+        return None
+
+    try:
+        decoded = base64.b64decode(header).decode("utf-8")
+        header_extensions = json.loads(decoded)
+        if not isinstance(header_extensions, dict):
+            return None
+        return header_extensions
+    except Exception:
+        return None
+
+
+def log_extension_responses(decoded: dict[str, Any] | None) -> None:
+    """Log decoded extension responses from the facilitator sidechannel."""
+    if not decoded:
+        return
+
+    _logger.info(
+        "[x402] extension responses: %s",
+        json.dumps(decoded),
+    )

--- a/python/x402/http/facilitator_client.py
+++ b/python/x402/http/facilitator_client.py
@@ -6,9 +6,7 @@ implementations for communicating with remote facilitator services.
 
 from __future__ import annotations
 
-import base64
 import json
-import logging
 from typing import TYPE_CHECKING, Any, TypeVar
 
 from pydantic import ValidationError
@@ -21,6 +19,7 @@ from ..schemas import (
     VerifyResponse,
 )
 from ..schemas.v1 import PaymentPayloadV1, PaymentRequirementsV1
+from .extension_responses import extract_extension_responses_header, log_extension_responses
 from .facilitator_client_base import (
     AuthHeaders,
     AuthProvider,
@@ -54,6 +53,7 @@ _ResponseModelT = TypeVar(
     SettleResponse,
     SupportedResponse,
 )
+_ResponseWithSidechannelT = TypeVar("_ResponseWithSidechannelT", VerifyResponse, SettleResponse)
 
 
 def _response_excerpt(response: Any, limit: int = 200) -> str:
@@ -89,43 +89,14 @@ def _parse_facilitator_response(
         ) from exc
 
 
-_logger = logging.getLogger("x402")
-
-_EXTENSION_RESPONSE_LOG_FIELD_ALLOWLIST = ["status", "rejectedReason", "reason", "code"]
-
-
-def _log_extension_responses_header(response: Any) -> None:
-    """Read the EXTENSION-RESPONSES header and log allowlisted fields.
-
-    Silently ignores malformed headers.
-
-    Args:
-        response: The HTTP response object (httpx.Response).
-    """
-    header = response.headers.get("EXTENSION-RESPONSES") or response.headers.get(
-        "extension-responses"
-    )
-    if not header:
-        return
-    try:
-        decoded = base64.b64decode(header).decode("utf-8")
-        header_extensions: dict[str, Any] = json.loads(decoded)
-        if not isinstance(header_extensions, dict):
-            return
-        sanitized: dict[str, dict[str, Any]] = {}
-        for extension_key, payload in header_extensions.items():
-            filtered: dict[str, Any] = {}
-            if isinstance(payload, dict):
-                for field in _EXTENSION_RESPONSE_LOG_FIELD_ALLOWLIST:
-                    if field in payload:
-                        filtered[field] = payload[field]
-            sanitized[extension_key] = filtered
-        _logger.info(
-            "[x402] extension responses: %s",
-            json.dumps(sanitized),
-        )
-    except Exception:
-        pass
+def _attach_extension_responses(
+    result: _ResponseWithSidechannelT,
+    response: Any,
+) -> _ResponseWithSidechannelT:
+    """Populate extension_responses from the HTTP sidechannel."""
+    header_obj = extract_extension_responses_header(response)
+    log_extension_responses(header_obj)
+    return result.model_copy(update={"extension_responses": header_obj})
 
 
 # ============================================================================
@@ -330,8 +301,7 @@ class HTTPFacilitatorClient(HTTPFacilitatorClientBase):
             raise ValueError(f"Facilitator verify failed ({response.status_code}): {response.text}")
 
         result = _parse_facilitator_response(response, VerifyResponse, "verify")
-        _log_extension_responses_header(response)
-        return result
+        return _attach_extension_responses(result, response)
 
     async def _settle_http(
         self,
@@ -353,8 +323,7 @@ class HTTPFacilitatorClient(HTTPFacilitatorClientBase):
             raise ValueError(f"Facilitator settle failed ({response.status_code}): {response.text}")
 
         result = _parse_facilitator_response(response, SettleResponse, "settle")
-        _log_extension_responses_header(response)
-        return result
+        return _attach_extension_responses(result, response)
 
 
 # ============================================================================
@@ -550,8 +519,7 @@ class HTTPFacilitatorClientSync(HTTPFacilitatorClientBase):
             raise ValueError(f"Facilitator verify failed ({response.status_code}): {response.text}")
 
         result = _parse_facilitator_response(response, VerifyResponse, "verify")
-        _log_extension_responses_header(response)
-        return result
+        return _attach_extension_responses(result, response)
 
     def _settle_http(
         self,
@@ -573,5 +541,4 @@ class HTTPFacilitatorClientSync(HTTPFacilitatorClientBase):
             raise ValueError(f"Facilitator settle failed ({response.status_code}): {response.text}")
 
         result = _parse_facilitator_response(response, SettleResponse, "settle")
-        _log_extension_responses_header(response)
-        return result
+        return _attach_extension_responses(result, response)

--- a/python/x402/http/utils.py
+++ b/python/x402/http/utils.py
@@ -67,7 +67,8 @@ def decode_payment_required_header(
 
 def encode_payment_response_header(settle_response: SettleResponse) -> str:
     """Encode a SettleResponse object as a base64 header value."""
-    return safe_base64_encode(settle_response.model_dump_json(by_alias=True, exclude_none=True))
+    payload = settle_response.model_dump(by_alias=True, exclude_none=True)
+    return safe_base64_encode(json.dumps(payload))
 
 
 def decode_payment_response_header(header_value: str) -> SettleResponse:

--- a/python/x402/schemas/hooks.py
+++ b/python/x402/schemas/hooks.py
@@ -263,6 +263,10 @@ class VerifyResultContext(VerifyContext):
         if self.result is None:
             raise ValueError("result is required for VerifyResultContext")
 
+    @property
+    def extension_responses(self) -> dict[str, Any] | None:
+        return self.result.extension_responses
+
 
 @dataclass
 class VerifyFailureContext(VerifyContext):
@@ -318,6 +322,10 @@ class SettleResultContext(SettleContext):
     def __post_init__(self) -> None:
         if self.result is None:
             raise ValueError("result is required for SettleResultContext")
+
+    @property
+    def extension_responses(self) -> dict[str, Any] | None:
+        return self.result.extension_responses
 
 
 @dataclass

--- a/python/x402/schemas/responses.py
+++ b/python/x402/schemas/responses.py
@@ -37,6 +37,11 @@ class VerifyResponse(BaseX402Model):
     invalid_message: str | None = None
     payer: str | None = None
     extensions: dict[str, Any] | None = None
+    extension_responses: dict[str, Any] | None = Field(
+        default=None,
+        exclude=True,
+        description="Facilitator extension sidechannel; not serialized to buyers.",
+    )
     extra: dict[str, Any] | None = None
 
 
@@ -75,6 +80,11 @@ class SettleResponse(BaseX402Model):
     network: Network
     amount: str | None = None
     extensions: dict[str, Any] | None = None
+    extension_responses: dict[str, Any] | None = Field(
+        default=None,
+        exclude=True,
+        description="Facilitator extension sidechannel; not serialized to buyers.",
+    )
     extra: dict[str, Any] | None = None
 
 

--- a/python/x402/tests/unit/http/test_extension_responses.py
+++ b/python/x402/tests/unit/http/test_extension_responses.py
@@ -1,0 +1,57 @@
+"""Unit tests for extension_responses HTTP sidechannel utilities."""
+
+from __future__ import annotations
+
+import base64
+import json
+from unittest.mock import MagicMock
+
+from x402.http.extension_responses import (
+    EXTENSION_RESPONSES_HEADER,
+    extract_extension_responses_header,
+)
+
+
+def _response_with_header(value: str | None) -> MagicMock:
+    response = MagicMock()
+    headers = {}
+    if value is not None:
+        headers[EXTENSION_RESPONSES_HEADER] = value
+    response.headers = headers
+    return response
+
+
+class TestExtractExtensionResponsesHeader:
+    def test_decodes_multi_key_envelope(self) -> None:
+        payload = {
+            "bazaar": {"status": "processing"},
+            "builder_code": {"status": "accepted"},
+        }
+        encoded = base64.b64encode(json.dumps(payload).encode("utf-8")).decode("utf-8")
+        response = _response_with_header(encoded)
+
+        assert extract_extension_responses_header(response) == payload
+
+    def test_returns_none_when_header_missing(self) -> None:
+        response = _response_with_header(None)
+
+        assert extract_extension_responses_header(response) is None
+
+    def test_returns_none_for_malformed_header(self) -> None:
+        response = _response_with_header("not-valid-base64!!!")
+
+        assert extract_extension_responses_header(response) is None
+
+    def test_returns_none_for_non_object_json(self) -> None:
+        encoded = base64.b64encode(b'"string-value"').decode("utf-8")
+        response = _response_with_header(encoded)
+
+        assert extract_extension_responses_header(response) is None
+
+    def test_accepts_lowercase_header_name(self) -> None:
+        payload = {"bazaar": {"status": "success"}}
+        encoded = base64.b64encode(json.dumps(payload).encode("utf-8")).decode("utf-8")
+        response = MagicMock()
+        response.headers = {"extension-responses": encoded}
+
+        assert extract_extension_responses_header(response) == payload

--- a/python/x402/tests/unit/http/test_facilitator_client.py
+++ b/python/x402/tests/unit/http/test_facilitator_client.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import base64
 import json
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from x402.http.extension_responses import EXTENSION_RESPONSES_HEADER
 from x402.http.facilitator_client import (
     HTTPFacilitatorClient,
     HTTPFacilitatorClientSync,
@@ -37,6 +39,105 @@ def make_v2_payload(signature: str = "0xmock") -> PaymentPayload:
         payload={"signature": signature},
         accepted=make_payment_requirements(),
     )
+
+
+def _encode_extension_responses(payload: dict) -> str:
+    return base64.b64encode(json.dumps(payload).encode("utf-8")).decode("utf-8")
+
+
+def _make_settle_response() -> dict:
+    return {
+        "success": True,
+        "transaction": "0xabc",
+        "network": "eip155:8453",
+        "payer": "0x1234567890123456789012345678901234567890",
+    }
+
+
+@pytest.mark.asyncio
+async def test_async_verify_sets_extension_responses_from_header():
+    """Verify should populate extension_responses without touching extensions."""
+    header_payload = {"bazaar": {"status": "processing"}}
+    response = MagicMock(status_code=200, text="ok")
+    response.json.return_value = {"isValid": True, "payer": "0xpayer"}
+    response.headers = {EXTENSION_RESPONSES_HEADER: _encode_extension_responses(header_payload)}
+
+    http_client = MagicMock()
+    http_client.post = AsyncMock(return_value=response)
+
+    client = HTTPFacilitatorClient(
+        FacilitatorConfig(url="https://facilitator.test", http_client=http_client)
+    )
+
+    result = await client.verify(make_v2_payload(), make_payment_requirements())
+
+    assert result.extension_responses == header_payload
+    assert result.extensions is None
+
+
+@pytest.mark.asyncio
+async def test_async_settle_keeps_body_extensions_independent_from_sidechannel():
+    """Body extensions and header extension_responses must remain separate."""
+    body_extensions = {"terms": {"info": {"format": "uri"}}}
+    header_payload = {"bazaar": {"status": "success"}}
+    response = MagicMock(status_code=200, text="ok")
+    response.json.return_value = {
+        **_make_settle_response(),
+        "extensions": body_extensions,
+    }
+    response.headers = {EXTENSION_RESPONSES_HEADER: _encode_extension_responses(header_payload)}
+
+    http_client = MagicMock()
+    http_client.post = AsyncMock(return_value=response)
+
+    client = HTTPFacilitatorClient(
+        FacilitatorConfig(url="https://facilitator.test", http_client=http_client)
+    )
+
+    result = await client.settle(make_v2_payload(), make_payment_requirements())
+
+    assert result.extensions == body_extensions
+    assert result.extension_responses == header_payload
+
+
+@pytest.mark.asyncio
+async def test_async_verify_ignores_malformed_extension_responses_header():
+    response = MagicMock(status_code=200, text="ok")
+    response.json.return_value = {"isValid": True, "payer": "0xpayer"}
+    response.headers = {EXTENSION_RESPONSES_HEADER: "not-valid"}
+
+    http_client = MagicMock()
+    http_client.post = AsyncMock(return_value=response)
+
+    client = HTTPFacilitatorClient(
+        FacilitatorConfig(url="https://facilitator.test", http_client=http_client)
+    )
+
+    result = await client.verify(make_v2_payload(), make_payment_requirements())
+
+    assert result.extension_responses is None
+
+
+def test_sync_settle_sets_extension_responses_from_header():
+    header_payload = {
+        "bazaar": {"status": "processing"},
+        "builder_code": {"status": "accepted"},
+    }
+    response = MagicMock(status_code=200, text="ok")
+    response.json.return_value = _make_settle_response()
+    response.headers = {EXTENSION_RESPONSES_HEADER: _encode_extension_responses(header_payload)}
+
+    http_client = MagicMock()
+    http_client.post.return_value = response
+
+    client = HTTPFacilitatorClientSync(
+        FacilitatorConfig(url="https://facilitator.test", http_client=http_client)
+    )
+
+    result = client.settle(make_v2_payload(), make_payment_requirements())
+
+    assert result.extension_responses == header_payload
+    assert result.extensions is None
 
 
 @pytest.mark.asyncio

--- a/python/x402/tests/unit/http/test_utils.py
+++ b/python/x402/tests/unit/http/test_utils.py
@@ -275,6 +275,23 @@ class TestPaymentResponseHeader:
         assert decoded.success is False
         assert decoded.error_reason == "Insufficient funds"
 
+    def test_encode_excludes_extension_responses_sidechannel(self):
+        """PAYMENT-RESPONSE must not include facilitator extension_responses."""
+        settle = SettleResponse(
+            success=True,
+            transaction="0xabc123",
+            network="eip155:8453",
+            payer="0x1234567890123456789012345678901234567890",
+            extension_responses={"bazaar": {"status": "processing"}},
+        )
+        encoded = encode_payment_response_header(settle)
+        decoded_json = safe_base64_decode(encoded)
+        data = json.loads(decoded_json)
+
+        assert "extensionResponses" not in data
+        assert "extension_responses" not in data
+        assert "bazaar" not in data
+
 
 class TestDetectPaymentRequiredVersion:
     """Tests for version detection."""

--- a/specs/extensions/bazaar.md
+++ b/specs/extensions/bazaar.md
@@ -470,13 +470,23 @@ Search responses may include:
 | `pagination.limit` | `number` | Yes (when `pagination` is an object) | Number of results in this page |
 | `pagination.cursor` | `string` or `null` | Yes (when `pagination` is an object) | Cursor for the next page, or `null` if unavailable |
 
-### Verify and Settlement Response Header
+### Verify and Settlement Response Sidechannel
 
-After processing a `PaymentPayload`, a facilitator **MAY** append an `EXTENSION-RESPONSES` HTTP header to the verify or settlement response to communicate extension-specific outcomes to the client.
+Extension data flows through three distinct channels:
 
-**Header name:** `EXTENSION-RESPONSES`
+| Channel | Wire | Audience | Purpose |
+| ------- | ---- | -------- | ------- |
+| `PaymentRequired.extensions` | 402 response body | Buyer and server | Extension declarations the buyer echoes |
+| `SettleResponse.extensions` | `PAYMENT-RESPONSE` | Buyer and server | Settlement metadata both may consume; server enriches via hooks |
+| `EXTENSION-RESPONSES` object | Facilitator transport sidechannel (HTTP header today) | Server internal only | Facilitator extension processing outcomes; **never forwarded to the buyer** |
 
-**Header value:** A base64-encoded JSON object keyed by extension name. The `bazaar` key contains the bazaar extension's response:
+On HTTP, facilitators communicate the sidechannel using the `EXTENSION-RESPONSES` header. The transport definition and general keyed-object format are specified in [x402-specification-v2 §7.2.1](../x402-specification-v2.md#721-extension-responses-sidechannel). This section defines the `bazaar` payload under the `bazaar` key.
+
+After processing a `PaymentPayload`, a facilitator **MAY** append extension outcomes to the sidechannel on verify or settlement responses.
+
+**HTTP header name:** `EXTENSION-RESPONSES`
+
+**HTTP header value:** A base64-encoded JSON object keyed by extension name. The `bazaar` key contains the bazaar extension's response:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
@@ -505,7 +515,6 @@ EXTENSION-RESPONSES: eyJiYXphYXIiOnsic3RhdHVzIjoicmVqZWN0ZWQiLCJyZWplY3RlZFJlYXN
 ```
 *(base64 of `{"bazaar":{"status":"rejected","rejectedReason":"info failed schema validation"}}`)*
 
-Clients that understand the `bazaar` extension SHOULD read the `bazaar` key of this header to confirm cataloging succeeded and surface any rejection reason for debugging.
 
 ---
 

--- a/specs/x402-specification-v2.md
+++ b/specs/x402-specification-v2.md
@@ -263,7 +263,10 @@ The `VerifyResponse` schema contains the following fields:
 | `isValid`       | `boolean` | Required | Indicates whether the payment authorization is valid    |
 | `invalidReason` | `string`  | Optional | Reason for invalidity (omitted if valid)                |
 | `payer`         | `string`  | Optional | Address of the payer's wallet                           |
+| `extensions`    | `object`  | Optional | Protocol extensions data                                |
 | `extra`         | `object`  | Optional | Scheme-specific additional data                         |
+
+Facilitators MAY expose extension outcomes separately from `extensions` as `extensionResponses` (populated from the transport sidechannel; never serialized to buyers). See section 7.2.1.
 
 **6. Payment Schemes (The Logic)**
 
@@ -419,6 +422,19 @@ Durably commits payment state for the request — establishing finality from the
   "network": "eip155:84532"
 }
 ```
+
+**7.2.1 Extension Responses Sidechannel**
+
+Facilitators MAY communicate extension-specific processing outcomes on verify and settle responses through a transport-specific sidechannel that is **not** part of the JSON response body and **not** forwarded to buyers.
+
+On HTTP, the sidechannel is the `EXTENSION-RESPONSES` header:
+
+| Property | Value |
+| -------- | ----- |
+| Header name | `EXTENSION-RESPONSES` |
+| Header value | Base64-encoded JSON object keyed by extension name |
+
+Each key holds the extension's outcome object. Extension specs define the payload shape under their key (for example, `bazaar` in `specs/extensions/bazaar.md`).
 
 **7.3 GET /supported**
 


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

Fixes [#3270](https://github.com/x402-foundation/x402/issues/3270): the HTTP facilitator client decoded EXTENSION-RESPONSES for logging only, so resource servers had no programmatic access to extension outcomes after verify/settle.

TS [#3278](https://github.com/x402-foundation/x402/pull/3278) and Go [#3301](https://github.com/x402-foundation/x402/pull/3301) attach header data to SettleResponse.extensions. That merges a server-only facilitator sidechannel into a field the resource server forwards to clients via PAYMENT-RESPONSE. 
This is the wrong shape: EXTENSION-RESPONSES header should be server internal metadata only. If extension info is meant to propagate to clients, the facilitator should put it in SettleResponse.extensions directly rather than the EXTENSION-RESPONSES header.

This PR adds optional extension_responses on VerifyResponse / SettleResponse. The HTTP client populates it from the decoded EXTENSION-RESPONSES header after body parse, independent of extensions. Field(exclude=True) keeps it out of PAYMENT-RESPONSE encoding. Spec §7.2.1 and bazaar.md document the three-channel model. Hooks read result.extension_responses directly.

Follow-up: If approved, TS https://github.com/x402-foundation/x402/pull/3278 and Go https://github.com/x402-foundation/x402/pull/3301 should align accordingly

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [ ] I have formatted and linted my code
- [ ] All new and existing tests pass
- [ ] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [ ] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 