### PR TITLE
docs: add Mist to third-party extensions

### DIFF
--- a/docs/dev-tools/third-party-extensions.md
+++ b/docs/dev-tools/third-party-extensions.md
@@ -10,3 +10,4 @@ description: "Packages built by ecosystem partners that extend x402 beyond the c
 | [PEAC Protocol](https://x402.peacprotocol.org) | Verifiable receipts for x402 payments | TypeScript | [GitHub](https://github.com/peacprotocol/peac) · [npm](https://www.npmjs.com/package/@peac/adapter-x402) |
 | [x402r](https://x402r.org) | Non-custodial refund and arbitration protocol | Typescript | [GitHub](https://github.com/BackTrackCo/x402r-sdk) · [npm](https://www.npmjs.com/package/@x402r/sdk ) |
 | [zauth](https://zauthx402.com) | Monitoring, verification, and refund SDK | TypeScript | [GitHub](https://github.com/zauthofficial/zauthSDK) · [npm](https://www.npmjs.com/package/@zauthx402/sdk) |
+| [Mist](https://github.com/changshenhan/mist) | Agent-economy settlement layer with an x402 adapter (mist-v1 scheme, EIP-3009 bridge; v1 conventions, v2 planned) | Rust | [GitHub](https://github.com/changshenhan/mist) |

--- a/docs/dev-tools/third-party-extensions.md
+++ b/docs/dev-tools/third-party-extensions.md
@@ -10,4 +10,4 @@ description: "Packages built by ecosystem partners that extend x402 beyond the c
 | [PEAC Protocol](https://x402.peacprotocol.org) | Verifiable receipts for x402 payments | TypeScript | [GitHub](https://github.com/peacprotocol/peac) · [npm](https://www.npmjs.com/package/@peac/adapter-x402) |
 | [x402r](https://x402r.org) | Non-custodial refund and arbitration protocol | Typescript | [GitHub](https://github.com/BackTrackCo/x402r-sdk) · [npm](https://www.npmjs.com/package/@x402r/sdk ) |
 | [zauth](https://zauthx402.com) | Monitoring, verification, and refund SDK | TypeScript | [GitHub](https://github.com/zauthofficial/zauthSDK) · [npm](https://www.npmjs.com/package/@zauthx402/sdk) |
-| [Mist](https://github.com/changshenhan/mist) | Agent-economy settlement layer with an x402 adapter (mist-v1 scheme, EIP-3009 bridge; v1 conventions, v2 planned) | Rust | [GitHub](https://github.com/changshenhan/mist) |
+| [Mist](https://github.com/changshenhan/mist) | Agent-economy settlement layer with an x402 adapter (mist-v1 scheme, EIP-3009 bridge; v1+v2 wire formats) | Rust | [GitHub](https://github.com/changshenhan/mist) |


### PR DESCRIPTION
Adds [Mist](https://github.com/changshenhan/mist) to the third-party extensions list.

Mist is an agent-economy settlement layer (delegated spending authorizations, fraud-proof batch settlement, ZK spend authorization) with an x402 adapter: a custom `mist-v1` scheme plus an EIP-3009 bridge so standard x402 clients can route settlements through it. The adapter supports both v1 and v2 wire formats (v1 `X-PAYMENT` headers and v2 `PAYMENT-REQUIRED` negotiation), verified end-to-end against the official `@x402/axios` + `@x402/evm` client.

Docs-only change, single line in `docs/dev-tools/third-party-extensions.md`.

> [!NOTE]
> The majority of this PR was generated with AI assistance (Claude Code) and reviewed by the account owner before submission.