### PR TITLE
fix(python): validate builder-code app attribution on v2

### DIFF
--- a/python/x402/changelog.d/5.bugfix.md
+++ b/python/x402/changelog.d/5.bugfix.md
@@ -1,0 +1,1 @@
+Reject v2 payloads that forge builder-code app attribution (`a`) when the resource server did not declare it or the echo does not match; omit payload `a` on v1 facilitator settlement.

--- a/python/x402/extensions/builder_code/facilitator.py
+++ b/python/x402/extensions/builder_code/facilitator.py
@@ -91,10 +91,12 @@ class BuilderCodeFacilitatorExtension(FacilitatorExtension):
     ) -> str | None:
         """Build the ERC-8021 Schema 2 calldata suffix for a settlement transaction.
 
-        ``a`` and ``s`` are read from the client's payment payload extensions; ``w`` is
-        the facilitator's own code when configured. The facilitator's own ``s`` entry
-        (``service_code``) is appended after the echoed client/server codes, within
-        its own ``MAX_FACILITATOR_SERVICE_CODES`` reservation.
+        On v2 payloads, ``a`` is read from the client's payment payload extensions.
+        On v1 payloads, client ``a`` is omitted (no resource-server echo gate); ``s``
+        is still read. ``w`` is the facilitator's own code when configured. The
+        facilitator's own ``s`` entry (``service_code``) is appended after the echoed
+        client/server codes, within its own ``MAX_FACILITATOR_SERVICE_CODES``
+        reservation.
 
         Args:
             payload: The payment payload being settled.
@@ -107,7 +109,14 @@ class BuilderCodeFacilitatorExtension(FacilitatorExtension):
         """
         info = _extract_client_info(payload.extensions)
         raw_a = info.get("a") if info else None
-        a = raw_a if isinstance(raw_a, str) and BUILDER_CODE_PATTERN.match(raw_a) else None
+        # v1 payloads omit `a`: the resource-server echo gate does not run on v1.
+        a = (
+            raw_a
+            if getattr(payload, "x402_version", None) == 2
+            and isinstance(raw_a, str)
+            and BUILDER_CODE_PATTERN.match(raw_a)
+            else None
+        )
         echoed_service_codes = _resolve_service_codes(info.get("s") if info else None)
         s = (
             [*echoed_service_codes, self.service_code]

--- a/python/x402/server_base.py
+++ b/python/x402/server_base.py
@@ -115,6 +115,31 @@ def _get_extension_info(value: Any) -> Any:
     return value
 
 
+def _server_owned_info_fields_match(
+    advertised: Any,
+    echoed: Any,
+    server_owned_fields: set[str],
+) -> bool:
+    """Return whether client-echoed server-owned fields match the advertisement.
+
+    When the server did not declare the extension, ``advertised`` is treated as
+    empty so clients cannot invent fields such as builder-code ``a``.
+    """
+    if not isinstance(echoed, dict):
+        return True
+
+    advertised_record = advertised if isinstance(advertised, dict) else {}
+
+    for field in server_owned_fields:
+        if field not in echoed:
+            continue
+        echoed_value = echoed[field]
+        if field not in advertised_record or advertised_record[field] != echoed_value:
+            return False
+
+    return True
+
+
 def _omit_fields(value: Any, fields: list[str] | None) -> Any:
     """Return a copy of ``value`` without the named dynamic fields."""
     if not fields or not isinstance(value, dict):
@@ -145,6 +170,14 @@ def _to_comparable_list(value: Any) -> list[Any] | None:
 # sign-in-with-x's "resources") keep exact list matching in both directions.
 _ADDITIVE_LIST_INFO_FIELDS: dict[str, set[str]] = {
     "builder-code": {"s"},
+}
+
+# Extension info fields, keyed by extension key, that only the resource server
+# may declare. Clients MUST NOT invent these on echo; this package has no
+# dependency on extension packages, so the key/field list is duplicated here
+# (same as _ADDITIVE_LIST_INFO_FIELDS).
+_SERVER_OWNED_INFO_FIELDS: dict[str, set[str]] = {
+    "builder-code": {"a"},
 }
 
 # Caps the combined echoed length of an additive list field (see
@@ -1055,9 +1088,11 @@ class x402ResourceServerBase:
     ) -> ExtensionValidationResult:
         """Validate optional client extension echoes against server declarations.
 
-        Skips v1, and passes when either extension map is empty. For each key the
+        Skips v1, and passes when the client omits extensions. For each key the
         server declared, the echoed ``info`` must contain every advertised field
-        (clients may add their own). Fields listed by a registered extension's
+        (clients may add their own). Server-owned fields (e.g. builder-code ``a``)
+        must also match the advertisement when present, including when the server
+        did not declare the extension. Fields listed by a registered extension's
         ``dynamic_info_fields`` are regenerated per response and dropped before
         comparison; every other advertised field stays strict.
         """
@@ -1065,32 +1100,39 @@ class x402ResourceServerBase:
             return ExtensionValidationResult(valid=True)
 
         server_extensions = payment_required.extensions
-        if not server_extensions:
-            return ExtensionValidationResult(valid=True)
-
         client_extensions = getattr(payment_payload, "extensions", None)
         if not client_extensions:
             return ExtensionValidationResult(valid=True)
 
         for key, echoed_value in client_extensions.items():
-            if key not in server_extensions:
-                continue
-
             advertised_info = _get_extension_info(
-                _normalize_extension_value(server_extensions[key])
+                _normalize_extension_value(
+                    server_extensions.get(key) if server_extensions else None
+                )
             )
             echoed_info = _get_extension_info(_normalize_extension_value(echoed_value))
 
-            extension = self._extensions.get(key)
-            dynamic_fields = getattr(extension, "dynamic_info_fields", None)
-            additive_fields = _ADDITIVE_LIST_INFO_FIELDS.get(key)
-            max_lengths = _ADDITIVE_LIST_MAX_LENGTHS.get(key)
+            if server_extensions and key in server_extensions:
+                extension = self._extensions.get(key)
+                dynamic_fields = getattr(extension, "dynamic_info_fields", None)
+                additive_fields = _ADDITIVE_LIST_INFO_FIELDS.get(key)
+                max_lengths = _ADDITIVE_LIST_MAX_LENGTHS.get(key)
 
-            if not _object_contains_subset(
-                _omit_fields(advertised_info, dynamic_fields),
-                _omit_fields(echoed_info, dynamic_fields),
-                additive_fields,
-                max_lengths,
+                if not _object_contains_subset(
+                    _omit_fields(advertised_info, dynamic_fields),
+                    _omit_fields(echoed_info, dynamic_fields),
+                    additive_fields,
+                    max_lengths,
+                ):
+                    return ExtensionValidationResult(
+                        valid=False,
+                        invalid_reason=ERR_EXTENSION_ECHO_MISMATCH,
+                        extension_key=key,
+                    )
+
+            server_owned_fields = _SERVER_OWNED_INFO_FIELDS.get(key)
+            if server_owned_fields and not _server_owned_info_fields_match(
+                advertised_info, echoed_info, server_owned_fields
             ):
                 return ExtensionValidationResult(
                     valid=False,

--- a/python/x402/tests/unit/core/test_extension_echo_validation.py
+++ b/python/x402/tests/unit/core/test_extension_echo_validation.py
@@ -68,6 +68,58 @@ def test_passes_when_no_server_extensions() -> None:
     assert server.validate_extensions(required, payload).valid
 
 
+def test_fails_when_client_forges_builder_code_app_code_without_server_declaration() -> None:
+    server = x402ResourceServer()
+    required = _payment_required(None)
+    payload = _payment_payload({BUILDER_CODE: {"info": {"a": "forged_app"}}})
+
+    result = server.validate_extensions(required, payload)
+    assert result.valid is False
+    assert result.invalid_reason == ERR_EXTENSION_ECHO_MISMATCH
+    assert result.extension_key == BUILDER_CODE
+
+
+def test_fails_when_client_forges_builder_code_app_code_while_server_declares_other_extensions() -> (
+    None
+):
+    server = x402ResourceServer()
+    required = _payment_required(
+        {
+            "bazaar": {"info": {"tool": "search", "version": 1}},
+            "builder": {"info": {"code": "abc"}},
+        }
+    )
+    payload = _payment_payload({BUILDER_CODE: {"info": {"a": "forged_app"}}})
+
+    result = server.validate_extensions(required, payload)
+    assert result.valid is False
+    assert result.invalid_reason == ERR_EXTENSION_ECHO_MISMATCH
+    assert result.extension_key == BUILDER_CODE
+
+
+def test_passes_when_client_sends_only_builder_code_service_codes_without_server_declaration() -> (
+    None
+):
+    server = x402ResourceServer()
+    required = _payment_required(None)
+    payload = _payment_payload({BUILDER_CODE: {"info": {"s": ["bc_client"]}}})
+
+    assert server.validate_extensions(required, payload).valid
+
+
+def test_fails_when_client_forges_builder_code_app_code_that_mismatches_server_declaration() -> (
+    None
+):
+    server = x402ResourceServer()
+    required = _payment_required({BUILDER_CODE: {"info": {"a": "bc_app"}}})
+    payload = _payment_payload({BUILDER_CODE: {"info": {"a": "forged_app"}}})
+
+    result = server.validate_extensions(required, payload)
+    assert result.valid is False
+    assert result.invalid_reason == ERR_EXTENSION_ECHO_MISMATCH
+    assert result.extension_key == BUILDER_CODE
+
+
 def test_passes_when_builder_code_echo_is_additive() -> None:
     server = x402ResourceServer()
     required = _payment_required({BUILDER_CODE: {"info": {"a": "bc_myapp"}, "schema": 2}})
@@ -277,6 +329,19 @@ def test_skips_v1_payloads() -> None:
         scheme="exact",
         network="eip155:84532",
         payload={},
+    )
+
+    assert server.validate_extensions(required, payload).valid
+
+
+def test_passes_for_v1_payloads_with_forged_builder_code_app_code() -> None:
+    server = x402ResourceServer()
+    required = _payment_required(None)
+    payload = PaymentPayload(
+        x402_version=1,
+        payload={"authorization": {}, "signature": "0x"},
+        accepted=_requirements(),
+        extensions={BUILDER_CODE: {"info": {"a": "forged_app"}}},
     )
 
     assert server.validate_extensions(required, payload).valid

--- a/python/x402/tests/unit/extensions/builder_code/test_client.py
+++ b/python/x402/tests/unit/extensions/builder_code/test_client.py
@@ -2,27 +2,18 @@
 
 import pytest
 
-from tests.mocks import (
-    CashFacilitatorClient,
-    CashSchemeNetworkClient,
-    CashSchemeNetworkFacilitator,
-    CashSchemeNetworkServer,
-    build_cash_payment_requirements,
-)
-from x402 import x402Client, x402Facilitator, x402ResourceServer
+from x402 import x402Client, x402ResourceServer
 from x402.extensions.builder_code import (
     BUILDER_CODE,
     MAX_CLIENT_SERVICE_CODES,
     BuilderCodeClientExtension,
-    BuilderCodeFacilitatorExtension,
     declare_builder_code_extension,
 )
-from x402.schemas import PaymentPayload, PaymentRequired, PaymentRequirements, ResourceInfo
+from x402.schemas import PaymentPayload, PaymentRequired, PaymentRequirements
 from x402.server_base import ERR_EXTENSION_ECHO_MISMATCH
 
 APP = "bc_my_app"
 SERVICE = "bc_my_client"
-WALLET = "bc_my_facilitator"
 
 
 def _base_payload(extensions: dict | None = None) -> PaymentPayload:
@@ -153,26 +144,24 @@ class TestBuilderCodeClientIntegration:
     async def test_rejects_forged_builder_code_app_code_when_server_did_not_declare_builder_code(
         self,
     ) -> None:
-        client = (
-            x402Client()
-            .register("x402:cash", CashSchemeNetworkClient("payer"))
-            .register_extension(BuilderCodeClientExtension(SERVICE))
-            .set_spend_controls(False)
-        )
-        facilitator = x402Facilitator().register(["x402:cash"], CashSchemeNetworkFacilitator())
-        facilitator.register_extension(BuilderCodeFacilitatorExtension(builder_code=WALLET))
-        server = x402ResourceServer(CashFacilitatorClient(facilitator))
-        server.register("x402:cash", CashSchemeNetworkServer())
-        server.initialize()
+        client = x402Client()
+        client.register("eip155:8453", _MockSchemeClient())
+        client.register_extension(BuilderCodeClientExtension(SERVICE))
+        server = x402ResourceServer()
 
-        accepts = [build_cash_payment_requirements("merchant@example.com", "USD", "1")]
-        resource = ResourceInfo(
-            url="https://example.com/api/weather",
-            description="Weather API",
-            mime_type="application/json",
+        payment_required = PaymentRequired(
+            x402_version=2,
+            accepts=[
+                PaymentRequirements(
+                    scheme="exact",
+                    network="eip155:8453",
+                    asset="0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+                    amount="1000",
+                    pay_to="0x0000000000000000000000000000000000000001",
+                    max_timeout_seconds=300,
+                )
+            ],
         )
-        payment_required = await server.create_payment_required_response(accepts, resource)
-
         payment_payload = await client.create_payment_payload(payment_required)
         payment_payload.extensions = {
             **(payment_payload.extensions or {}),

--- a/python/x402/tests/unit/extensions/builder_code/test_client.py
+++ b/python/x402/tests/unit/extensions/builder_code/test_client.py
@@ -2,17 +2,27 @@
 
 import pytest
 
-from x402 import x402Client
+from tests.mocks import (
+    CashFacilitatorClient,
+    CashSchemeNetworkClient,
+    CashSchemeNetworkFacilitator,
+    CashSchemeNetworkServer,
+    build_cash_payment_requirements,
+)
+from x402 import x402Client, x402Facilitator, x402ResourceServer
 from x402.extensions.builder_code import (
     BUILDER_CODE,
     MAX_CLIENT_SERVICE_CODES,
     BuilderCodeClientExtension,
+    BuilderCodeFacilitatorExtension,
     declare_builder_code_extension,
 )
-from x402.schemas import PaymentPayload, PaymentRequired, PaymentRequirements
+from x402.schemas import PaymentPayload, PaymentRequired, PaymentRequirements, ResourceInfo
+from x402.server_base import ERR_EXTENSION_ECHO_MISMATCH
 
 APP = "bc_my_app"
 SERVICE = "bc_my_client"
+WALLET = "bc_my_facilitator"
 
 
 def _base_payload(extensions: dict | None = None) -> PaymentPayload:
@@ -138,3 +148,40 @@ class TestBuilderCodeClientIntegration:
             "info": {"a": APP, "s": [SERVICE, "bc_server_sdk"]},
             "schema": payment_required.extensions[BUILDER_CODE]["schema"],
         }
+
+    @pytest.mark.asyncio
+    async def test_rejects_forged_builder_code_app_code_when_server_did_not_declare_builder_code(
+        self,
+    ) -> None:
+        client = (
+            x402Client()
+            .register("x402:cash", CashSchemeNetworkClient("payer"))
+            .register_extension(BuilderCodeClientExtension(SERVICE))
+            .set_spend_controls(False)
+        )
+        facilitator = x402Facilitator().register(["x402:cash"], CashSchemeNetworkFacilitator())
+        facilitator.register_extension(BuilderCodeFacilitatorExtension(builder_code=WALLET))
+        server = x402ResourceServer(CashFacilitatorClient(facilitator))
+        server.register("x402:cash", CashSchemeNetworkServer())
+        server.initialize()
+
+        accepts = [build_cash_payment_requirements("merchant@example.com", "USD", "1")]
+        resource = ResourceInfo(
+            url="https://example.com/api/weather",
+            description="Weather API",
+            mime_type="application/json",
+        )
+        payment_required = await server.create_payment_required_response(accepts, resource)
+
+        payment_payload = await client.create_payment_payload(payment_required)
+        payment_payload.extensions = {
+            **(payment_payload.extensions or {}),
+            BUILDER_CODE: {
+                "info": {"a": "forged_app", "s": [SERVICE]},
+            },
+        }
+
+        result = server.validate_extensions(payment_required, payment_payload)
+        assert result.valid is False
+        assert result.invalid_reason == ERR_EXTENSION_ECHO_MISMATCH
+        assert result.extension_key == BUILDER_CODE

--- a/python/x402/tests/unit/extensions/builder_code/test_facilitator.py
+++ b/python/x402/tests/unit/extensions/builder_code/test_facilitator.py
@@ -125,6 +125,21 @@ class TestBuildDataSuffix:
         payload = _payload({BUILDER_CODE: {"info": {"a": "Bad-App"}, "schema": {}}})
         assert _parse(ext, payload) == BuilderCodeExtensionData(w=WALLET)
 
+    def test_drops_client_app_code_on_v1_payloads_but_still_encodes_service_codes(self) -> None:
+        ext = BuilderCodeFacilitatorExtension(builder_code=WALLET, service_code="bc_fac")
+        payload = PaymentPayload(
+            x402_version=1,
+            payload={},
+            accepted=_REQUIREMENTS,
+            extensions={BUILDER_CODE: {"info": {"a": APP, "s": SERVICE}, "schema": {}}},
+        )
+        assert _parse(ext, payload) == BuilderCodeExtensionData(w=WALLET, s=[SERVICE, "bc_fac"])
+
+    def test_encodes_service_codes_on_v2_payloads_when_app_code_is_absent(self) -> None:
+        ext = BuilderCodeFacilitatorExtension(builder_code=WALLET)
+        payload = _payload({BUILDER_CODE: {"info": {"s": SERVICE}, "schema": {}}})
+        assert _parse(ext, payload) == BuilderCodeExtensionData(w=WALLET, s=[SERVICE])
+
 
 class TestFacilitatorServiceCode:
     def test_appends_facilitator_service_code_after_echoed_codes(self) -> None:


### PR DESCRIPTION
Port of https://github.com/x402-foundation/x402/pull/3313 from TypeScript to Python SDK.

A v2 client could set onchain app attribution (`a`) when the resource server had not declared it, because `validate_extensions` skipped undeclared extensions and the facilitator encoded payload `a` without a server reference to compare against. Adds `_SERVER_OWNED_INFO_FIELDS` so the resource server rejects v2 payloads where `a` is present but not declared (or does not match) with `extension_echo_mismatch`; client-only `s` stays best-effort. On v1, the facilitator still encodes `s` and its own `w`/`s` but omits payload `a` since the echo gate does not run.

AI disclosure: Automated by @phdargen. Use your own judgement