### PR TITLE
fix(ts): validate builder-code app attribution on v2 (#3299)

### DIFF
--- a/specs/extensions/builder_code.md
+++ b/specs/extensions/builder_code.md
@@ -167,12 +167,11 @@ Declaring more than a party's own reservation at that layer MUST be rejected (se
 
 When a facilitator settles a payment containing the `builder-code` extension, it:
 
-1. When the resource server declared `builder-code.info.a`, verifies that `PaymentPayload.extensions["builder-code"].a` matches `PaymentRequired.extensions["builder-code"].info.a`
-2. Reads `a` (app code) and `s` (service codes) from the payment payload extensions
-3. Adds its own builder code as the `w` (wallet) field
-4. Optionally appends its own service code to `s` (deduped against the echoed entries), up to its `MAX_FACILITATOR_SERVICE_CODES` reservation
-5. Encodes the combined data as an ERC-8021 Schema 2 CBOR suffix
-6. Appends the suffix to the settlement transaction calldata
+1. Reads `a` (app code) and `s` (service codes) from the payment payload extensions
+2. Adds its own builder code as the `w` (wallet) field
+3. Optionally appends its own service code to `s` (deduped against the echoed entries), up to its `MAX_FACILITATOR_SERVICE_CODES` reservation
+4. Encodes the combined data as an ERC-8021 Schema 2 CBOR suffix
+5. Appends the suffix to the settlement transaction calldata
 
 The facilitator's builder code and service code are configured at initialization and validated against the same `^[a-z0-9_]{1,32}$` pattern.
 
@@ -289,7 +288,7 @@ The resource server MUST also reject the payment (`extension_echo_mismatch`) bef
 
 ### App Code Echo Validation
 
-When the resource server declared `builder-code` in `PaymentRequired`, the facilitator MUST verify that the `a` field echoed by the client in `PaymentPayload.extensions["builder-code"]` exactly matches the `a` field declared by the application in `PaymentRequired.extensions["builder-code"].info`. A mismatch indicates the client tampered with the attribution and the payment MUST be rejected.
+The resource server is the authority for `a`. Before forwarding a v2 payment to the facilitator, the resource server MUST reject the payment (`extension_echo_mismatch`) when `PaymentPayload.extensions["builder-code"].a` is present and does not exactly match `PaymentRequired.extensions["builder-code"].info.a` (including when the server did not declare `a`).
 
 
 ### Schema Validation

--- a/typescript/packages/core/src/server/x402ResourceServer.ts
+++ b/typescript/packages/core/src/server/x402ResourceServer.ts
@@ -21,6 +21,7 @@ import type { DeepReadonly } from "../types/readonly";
 import {
   ADDITIVE_ARRAY_INFO_FIELDS,
   ADDITIVE_ARRAY_MAX_LENGTHS,
+  SERVER_OWNED_INFO_FIELDS,
   deepEqual,
   convertToTokenAmount,
   findByNetworkAndScheme,
@@ -1461,33 +1462,39 @@ export class x402ResourceServer {
     }
 
     const serverExtensions = paymentRequired.extensions;
-    if (!serverExtensions || Object.keys(serverExtensions).length === 0) {
-      return { valid: true };
-    }
-
     const clientExtensions = paymentPayload.extensions;
     if (!clientExtensions || Object.keys(clientExtensions).length === 0) {
       return { valid: true };
     }
 
     for (const [key, echoedValue] of Object.entries(clientExtensions)) {
-      if (!Object.prototype.hasOwnProperty.call(serverExtensions, key)) {
-        continue;
-      }
-
-      const advertisedInfo = getExtensionInfo(serverExtensions[key]);
+      const advertisedInfo = getExtensionInfo(serverExtensions?.[key]);
       const echoedInfo = getExtensionInfo(echoedValue);
 
-      const dynamicFields = this.registeredExtensions.get(key)?.dynamicInfoFields;
-      const additiveFields = ADDITIVE_ARRAY_INFO_FIELDS[key];
-      const maxLengths = ADDITIVE_ARRAY_MAX_LENGTHS[key];
+      if (serverExtensions && Object.prototype.hasOwnProperty.call(serverExtensions, key)) {
+        const dynamicFields = this.registeredExtensions.get(key)?.dynamicInfoFields;
+        const additiveFields = ADDITIVE_ARRAY_INFO_FIELDS[key];
+        const maxLengths = ADDITIVE_ARRAY_MAX_LENGTHS[key];
+        if (
+          !extensionInfoMatchesAdvertised(
+            omitFields(advertisedInfo, dynamicFields),
+            omitFields(echoedInfo, dynamicFields),
+            additiveFields,
+            maxLengths,
+          )
+        ) {
+          return {
+            valid: false,
+            invalidReason: "extension_echo_mismatch",
+            extensionKey: key,
+          };
+        }
+      }
+
+      const serverOwnedFields = SERVER_OWNED_INFO_FIELDS[key];
       if (
-        !extensionInfoMatchesAdvertised(
-          omitFields(advertisedInfo, dynamicFields),
-          omitFields(echoedInfo, dynamicFields),
-          additiveFields,
-          maxLengths,
-        )
+        serverOwnedFields &&
+        !serverOwnedInfoFieldsMatch(advertisedInfo, echoedInfo, serverOwnedFields)
       ) {
         return {
           valid: false,
@@ -1944,6 +1951,50 @@ function getExtensionInfo(value: unknown): unknown {
     return (value as Record<string, unknown>).info;
   }
   return value;
+}
+
+/**
+ * Returns whether client-echoed server-owned fields match the server advertisement.
+ * When the server did not declare the extension, `advertised` is treated as empty
+ * so clients cannot invent fields such as builder-code `a`.
+ *
+ * @param advertised - Extension info advertised by the server, if any.
+ * @param echoed - Extension info echoed back by the client.
+ * @param serverOwnedFields - Field names the client must not invent.
+ * @returns True when every echoed server-owned field matches the advertisement.
+ */
+function serverOwnedInfoFieldsMatch(
+  advertised: unknown,
+  echoed: unknown,
+  serverOwnedFields: ReadonlySet<string>,
+): boolean {
+  if (echoed === null || typeof echoed !== "object" || Array.isArray(echoed)) {
+    return true;
+  }
+
+  const echoedRecord = echoed as Record<string, unknown>;
+  const advertisedRecord =
+    advertised !== null && typeof advertised === "object" && !Array.isArray(advertised)
+      ? (advertised as Record<string, unknown>)
+      : {};
+
+  for (const field of serverOwnedFields) {
+    if (!Object.prototype.hasOwnProperty.call(echoedRecord, field)) {
+      continue;
+    }
+    const echoedValue = echoedRecord[field];
+    if (echoedValue === undefined) {
+      continue;
+    }
+    if (
+      !Object.prototype.hasOwnProperty.call(advertisedRecord, field) ||
+      !deepEqual(advertisedRecord[field], echoedValue)
+    ) {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 /**

--- a/typescript/packages/core/src/utils/index.ts
+++ b/typescript/packages/core/src/utils/index.ts
@@ -297,6 +297,16 @@ export const ADDITIVE_ARRAY_INFO_FIELDS: Record<string, ReadonlySet<string>> = {
 };
 
 /**
+ * Extension info fields, keyed by extension key, that only the resource server
+ * may declare. Clients MUST NOT invent these on echo; core cannot import
+ * `@x402/extensions`, so the key/field list is duplicated here (same as
+ * {@link ADDITIVE_ARRAY_INFO_FIELDS}).
+ */
+export const SERVER_OWNED_INFO_FIELDS: Record<string, ReadonlySet<string>> = {
+  "builder-code": new Set(["a"]),
+};
+
+/**
  * Caps the combined echoed length of an additive array field (see
  * {@link ADDITIVE_ARRAY_INFO_FIELDS}) so a hand-crafted payload cannot pad the
  * field past the sum of every party's own reservation and later crowd out a

--- a/typescript/packages/core/test/unit/server/x402ResourceServer.test.ts
+++ b/typescript/packages/core/test/unit/server/x402ResourceServer.test.ts
@@ -1996,6 +1996,70 @@ describe("x402ResourceServer", () => {
       expect(server.validateExtensions(paymentRequired, payload)).toEqual({ valid: true });
     });
 
+    it("fails when client forges builder-code app code without server declaration", () => {
+      const server = new x402ResourceServer();
+      const paymentRequired = buildPaymentRequired({ extensions: undefined });
+      const payload = buildPaymentPayload({
+        extensions: {
+          "builder-code": { info: { a: "forged_app" } },
+        },
+      });
+
+      expect(server.validateExtensions(paymentRequired, payload)).toEqual({
+        valid: false,
+        invalidReason: "extension_echo_mismatch",
+        extensionKey: "builder-code",
+      });
+    });
+
+    it("fails when client forges builder-code app code while server declares other extensions", () => {
+      const server = new x402ResourceServer();
+      const paymentRequired = buildPaymentRequired({ extensions: serverExtensions });
+      const payload = buildPaymentPayload({
+        extensions: {
+          "builder-code": { info: { a: "forged_app" } },
+        },
+      });
+
+      expect(server.validateExtensions(paymentRequired, payload)).toEqual({
+        valid: false,
+        invalidReason: "extension_echo_mismatch",
+        extensionKey: "builder-code",
+      });
+    });
+
+    it("passes when client sends only builder-code service codes without server declaration", () => {
+      const server = new x402ResourceServer();
+      const paymentRequired = buildPaymentRequired({ extensions: undefined });
+      const payload = buildPaymentPayload({
+        extensions: {
+          "builder-code": { info: { s: ["bc_client"] } },
+        },
+      });
+
+      expect(server.validateExtensions(paymentRequired, payload)).toEqual({ valid: true });
+    });
+
+    it("fails when client forges builder-code app code that mismatches server declaration", () => {
+      const server = new x402ResourceServer();
+      const paymentRequired = buildPaymentRequired({
+        extensions: {
+          "builder-code": { info: { a: "bc_app" } },
+        },
+      });
+      const payload = buildPaymentPayload({
+        extensions: {
+          "builder-code": { info: { a: "forged_app" } },
+        },
+      });
+
+      expect(server.validateExtensions(paymentRequired, payload)).toEqual({
+        valid: false,
+        invalidReason: "extension_echo_mismatch",
+        extensionKey: "builder-code",
+      });
+    });
+
     it("passes when client omits extensions", () => {
       const server = new x402ResourceServer();
       const paymentRequired = buildPaymentRequired({ extensions: serverExtensions });
@@ -2090,6 +2154,19 @@ describe("x402ResourceServer", () => {
       const payload = buildPaymentPayload({
         x402Version: 1,
         extensions: { bazaar: { info: { tool: "wrong" } } },
+      });
+
+      expect(server.validateExtensions(paymentRequired, payload)).toEqual({ valid: true });
+    });
+
+    it("passes for v1 payloads with forged builder-code app code", () => {
+      const server = new x402ResourceServer();
+      const paymentRequired = buildPaymentRequired({ extensions: undefined });
+      const payload = buildPaymentPayload({
+        x402Version: 1,
+        extensions: {
+          "builder-code": { info: { a: "forged_app" } },
+        },
       });
 
       expect(server.validateExtensions(paymentRequired, payload)).toEqual({ valid: true });

--- a/typescript/packages/extensions/src/builder-code/facilitator.ts
+++ b/typescript/packages/extensions/src/builder-code/facilitator.ts
@@ -98,7 +98,8 @@ export class BuilderCodeFacilitatorExtension implements FacilitatorExtension {
   /**
    * Builds the ERC-8021 Schema 2 calldata suffix for a settlement transaction.
    *
-   * - `a` and `s` are read from the client's payment payload extensions.
+   * - On v2 payloads, `a` is read from the client's payment payload extensions.
+   * - On v1 payloads, client `a` is omitted (no resource-server echo gate); `s` is still read.
    * - `w` is the facilitator's own code when configured.
    * - The facilitator's own `s` entry (`config.serviceCode`) is appended after the
    *   echoed client/server codes, within its own {@link MAX_FACILITATOR_SERVICE_CODES}
@@ -109,9 +110,11 @@ export class BuilderCodeFacilitatorExtension implements FacilitatorExtension {
    */
   buildDataSuffix(ctx: DataSuffixContext): Hex | undefined {
     const clientExt = extractClientExtension(ctx.paymentPayload.extensions);
-
+    // v1 payloads omit `a`: the resource-server echo gate does not run on v1.
     const a =
-      typeof clientExt?.a === "string" && BUILDER_CODE_PATTERN.test(clientExt.a)
+      ctx.paymentPayload.x402Version === 2 &&
+      typeof clientExt?.a === "string" &&
+      BUILDER_CODE_PATTERN.test(clientExt.a)
         ? clientExt.a
         : undefined;
     const echoedServiceCodes = resolveServiceCodes(clientExt?.s);

--- a/typescript/packages/extensions/test/builder-code.test.ts
+++ b/typescript/packages/extensions/test/builder-code.test.ts
@@ -398,6 +398,47 @@ describe("Builder Code Extension", () => {
 
       expect(parsed).toEqual({ w: WALLET, a: APP });
     });
+
+    it("drops client app code on v1 payloads but still encodes service codes", () => {
+      const ext = new BuilderCodeFacilitatorExtension({
+        builderCode: WALLET,
+        serviceCode: "bc_fac",
+      });
+      const suffix = ext.buildDataSuffix({
+        ...suffixContext({
+          paymentPayloadExtensions: {
+            [BUILDER_CODE]: { info: { a: APP, s: SERVICE }, schema: {} },
+          },
+        }),
+        paymentPayload: {
+          ...basePayload(),
+          x402Version: 1,
+          extensions: {
+            [BUILDER_CODE]: { info: { a: APP, s: SERVICE }, schema: {} },
+          },
+        },
+      });
+      if (!suffix) {
+        throw new Error("Expected builder-code suffix");
+      }
+
+      const parsed = parseBuilderCodeSuffixFromCalldata(
+        `0xdeadbeef${suffix.slice(2)}` as `0x${string}`,
+      );
+      expect(parsed).toEqual({ w: WALLET, s: [SERVICE, "bc_fac"] });
+    });
+
+    it("encodes service codes on v2 payloads when app code is absent", () => {
+      const parsed = parsedFromFacilitator(
+        suffixContext({
+          paymentPayloadExtensions: {
+            [BUILDER_CODE]: { info: { s: SERVICE }, schema: {} },
+          },
+        }),
+      );
+
+      expect(parsed).toEqual({ w: WALLET, s: [SERVICE] });
+    });
   });
 
   describe("suffix encode and parse", () => {

--- a/typescript/packages/extensions/test/integrations/builder-code.test.ts
+++ b/typescript/packages/extensions/test/integrations/builder-code.test.ts
@@ -270,4 +270,28 @@ describe("Builder Code Integration Tests", () => {
     const parsed = parseBuilderCodeSuffixFromCalldata(`0x${"00".repeat(4)}${suffix.slice(2)}`);
     expect(parsed).toEqual({ w: WALLET, s: [SERVICE] });
   });
+
+  it("rejects forged builder-code app code when server did not declare builder-code", async () => {
+    const accepts = [buildCashPaymentRequirements("merchant@example.com", "USD", "1")];
+    const resource = {
+      url: "https://example.com/api/weather",
+      description: "Weather API",
+      mimeType: "application/json",
+    };
+    const paymentRequired = await server.createPaymentRequiredResponse(accepts, resource);
+
+    const paymentPayload = await client.createPaymentPayload(paymentRequired);
+    paymentPayload.extensions = {
+      ...paymentPayload.extensions,
+      [BUILDER_CODE]: {
+        info: { a: "forged_app", s: [SERVICE] },
+      },
+    };
+
+    expect(server.validateExtensions(paymentRequired, paymentPayload)).toEqual({
+      valid: false,
+      invalidReason: "extension_echo_mismatch",
+      extensionKey: BUILDER_CODE,
+    });
+  });
 });


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

Fixes [#3299](https://github.com/x402-foundation/x402/issues/3299): a v2 client could set onchain app attribution (a) when the resource server had not declared it, because validateExtensions skipped undeclared extensions and the facilitator encoded payload a without a server reference to compare against.

Adds SERVER_OWNED_INFO_FIELDS so the resource server rejects v2 payloads where a is present but not declared (or does not match) with extension_echo_mismatch; client-only s stays best-effort. On v1, the facilitator still encodes s and its own w/s but omits payload a since the echo gate does not run. Spec updated to make the resource server the authority for a.

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [ ] I have formatted and linted my code
- [ ] All new and existing tests pass
- [ ] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [ ] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 