### PR TITLE
fix: improve facilitator evm latency

### DIFF
--- a/go/.changes/unreleased/changed-20260831-111823.yaml
+++ b/go/.changes/unreleased/changed-20260831-111823.yaml
@@ -1,0 +1,3 @@
+kind: changed
+body: Speed up EVM exact and upto facilitator verify by overlapping the asset-contract GetCode with signature checks and reusing VerifyUniversalSignature's bytecode result via ERC6492SignatureData.CodeDeployed instead of a second payer GetCode
+time: 2026-08-31T11:18:23.734559-04:00

--- a/go/mechanisms/evm/exact/facilitator/eip3009.go
+++ b/go/mechanisms/evm/exact/facilitator/eip3009.go
@@ -84,6 +84,13 @@ func (f *ExactEvmScheme) verifyEIP3009(
 		return nil, x402.NewVerifyError(ErrInvalidSignatureFormat, evmPayload.Authorization.From, err.Error())
 	}
 
+	// Run the asset-contract check concurrently with signature classification.
+	assetCheckCh := make(chan assetContractCheck, 1)
+	go func() {
+		reason, err := evm.ValidateAssetIsContract(ctx, f.signer, requirements.Asset)
+		assetCheckCh <- assetContractCheck{reason: reason, err: err}
+	}()
+
 	classification, err := ClassifyEIP3009Signature(
 		ctx,
 		f.signer,
@@ -115,10 +122,12 @@ func (f *ExactEvmScheme) verifyEIP3009(
 		}
 	}
 
-	if errReason, err := evm.ValidateAssetIsContract(ctx, f.signer, requirements.Asset); err != nil {
-		return nil, fmt.Errorf("asset contract check failed: %w", err)
-	} else if errReason != "" {
-		return nil, x402.NewVerifyError(errReason, evmPayload.Authorization.From, fmt.Sprintf("asset %s is not a deployed contract", requirements.Asset))
+	assetResult := <-assetCheckCh
+	if assetResult.err != nil {
+		return nil, fmt.Errorf("asset contract check failed: %w", assetResult.err)
+	}
+	if assetResult.reason != "" {
+		return nil, x402.NewVerifyError(assetResult.reason, evmPayload.Authorization.From, fmt.Sprintf("asset %s is not a deployed contract", requirements.Asset))
 	}
 
 	if simulate {

--- a/go/mechanisms/evm/exact/facilitator/eip3009_helpers.go
+++ b/go/mechanisms/evm/exact/facilitator/eip3009_helpers.go
@@ -172,11 +172,8 @@ func ClassifyEIP3009Signature(
 		return classification, nil
 	}
 
-	code, err := signer.GetCode(ctx, authorization.From)
-	if err != nil {
-		return nil, err
-	}
-	if len(code) > 0 {
+	// Reuse the GetCode result VerifyUniversalSignature already fetched.
+	if sigData.CodeDeployed {
 		classification.IsSmartWallet = true
 		return classification, nil
 	}

--- a/go/mechanisms/evm/exact/facilitator/permit2.go
+++ b/go/mechanisms/evm/exact/facilitator/permit2.go
@@ -21,6 +21,12 @@ type VerifyPermit2Options struct {
 	Simulate *bool
 }
 
+// assetContractCheck carries evm.ValidateAssetIsContract's result out of a goroutine.
+type assetContractCheck struct {
+	reason string
+	err    error
+}
+
 func (o *VerifyPermit2Options) shouldSimulate() bool {
 	if o == nil || o.Simulate == nil {
 		return true
@@ -57,11 +63,12 @@ func VerifyPermit2(
 
 	tokenAddress := evm.NormalizeAddress(requirements.Asset)
 
-	if errReason, err := evm.ValidateAssetIsContract(ctx, signer, requirements.Asset); err != nil {
-		return nil, fmt.Errorf("asset contract check failed: %w", err)
-	} else if errReason != "" {
-		return nil, x402.NewVerifyError(errReason, payer, fmt.Sprintf("asset %s is not a deployed contract", requirements.Asset))
-	}
+	// Run the asset-contract check concurrently with the signature check below.
+	assetCheckCh := make(chan assetContractCheck, 1)
+	go func() {
+		reason, err := evm.ValidateAssetIsContract(ctx, signer, requirements.Asset)
+		assetCheckCh <- assetContractCheck{reason: reason, err: err}
+	}()
 
 	// Verify spender is x402ExactPermit2Proxy
 	if !strings.EqualFold(permit2Payload.Permit2Authorization.Spender, evm.X402ExactPermit2ProxyAddress) {
@@ -116,12 +123,25 @@ func VerifyPermit2(
 		return nil, x402.NewVerifyError(ErrInvalidSignatureFormat, payer, err.Error())
 	}
 
-	sigValid, sigErr := verifyPermit2Signature(ctx, signer, permit2Payload.Permit2Authorization, signatureBytes, chainID)
+	sigValid, sigData, sigErr := verifyPermit2Signature(ctx, signer, permit2Payload.Permit2Authorization, signatureBytes, chainID)
+
+	assetResult := <-assetCheckCh
+	if assetResult.err != nil {
+		return nil, fmt.Errorf("asset contract check failed: %w", assetResult.err)
+	}
+	if assetResult.reason != "" {
+		return nil, x402.NewVerifyError(assetResult.reason, payer, fmt.Sprintf("asset %s is not a deployed contract", requirements.Asset))
+	}
+
 	if sigErr != nil || !sigValid {
-		// Check if payer is a deployed smart contract
-		// ERC-1271 signatures may not be verifiable by all signer implementations
-		code, codeErr := signer.GetCode(ctx, payer)
-		if codeErr != nil || len(code) == 0 {
+		// Check if payer is a deployed smart contract.
+		deployed := false
+		if sigData != nil {
+			deployed = sigData.CodeDeployed
+		} else if code, codeErr := signer.GetCode(ctx, payer); codeErr == nil {
+			deployed = len(code) > 0
+		}
+		if !deployed {
 			return nil, x402.NewVerifyError(ErrPermit2InvalidSignature, payer, "invalid signature")
 		}
 		// Deployed smart contract: fall through to simulation
@@ -450,18 +470,17 @@ func verifyPermit2Signature(
 	authorization evm.Permit2Authorization,
 	signature []byte,
 	chainID *big.Int,
-) (bool, error) {
+) (bool, *evm.ERC6492SignatureData, error) {
 	hash, err := evm.HashPermit2Authorization(authorization, chainID)
 	if err != nil {
-		return false, err
+		return false, nil, err
 	}
 
 	var hash32 [32]byte
 	copy(hash32[:], hash)
 
 	// Use universal verification (supports EOA and EIP-1271)
-	valid, _, err := evm.VerifyUniversalSignature(ctx, signer, authorization.From, hash32, signature, true)
-	return valid, err
+	return evm.VerifyUniversalSignature(ctx, signer, authorization.From, hash32, signature, true)
 }
 
 var validateEip2612PermitForPayment = evm.ValidateEip2612PermitForPayment

--- a/go/mechanisms/evm/types.go
+++ b/go/mechanisms/evm/types.go
@@ -533,4 +533,8 @@ type ERC6492SignatureData struct {
 	Factory         [20]byte // CREATE2 factory address (zero address if not ERC-6492)
 	FactoryCalldata []byte   // Calldata to deploy the wallet (empty if not ERC-6492)
 	InnerSignature  []byte   // The actual signature (EIP-1271 or EOA)
+
+	// CodeDeployed reports whether the signer had bytecode, as determined by
+	// VerifyUniversalSignature. Zero value elsewhere.
+	CodeDeployed bool
 }

--- a/go/mechanisms/evm/upto/facilitator/permit2.go
+++ b/go/mechanisms/evm/upto/facilitator/permit2.go
@@ -16,6 +16,12 @@ import (
 	"github.com/x402-foundation/x402/go/v2/types"
 )
 
+// assetContractCheck carries evm.ValidateAssetIsContract's result out of a goroutine.
+type assetContractCheck struct {
+	reason string
+	err    error
+}
+
 // VerifyUptoPermit2 verifies an upto Permit2 payment payload against the given requirements.
 // simulate controls whether to run an eth_call simulation as part of verification.
 func VerifyUptoPermit2(
@@ -44,11 +50,12 @@ func VerifyUptoPermit2(
 
 	tokenAddress := evm.NormalizeAddress(requirements.Asset)
 
-	if errReason, err := evm.ValidateAssetIsContract(ctx, signer, requirements.Asset); err != nil {
-		return nil, fmt.Errorf("asset contract check failed: %w", err)
-	} else if errReason != "" {
-		return nil, x402.NewVerifyError(errReason, payer, fmt.Sprintf("asset %s is not a deployed contract", requirements.Asset))
-	}
+	// Run the asset-contract check concurrently with the signature check below.
+	assetCheckCh := make(chan assetContractCheck, 1)
+	go func() {
+		reason, err := evm.ValidateAssetIsContract(ctx, signer, requirements.Asset)
+		assetCheckCh <- assetContractCheck{reason: reason, err: err}
+	}()
 
 	if !strings.EqualFold(permit2Payload.Permit2Authorization.Spender, evm.X402UptoPermit2ProxyAddress) {
 		return nil, x402.NewVerifyError(ErrPermit2InvalidSpender, payer, "invalid spender")
@@ -110,10 +117,24 @@ func VerifyUptoPermit2(
 		return nil, x402.NewVerifyError(ErrInvalidSignatureFormat, payer, err.Error())
 	}
 
-	sigValid, sigErr := verifyUptoPermit2Signature(ctx, signer, permit2Payload.Permit2Authorization, signatureBytes, chainID)
+	sigValid, sigData, sigErr := verifyUptoPermit2Signature(ctx, signer, permit2Payload.Permit2Authorization, signatureBytes, chainID)
+
+	assetResult := <-assetCheckCh
+	if assetResult.err != nil {
+		return nil, fmt.Errorf("asset contract check failed: %w", assetResult.err)
+	}
+	if assetResult.reason != "" {
+		return nil, x402.NewVerifyError(assetResult.reason, payer, fmt.Sprintf("asset %s is not a deployed contract", requirements.Asset))
+	}
+
 	if sigErr != nil || !sigValid {
-		code, codeErr := signer.GetCode(ctx, payer)
-		if codeErr != nil || len(code) == 0 {
+		deployed := false
+		if sigData != nil {
+			deployed = sigData.CodeDeployed
+		} else if code, codeErr := signer.GetCode(ctx, payer); codeErr == nil {
+			deployed = len(code) > 0
+		}
+		if !deployed {
 			return nil, x402.NewVerifyError(ErrPermit2InvalidSignature, payer, "invalid signature")
 		}
 	}
@@ -383,23 +404,23 @@ func SettleUptoPermit2(
 	)
 }
 
+// verifyUptoPermit2Signature verifies the upto Permit2 EIP-712 signature.
 func verifyUptoPermit2Signature(
 	ctx context.Context,
 	signer evm.FacilitatorEvmSigner,
 	authorization evm.UptoPermit2Authorization,
 	signature []byte,
 	chainID *big.Int,
-) (bool, error) {
+) (bool, *evm.ERC6492SignatureData, error) {
 	hash, err := evm.HashUptoPermit2Authorization(authorization, chainID)
 	if err != nil {
-		return false, err
+		return false, nil, err
 	}
 
 	var hash32 [32]byte
 	copy(hash32[:], hash)
 
-	valid, _, err := evm.VerifyUniversalSignature(ctx, signer, authorization.From, hash32, signature, true)
-	return valid, err
+	return evm.VerifyUniversalSignature(ctx, signer, authorization.From, hash32, signature, true)
 }
 
 var validateEip2612PermitForPayment = evm.ValidateEip2612PermitForPayment

--- a/go/mechanisms/evm/verify_universal.go
+++ b/go/mechanisms/evm/verify_universal.go
@@ -62,6 +62,7 @@ func VerifyUniversalSignature(
 	}
 
 	isDeployed := len(code) > 0
+	sigData.CodeDeployed = isDeployed
 	zeroFactory := [20]byte{}
 
 	// Step 5: Handle undeployed address


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

Micro optimization in the Go EVM facilitator code to remove duplicate `eth_getCode` calls.

Best case: Was 2 `eth_getCode` calls, previously run sequentially, that now run concurrently
Worst case: Was 3 before running sequentially, now 2 calls running concurrently

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Tests

Retested e2e, continues working

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 