### PR TITLE
fix(bazaar,next): withX402 discovery indexing

### DIFF
--- a/e2e/servers/typescript/http/next/lib/setup.ts
+++ b/e2e/servers/typescript/http/next/lib/setup.ts
@@ -6,7 +6,7 @@ import {
   type RouteConfig,
 } from "@x402/core/server";
 
-import { PROTECTED_ROUTE_MESSAGE } from "../../../../../src/mechanisms";
+import { PROTECTED_ROUTE_MESSAGE, nextWithX402HttpPath } from "../../../../../src/mechanisms";
 import {
   buildUnconfiguredFamilyError,
   loadServerEnv,
@@ -76,7 +76,11 @@ export function createWithX402GetHandler(catalogPath: string, server: x402Resour
     }
 
     if (!wrapped) {
-      wrapped = withX402(buildWithX402Handler(catalogPath, cfg), routeConfig, server);
+      wrapped = withX402(
+        buildWithX402Handler(catalogPath, cfg),
+        { [nextWithX402HttpPath(catalogPath)]: routeConfig },
+        server,
+      );
     }
     return wrapped(req);
   };

--- a/examples/typescript/fullstack/miniapp/README.md
+++ b/examples/typescript/fullstack/miniapp/README.md
@@ -67,7 +67,7 @@ NEXT_PUBLIC_ICON_URL=https://example.com/app-logo.png
 
 ### Server-Side Payment Protection
 
-The `/api/protected` endpoint uses the `withX402` wrapper for payment protection:
+The `/api/protected` endpoint uses the `withX402` wrapper for payment protection. This is a **static** route, so a bare route config (no path key) is sufficient:
 
 ```typescript
 // app/api/protected/route.ts
@@ -98,6 +98,8 @@ export const GET = withX402(
   server,
 );
 ```
+
+For **dynamic** routes (`/api/users/[id]`, etc.) or bazaar discovery with an explicit catalog path, key the config by pattern: `{ "/api/users/[id]": { accepts: … } }`. See [`@x402/next` README](../../../../typescript/packages/http/next/README.md#protecting-api-routes).
 
 ### Client-Side Payment Handling
 
@@ -211,7 +213,7 @@ The `PAYMENT-REQUIRED` header contains payment requirements:
 
 ### Adding More Protected Routes
 
-Create a new route file (e.g., `app/api/premium/route.ts`) and use the `withX402` wrapper:
+Create a new route file (e.g., `app/api/premium/route.ts`) and use the `withX402` wrapper. Static paths can use a bare config; dynamic paths need a path key — see [`@x402/next` README](../../../../typescript/packages/http/next/README.md#protecting-api-routes).
 
 ```typescript
 // app/api/premium/route.ts

--- a/examples/typescript/fullstack/next-batch-settlement-redis/README.md
+++ b/examples/typescript/fullstack/next-batch-settlement-redis/README.md
@@ -4,7 +4,7 @@ Next.js demo that exposes **`GET /api/weather`** behind `withX402` with the **ba
 
 Parallels:
 
-- Response shape / `withX402` usage: `examples/typescript/fullstack/next/app/api/weather/route.ts`
+- Response shape / `withX402` usage: `examples/typescript/fullstack/next/app/api/weather/route.ts` (path-keyed config + bazaar discovery; static routes can use a bare config instead)
 - Batch-settlement Express example wiring: `examples/typescript/servers/batch-settlement/index.ts`
 - Batch-settlement client: `examples/typescript/clients/batch-settlement`
 

--- a/examples/typescript/fullstack/next/README.md
+++ b/examples/typescript/fullstack/next/README.md
@@ -104,12 +104,13 @@ export const config = {
 
 ### Weather API Route (using withX402)
 
-The `/api/weather` route demonstrates the `withX402` wrapper for individual API routes:
+The `/api/weather` route demonstrates the `withX402` wrapper for individual API routes. It uses bazaar discovery, so the route config is keyed by path (`/api/weather`). For a static route without discovery, a bare config (no path key) is enough — see [`@x402/next` README](../../../../typescript/packages/http/next/README.md#protecting-api-routes).
 
 ```typescript
 // app/api/weather/route.ts
 import { NextRequest, NextResponse } from "next/server";
 import { withX402 } from "@x402/next";
+import { declareDiscoveryExtension } from "@x402/extensions/bazaar";
 import { server, paywall, evmAddress, svmAddress } from "../../../proxy";
 
 const handler = async (_: NextRequest) => {
@@ -124,22 +125,33 @@ const handler = async (_: NextRequest) => {
 export const GET = withX402(
   handler,
   {
-    accepts: [
-      {
-        scheme: "exact",
-        price: "$0.001",
-        network: "eip155:84532",
-        payTo: evmAddress,
+    "/api/weather": {
+      accepts: [
+        {
+          scheme: "exact",
+          price: "$0.001",
+          network: "eip155:84532",
+          payTo: evmAddress,
+        },
+        {
+          scheme: "exact",
+          price: "$0.001",
+          network: "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",
+          payTo: svmAddress,
+        },
+      ],
+      description: "Access to weather API",
+      mimeType: "application/json",
+      extensions: {
+        ...declareDiscoveryExtension({
+          output: {
+            example: {
+              report: { weather: "sunny", temperature: 72 },
+            },
+          },
+        }),
       },
-      {
-        scheme: "exact",
-        price: "$0.001",
-        network: "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",
-        payTo: svmAddress,
-      },
-    ],
-    description: "Access to weather API",
-    mimeType: "application/json",
+    },
   },
   server,
   undefined, // paywallConfig (using custom paywall from proxy.ts)
@@ -233,6 +245,8 @@ The `withX402` function wraps API route handlers. This is the recommended approa
 |----------|----------|
 | `paymentProxy` | Protecting page routes or multiple routes with a single configuration |
 | `withX402` | Protecting individual API routes where you need precise control over settlement timing |
+
+For `withX402`, pass a **bare route config** on static routes; key by path pattern (e.g. `{ "/api/users/[id]": config }`) when the URL has dynamic segments or you use bazaar discovery and want an explicit catalog path. Details: [`@x402/next` README](../../../../typescript/packages/http/next/README.md#protecting-api-routes).
 
 ## Extending the Example
 

--- a/examples/typescript/fullstack/next/app/api/weather/route.ts
+++ b/examples/typescript/fullstack/next/app/api/weather/route.ts
@@ -34,33 +34,35 @@ const handler = async (_: NextRequest) => {
 export const GET = withX402(
   handler,
   {
-    accepts: [
-      {
-        scheme: "exact",
-        price: "$0.001",
-        network: "eip155:84532", // base-sepolia
-        payTo: evmAddress,
-      },
-      {
-        scheme: "exact",
-        price: "$0.001",
-        network: "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1", // solana devnet
-        payTo: svmAddress,
-      },
-    ],
-    description: "Access to weather API",
-    mimeType: "application/json",
-    extensions: {
-      ...declareDiscoveryExtension({
-        output: {
-          example: {
-            report: {
-              weather: "sunny",
-              temperature: 72,
+    "/api/weather": {
+      accepts: [
+        {
+          scheme: "exact",
+          price: "$0.001",
+          network: "eip155:84532", // base-sepolia
+          payTo: evmAddress,
+        },
+        {
+          scheme: "exact",
+          price: "$0.001",
+          network: "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1", // solana devnet
+          payTo: svmAddress,
+        },
+      ],
+      description: "Access to weather API",
+      mimeType: "application/json",
+      extensions: {
+        ...declareDiscoveryExtension({
+          output: {
+            example: {
+              report: {
+                weather: "sunny",
+                temperature: 72,
+              },
             },
           },
-        },
-      }),
+        }),
+      },
     },
   },
   server,

--- a/typescript/.changeset/bazaar-bare-wildcard-route-template.md
+++ b/typescript/.changeset/bazaar-bare-wildcard-route-template.md
@@ -1,0 +1,5 @@
+---
+"@x402/extensions": patch
+---
+
+Bazaar discovery no longer emits a `routeTemplate` for bare wildcard (`*`) route patterns. Previously the auto-generated `:var1` template failed CDP's required `matches_resource` check, so Next.js resources using the default `withX402()` wildcard registration were never indexed.

--- a/typescript/.changeset/next-withx402-route-pattern.md
+++ b/typescript/.changeset/next-withx402-route-pattern.md
@@ -1,0 +1,5 @@
+---
+"@x402/next": minor
+---
+
+`withX402` now accepts a `RoutesConfig`, so the route's path pattern can be given explicitly (e.g. `{ "/api/users/[id]": config }`) instead of always registering a wildcard route. Passing a bare route config remains supported and unchanged. When a pattern-keyed config matches no request path, the handler runs without payment and a warning is logged once per wrapper.

--- a/typescript/packages/extensions/src/bazaar/server.ts
+++ b/typescript/packages/extensions/src/bazaar/server.ts
@@ -47,6 +47,19 @@ function normalizeWildcardPattern(pattern: string): string {
 }
 
 /**
+ * Returns true when a route pattern contains only wildcard segments (e.g. `"*"`),
+ * with no literal path segments. Bare wildcards must not produce a routeTemplate
+ * for discovery catalog indexing.
+ *
+ * @param pattern - Route pattern from route matching (path only, no HTTP method)
+ * @returns True if every segment is a wildcard
+ */
+function isWildcardOnlyPattern(pattern: string): boolean {
+  const segments = pattern.split("/").filter(segment => segment.length > 0);
+  return segments.length > 0 && segments.every(segment => segment === "*");
+}
+
+/**
  * Converts a parameterized route pattern into a :param template and extracts concrete
  * param values from the URL path in a single call.
  *
@@ -200,6 +213,9 @@ export const bazaarResourceServerExtension: ResourceServerExtension = {
     // pathParams carries runtime values (distinct from pathParamsSchema in the declaration).
     // Wildcard * segments are auto-converted to :var1, :var2, etc. for catalog normalization.
     const rawRoutePattern = (transportContext as HTTPRequestContext).routePattern;
+    if (rawRoutePattern && isWildcardOnlyPattern(rawRoutePattern)) {
+      return enrichedResult;
+    }
     const routePattern = rawRoutePattern ? normalizeWildcardPattern(rawRoutePattern) : undefined;
     const dynamicRoute = routePattern
       ? extractDynamicRouteInfo(routePattern, transportContext.adapter.getPath())

--- a/typescript/packages/extensions/test/bazaar.test.ts
+++ b/typescript/packages/extensions/test/bazaar.test.ts
@@ -1972,6 +1972,28 @@ describe("Bazaar Discovery Extension", () => {
       expect(input.pathParams).toEqual({ var1: "san-francisco" });
     });
 
+    it("should not emit routeTemplate for a bare wildcard * pattern", () => {
+      const declared = declareDiscoveryExtension({
+        input: {},
+        inputSchema: { properties: {} },
+      });
+      const extension = declared.bazaar;
+
+      const httpContext: HTTPRequestContext = {
+        method: "GET",
+        path: "/api/rotation",
+        routePattern: "*",
+        adapter: createMockAdapterWithPath("/api/rotation"),
+      };
+
+      const enriched = bazaarResourceServerExtension.enrichDeclaration!(
+        extension,
+        httpContext,
+      ) as Record<string, unknown>;
+
+      expect(enriched.routeTemplate).toBeUndefined();
+    });
+
     it("should auto-convert multiple wildcards to :var1, :var2, etc.", () => {
       const declared = declareDiscoveryExtension({
         input: {},

--- a/typescript/packages/http/next/README.md
+++ b/typescript/packages/http/next/README.md
@@ -48,6 +48,8 @@ export const config = {
 
 API routes are protected using the `withX402` route wrapper. This is the recommended approach to protect API routes as it guarantees payment settlement only AFTER successful API responses (status < 400). API routes can also be protected by `paymentProxy`, however this will charge clients for failed API responses:
 
+**Static routes** — pass a bare route config (second argument). Payment matches any request to the handler; no path key required:
+
 ```typescript
 // app/api/your-endpoint/route.ts
 import { NextRequest, NextResponse } from "next/server";
@@ -71,6 +73,30 @@ export const GET = withX402(
   server, // your configured x402ResourceServer
 );
 ```
+
+**Dynamic routes** (`/api/users/[id]`, catch-all `[...slug]`, etc.) — key the config by the route's path pattern so bazaar discovery gets the correct `routeTemplate` and path params:
+
+```typescript
+export const GET = withX402(
+  handler,
+  {
+    "/api/users/[id]": {
+      accepts: {
+        scheme: "exact",
+        price: "$0.01",
+        network: "eip155:84532",
+        payTo: "0xYourAddress",
+      },
+      description: "Access to user API",
+    },
+  },
+  server,
+);
+```
+
+For static routes that use bazaar discovery (`declareDiscoveryExtension`), you may also key by path (e.g. `{ "/api/your-endpoint": config }`) — optional, but makes the catalog URL explicit.
+
+The pattern must match the request path exactly as served (including any `basePath`, no trailing slash). If a keyed pattern does not match — a typo, a missing dynamic segment — the handler runs **without** payment protection; `withX402` logs a warning once when this happens.
 
 ## Configuration
 
@@ -103,7 +129,7 @@ The `withX402` function wraps API route handlers. This is the recommended approa
 ```typescript
 withX402(
   routeHandler: (request: NextRequest) => Promise<NextResponse>,
-  routeConfig: RouteConfig,
+  routes: RoutesConfig,
   server: x402ResourceServer,
   paywallConfig?: PaywallConfig,
   paywall?: PaywallProvider,
@@ -114,7 +140,7 @@ withX402(
 #### Parameters
 
 1. **`routeHandler`** (required): Your API route handler function
-2. **`routeConfig`** (required): Payment configuration for this specific route
+2. **`routes`** (required): Payment configuration — a **bare `RouteConfig`** for static routes (matches any path to the handler), or a **map keyed by path pattern** for dynamic routes (e.g. `{ "/api/users/[id]": config }`). See [Protecting API Routes](#protecting-api-routes) above.
 3. **`server`** (required): Pre-configured x402ResourceServer instance
 4. **`paywallConfig`** (optional): Configuration for the built-in paywall UI
 5. **`paywall`** (optional): Custom paywall provider

--- a/typescript/packages/http/next/src/index.test.ts
+++ b/typescript/packages/http/next/src/index.test.ts
@@ -677,6 +677,67 @@ describe("withX402", () => {
     expect(body).toEqual({});
     expect(response.headers.get("PAYMENT-RESPONSE")).toBe("settlement-failed-encoded");
   });
+
+  it("passes a pattern-keyed routes config to x402HTTPResourceServer unchanged", async () => {
+    const mockServer = createMockHttpServer({ type: "no-payment-required" });
+    setupMockCreateHttpServer(mockServer);
+    const handler = vi.fn().mockResolvedValue(NextResponse.json({ data: "protected" }));
+    const routes = { "/api/users/[id]": mockRouteConfig };
+
+    const wrappedHandler = withX402(handler, routes, {} as unknown as x402ResourceServer);
+    const response = await wrappedHandler(createMockRequest());
+
+    expect(vi.mocked(x402HTTPResourceServer)).toHaveBeenCalledWith(expect.anything(), routes);
+    expect(response.status).toBe(200);
+  });
+
+  it("passes a bare route config through for core's default wildcard handling", () => {
+    const mockServer = createMockHttpServer({ type: "no-payment-required" });
+    setupMockCreateHttpServer(mockServer);
+    const handler = vi.fn().mockResolvedValue(NextResponse.json({ data: "protected" }));
+
+    withX402(handler, mockRouteConfig, {} as unknown as x402ResourceServer);
+
+    expect(vi.mocked(x402HTTPResourceServer)).toHaveBeenCalledWith(
+      expect.anything(),
+      mockRouteConfig,
+    );
+  });
+
+  it("warns once when a pattern-keyed routes config matches no request", async () => {
+    const mockServer = createMockHttpServer({ type: "no-payment-required" });
+    vi.mocked(mockServer.requiresPayment).mockReturnValue(false);
+    setupMockCreateHttpServer(mockServer);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const handler = vi.fn().mockResolvedValue(NextResponse.json({ data: "protected" }));
+
+    const wrappedHandler = withX402(
+      handler,
+      { "/api/users/[id]": mockRouteConfig },
+      {} as unknown as x402ResourceServer,
+    );
+    await wrappedHandler(createMockRequest());
+    await wrappedHandler(createMockRequest());
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain('"/api/users/[id]"');
+    expect(handler).toHaveBeenCalledTimes(2);
+    warnSpy.mockRestore();
+  });
+
+  it("does not warn for a bare route config when no route matches", async () => {
+    const mockServer = createMockHttpServer({ type: "no-payment-required" });
+    vi.mocked(mockServer.requiresPayment).mockReturnValue(false);
+    setupMockCreateHttpServer(mockServer);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const handler = vi.fn().mockResolvedValue(NextResponse.json({ data: "protected" }));
+
+    const wrappedHandler = withX402(handler, mockRouteConfig, {} as unknown as x402ResourceServer);
+    await wrappedHandler(createMockRequest());
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
 });
 
 describe("paymentProxyFromConfig", () => {

--- a/typescript/packages/http/next/src/index.ts
+++ b/typescript/packages/http/next/src/index.ts
@@ -4,7 +4,6 @@ import {
   x402ResourceServer,
   x402HTTPResourceServer,
   RoutesConfig,
-  RouteConfig,
   FacilitatorClient,
   FacilitatorResponseError,
   checkIfBazaarNeeded,
@@ -268,7 +267,7 @@ export function paymentProxyFromConfig(
  * const resourceServer = new x402ResourceServer(facilitatorClient)
  *   .register(NETWORK, new ExactEvmScheme());
  *
- * const httpServer = new x402HTTPResourceServer(resourceServer, { "*": routeConfig })
+ * const httpServer = new x402HTTPResourceServer(resourceServer, { "/api/protected": routeConfig })
  *   .onProtectedRequest(requestHook);
  *
  * const handler = async (request: NextRequest) => {
@@ -306,6 +305,8 @@ export function withX402FromHTTPServer<T = unknown>(
       });
   }
 
+  let warnedNoMatch = false;
+
   return async (request: NextRequest): Promise<NextResponse<T>> => {
     // Only initialize when processing a protected route
     try {
@@ -340,6 +341,23 @@ export function withX402FromHTTPServer<T = unknown>(
     // Handle the different result types
     switch (result.type) {
       case "no-payment-required":
+        // This wrapper protects a single handler, so with pattern-keyed routes every
+        // request should match one; a miss means the pattern is wrong and the handler
+        // is being served without payment.
+        if (
+          !warnedNoMatch &&
+          !("accepts" in httpServer.routes) &&
+          !httpServer.requiresPayment(context)
+        ) {
+          warnedNoMatch = true;
+          const patterns = Object.keys(httpServer.routes)
+            .map(pattern => `"${pattern}"`)
+            .join(", ");
+          console.warn(
+            `[x402] Request path "${context.path}" did not match any configured route pattern (${patterns}); ` +
+              `the handler ran without payment. Check the route patterns passed to withX402.`,
+          );
+        }
         // No payment needed, proceed directly to the route handler
         return routeHandler(request);
 
@@ -396,7 +414,12 @@ export function withX402FromHTTPServer<T = unknown>(
  * response (status < 400). This provides more precise control over when payments are settled.
  *
  * @param routeHandler - The API route handler function to wrap
- * @param routeConfig - Payment configuration for this specific route
+ * @param routes - Payment configuration for this route: either a bare route config
+ * (matches any path, like the previous behavior) or a single-entry map keyed by the
+ * route's path pattern (e.g. `{ "/api/users/[id]": config }`). Prefer the keyed form
+ * when using bazaar discovery extensions so the resource is indexed with the correct path.
+ * The pattern must match the request path exactly as served (including any `basePath`);
+ * if it does not match, the handler runs without payment and a warning is logged.
  * @param server - Pre-configured x402ResourceServer instance
  * @param paywallConfig - Optional configuration for the built-in paywall UI
  * @param paywall - Optional custom paywall provider (overrides default)
@@ -418,13 +441,15 @@ export function withX402FromHTTPServer<T = unknown>(
  * export const GET = withX402(
  *   handler,
  *   {
- *     accepts: {
- *       scheme: "exact",
- *       payTo: "0x123...",
- *       price: "$0.01",
- *       network: "eip155:84532",
+ *     "/api/protected": {
+ *       accepts: {
+ *         scheme: "exact",
+ *         payTo: "0x123...",
+ *         price: "$0.01",
+ *         network: "eip155:84532",
+ *       },
+ *       description: "Access to protected API",
  *     },
- *     description: "Access to protected API",
  *   },
  *   server,
  * );
@@ -432,13 +457,12 @@ export function withX402FromHTTPServer<T = unknown>(
  */
 export function withX402<T = unknown>(
   routeHandler: (request: NextRequest) => Promise<NextResponse<T>>,
-  routeConfig: RouteConfig,
+  routes: RoutesConfig,
   server: x402ResourceServer,
   paywallConfig?: PaywallConfig,
   paywall?: PaywallProvider,
   syncFacilitatorOnStart: boolean = true,
 ): (request: NextRequest) => Promise<NextResponse<T>> {
-  const routes = { "*": routeConfig };
   // Create the x402 HTTP server instance with the resource server
   const httpServer = new x402HTTPResourceServer(server, routes);
 


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

Fixes [#3019](https://github.com/x402-foundation/x402/issues/3019). withX402() registered routes as "*", which bazaar converted to routeTemplate: ":var1". Discovery validation then rejected those resources, so many Next.js endpoints were never indexed.

@x402/extensions: Bazaar enrichDeclaration no longer emits routeTemplate for wildcard-only patterns (such as bare "*"). Existing withX402(handler, routeConfig, server) callers are indexed again with no API change. Prefixed patterns like /weather/* are unchanged.

@402/next: withX402 accepts RoutesConfig, so callers can pass an explicit path (for example { "/api/users/[id]": config }) for dynamic segments and discovery metadata. Bare RouteConfig remains supported. A one-time warning is logged when a keyed pattern does not match the request
## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [ ] I have formatted and linted my code
- [ ] All new and existing tests pass
- [ ] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [ ] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 