### PR TITLE
fix(svm): accept Lighthouse guards at any position in static verification

### DIFF
--- a/typescript/.changeset/svm-lighthouse-bracket-shape.md
+++ b/typescript/.changeset/svm-lighthouse-bracket-shape.md
@@ -1,0 +1,5 @@
+---
+"@x402/svm": patch
+---
+
+The facilitator's static verification path now tolerates wallet-injected Lighthouse guard instructions at any position. Phantom currently brackets the TransferChecked with four guards (three inserted before it, one appended after), so the previous positional layout check rejected every Phantom-signed payment with `invalid_exact_svm_payload_transaction_instructions_length` even though the payment instructions were untouched. Guard instructions are filtered out before the positional checks and bounded to four; the compute budget, transfer, and memo verification is unchanged.

--- a/typescript/packages/mechanisms/svm/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/svm/src/exact/facilitator/scheme.ts
@@ -77,6 +77,13 @@ const DEFAULT_SMART_WALLET_ALLOWED_PROGRAMS = [
 const IX_TOKEN_TRANSFER_CHECKED = 12;
 
 /**
+ * Maximum wallet-injected Lighthouse guard instructions tolerated by Path 1.
+ * Phantom currently brackets the transfer with four guards: three inserted
+ * before the TransferChecked and one appended after it (see #2097).
+ */
+const MAX_LIGHTHOUSE_INSTRUCTIONS = 4;
+
+/**
  * Which verification path produced a successful result.
  * Returned by the internal _verify so settle() knows whether post-settlement
  * TOCTOU verification is required, without re-deriving it from the transaction.
@@ -665,8 +672,18 @@ export class ExactSvmScheme implements SchemeNetworkFacilitator {
    */
   private hasStaticTransferLayout(transaction: Transaction): boolean {
     const compiled = compiledMessageDecoder.decode(transaction.messageBytes);
-    const instructions = decompileTransactionMessage(compiled).instructions ?? [];
-    if (instructions.length < 3 || instructions.length > 7) {
+    const rawInstructions = decompileTransactionMessage(compiled).instructions ?? [];
+    const lighthouseCount = rawInstructions.filter(
+      ix => ix.programAddress.toString() === LIGHTHOUSE_PROGRAM_ADDRESS,
+    ).length;
+    const instructions = rawInstructions.filter(
+      ix => ix.programAddress.toString() !== LIGHTHOUSE_PROGRAM_ADDRESS,
+    );
+    if (
+      instructions.length < 3 ||
+      instructions.length > 4 ||
+      lighthouseCount > MAX_LIGHTHOUSE_INSTRUCTIONS
+    ) {
       return false;
     }
     const transferIx = instructions[2];
@@ -970,17 +987,32 @@ export class ExactSvmScheme implements SchemeNetworkFacilitator {
     requirements: PaymentRequirements,
     signerAddresses: string[],
   ): Promise<VerifyResponse> {
-    const instructions = decompiled.instructions ?? [];
+    const rawInstructions = decompiled.instructions ?? [];
 
-    // Allow 3-7 instructions:
+    // Phantom brackets the transfer with its Lighthouse guards - some inserted
+    // before the TransferChecked and some appended after it (see #2097), so
+    // guard position cannot be assumed. Validate the payment instructions
+    // positionally with the guards filtered out, and bound the guard count
+    // separately.
+    const lighthouseInstructions = rawInstructions.filter(
+      ix => ix.programAddress.toString() === LIGHTHOUSE_PROGRAM_ADDRESS,
+    );
+    const instructions = rawInstructions.filter(
+      ix => ix.programAddress.toString() !== LIGHTHOUSE_PROGRAM_ADDRESS,
+    );
+
+    // Allow 3-4 payment instructions:
     // - 3 instructions: ComputeLimit + ComputePrice + TransferChecked
-    // - 4 instructions: ComputeLimit + ComputePrice + TransferChecked + Lighthouse or Memo
-    // - 5 instructions: ComputeLimit + ComputePrice + TransferChecked + Lighthouse + Lighthouse or Memo
-    // - 6 instructions: ComputeLimit + ComputePrice + TransferChecked + Lighthouse + Lighthouse + Memo
-    // - 7 instructions: + a third wallet-injected Lighthouse (Phantom, see #2097)
+    // - 4 instructions: ComputeLimit + ComputePrice + TransferChecked + Memo
+    // plus up to MAX_LIGHTHOUSE_INSTRUCTIONS wallet-injected Lighthouse guards
+    // at any position.
     // See: https://github.com/x402-foundation/x402/issues/828
     //  and: https://github.com/x402-foundation/x402/issues/2097
-    if (instructions.length < 3 || instructions.length > 7) {
+    if (
+      instructions.length < 3 ||
+      instructions.length > 4 ||
+      lighthouseInstructions.length > MAX_LIGHTHOUSE_INSTRUCTIONS
+    ) {
       return {
         isValid: false,
         invalidReason: Errors.ErrTransactionInstructionsLength,
@@ -1110,7 +1142,8 @@ export class ExactSvmScheme implements SchemeNetworkFacilitator {
     }
 
     // Step 5: Verify optional instructions (if present)
-    // Allowed optional programs: Lighthouse (wallet protection) and Memo (uniqueness)
+    // Lighthouse guards were filtered out above, so the only allowed optional
+    // payment instruction is Memo (uniqueness)
     const optionalInstructions = instructions.slice(3);
     const invalidReasonByIndex = [
       Errors.ErrUnknownFourthInstruction,

--- a/typescript/packages/mechanisms/svm/test/unit/smartWalletFallback.test.ts
+++ b/typescript/packages/mechanisms/svm/test/unit/smartWalletFallback.test.ts
@@ -120,6 +120,7 @@ async function buildStaticTransferPayload(args: {
   authority: { address: Address; signMessages: (messages: never[]) => Promise<unknown[]> };
   amount: bigint;
   discriminator?: number;
+  leading?: IInstruction[];
   trailing?: IInstruction[];
 }) {
   const data = new Uint8Array(10);
@@ -130,6 +131,7 @@ async function buildStaticTransferPayload(args: {
   const tx = await buildTransaction(args.feePayer, [
     { programAddress: COMPUTE_BUDGET_PROGRAM, data: new Uint8Array([2, 160, 134, 1, 0]) },
     { programAddress: COMPUTE_BUDGET_PROGRAM, data: new Uint8Array([3, 16, 39, 0, 0, 0, 0, 0, 0]) },
+    ...(args.leading ?? []),
     {
       programAddress: TOKEN_PROGRAM_ADDRESS,
       accounts: [
@@ -1086,6 +1088,145 @@ describe("ExactSvmScheme smart wallet fallback path", () => {
     // Layout failure is recoverable: Path 2 runs and validates via simulation.
     expect(result.isValid).toBe(true);
     expect(mockSigner.simulateTransactionWithInnerInstructions).toHaveBeenCalled();
+  });
+
+  it("accepts a Phantom transaction that brackets the transfer with Lighthouse guards on Path 1", async () => {
+    const { ExactSvmScheme } = await import("../../src/exact/facilitator/scheme");
+
+    const feePayer = await generateKeyPairSigner();
+    const payTo = await generateKeyPairSigner();
+    const payer = await generateKeyPairSigner();
+    const source = await generateKeyPairSigner();
+
+    const expectedAta = payTo.address;
+    mockAtaMap[payTo.address] = expectedAta;
+
+    // Current Phantom shape (see #2097): three Lighthouse guards inserted
+    // before the TransferChecked and a fourth appended after it.
+    const guard = (size: number): IInstruction => ({
+      programAddress: LIGHTHOUSE_PROGRAM_ADDRESS as Address,
+      data: new Uint8Array(size).fill(1),
+    });
+    const txBase64 = await buildStaticTransferPayload({
+      feePayer: feePayer.address,
+      source: source.address,
+      mint: USDC_DEVNET_ADDRESS as Address,
+      destination: expectedAta,
+      authority: payer,
+      amount: 100000n,
+      leading: [guard(17), guard(52), guard(16)],
+      trailing: [guard(27)],
+    });
+
+    const mockSigner = {
+      getAddresses: vi.fn().mockReturnValue([feePayer.address]),
+      getSigner: vi.fn().mockReturnValue(feePayer),
+      signTransaction: vi.fn().mockResolvedValue(txBase64),
+      simulateTransaction: vi.fn().mockResolvedValue(undefined),
+      sendTransaction: vi.fn(),
+      confirmTransaction: vi.fn(),
+      getConfirmedTransactionInnerInstructions: vi.fn().mockResolvedValue(null),
+      getTokenAccountBalance: vi.fn().mockResolvedValue(null),
+      fetchAddressLookupTables: vi.fn().mockResolvedValue({}),
+      simulateTransactionWithInnerInstructions: vi
+        .fn()
+        .mockResolvedValue({ innerInstructions: [] }),
+    };
+
+    const scheme = new ExactSvmScheme(mockSigner as never, undefined, {
+      enableSmartWalletVerification: true,
+    });
+
+    const accepted = {
+      scheme: "exact",
+      network: SOLANA_DEVNET_CAIP2,
+      asset: USDC_DEVNET_ADDRESS,
+      amount: "100000",
+      payTo: payTo.address,
+      maxTimeoutSeconds: 60,
+      extra: { feePayer: feePayer.address },
+    };
+
+    const result = await scheme.verify(
+      {
+        x402Version: 2,
+        resource: { url: "http://test.com", description: "test", mimeType: "application/json" },
+        accepted,
+        payload: { transaction: txBase64 },
+      } as never,
+      accepted as never,
+    );
+
+    expect(result.isValid).toBe(true);
+    expect(result.payer).toBe(payer.address);
+    // Path 1 accepted the shape; no simulation fallback was needed.
+    expect(mockSigner.simulateTransactionWithInnerInstructions).not.toHaveBeenCalled();
+  });
+
+  it("rejects more Lighthouse guards than Path 1 tolerates", async () => {
+    const { ExactSvmScheme } = await import("../../src/exact/facilitator/scheme");
+
+    const feePayer = await generateKeyPairSigner();
+    const payTo = await generateKeyPairSigner();
+    const payer = await generateKeyPairSigner();
+    const source = await generateKeyPairSigner();
+
+    const expectedAta = payTo.address;
+    mockAtaMap[payTo.address] = expectedAta;
+
+    const guard: IInstruction = {
+      programAddress: LIGHTHOUSE_PROGRAM_ADDRESS as Address,
+      data: new Uint8Array([0]),
+    };
+    const txBase64 = await buildStaticTransferPayload({
+      feePayer: feePayer.address,
+      source: source.address,
+      mint: USDC_DEVNET_ADDRESS as Address,
+      destination: expectedAta,
+      authority: payer,
+      amount: 100000n,
+      leading: [guard, guard, guard],
+      trailing: [guard, guard],
+    });
+
+    const mockSigner = {
+      getAddresses: vi.fn().mockReturnValue([feePayer.address]),
+      getSigner: vi.fn().mockReturnValue(feePayer),
+      signTransaction: vi.fn().mockResolvedValue(txBase64),
+      simulateTransaction: vi.fn().mockResolvedValue(undefined),
+      sendTransaction: vi.fn(),
+      confirmTransaction: vi.fn(),
+      getConfirmedTransactionInnerInstructions: vi.fn().mockResolvedValue(null),
+      getTokenAccountBalance: vi.fn().mockResolvedValue(null),
+      fetchAddressLookupTables: vi.fn().mockResolvedValue({}),
+      simulateTransactionWithInnerInstructions: vi
+        .fn()
+        .mockResolvedValue({ innerInstructions: [] }),
+    };
+
+    const scheme = new ExactSvmScheme(mockSigner as never, undefined, {});
+
+    const accepted = {
+      scheme: "exact",
+      network: SOLANA_DEVNET_CAIP2,
+      asset: USDC_DEVNET_ADDRESS,
+      amount: "100000",
+      payTo: payTo.address,
+      maxTimeoutSeconds: 60,
+      extra: { feePayer: feePayer.address },
+    };
+
+    const result = await scheme.verify(
+      {
+        x402Version: 2,
+        resource: { url: "http://test.com", description: "test", mimeType: "application/json" },
+        accepted,
+        payload: { transaction: txBase64 },
+      } as never,
+      accepted as never,
+    );
+
+    expect(result.isValid).toBe(false);
   });
 
   it("accepts a 7-instruction Phantom transaction (3 Lighthouse) on Path 1 without Path 2", async () => {


### PR DESCRIPTION
## Description

Phantom's Lighthouse guards no longer only trail the transfer: on current Phantom (observed on Solana mainnet, 2026-08-31), a plain exact-SVM payment comes back as

```
[computeLimit, computePrice, LH(17), LH(52), LH(16), transferChecked, memo, LH(27)]
```

i.e. three guard instructions **inserted before** the TransferChecked and a fourth appended after it. The static path's positional 3-7 layout check therefore rejects every current Phantom-signed payment with `invalid_exact_svm_payload_transaction_instructions_length`, even though the payment instructions themselves are untouched. The smart-wallet fallback cannot recover it either: the guards reference the fee payer account (they assert on its lamports), which trips the fee-payer isolation requirement, and `TokenkegQ…` is not in the smart-wallet program allowlist.

This continues #828 / #2097: filter Lighthouse instructions out before the positional checks, validate the remaining 3-4 payment instructions exactly as before (compute budget, TransferChecked terms, memo), and bound the guard count at four. `hasStaticTransferLayout` applies the same filter so pending-settlement reconciliation re-derives the correct verification path.

Verified end to end against a live facilitator on Solana mainnet with a real Phantom-signed payment carrying this exact shape.

## Tests

- new: accepts the bracketed Phantom shape on Path 1 (no simulation fallback)
- new: rejects more than four guard instructions
- existing 7-instruction trailing-guard test unchanged
- `pnpm vitest run` in `packages/mechanisms/svm`: 468 passed (23 files)

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass