### PR TITLE
docs: add SVM402 Facilitator to facilitators table

### DIFF
--- a/docs/dev-tools/facilitators.md
+++ b/docs/dev-tools/facilitators.md
@@ -31,6 +31,7 @@ If you are evaluating a mainnet EVM route, decide on your production facilitator
 | [NEAR x402 Facilitator](https://x402.mikedotexe.com/) | Independent open-source facilitator for exact Circle USDC payments on NEAR and Base, with sponsored gas and durable settlement recovery |
 | [PayAI Facilitator](https://facilitator.payai.network) | Multi-network facilitator supporting all tokens. No API keys required |
 | [Polygon Facilitator](https://docs.polygon.technology/payment-services/agentic-payments/x402/intro/) | Production-grade x402 facilitator for Polygon Mainnet and Amoy testnet |
+| [SVM402 Facilitator](https://facilitator.svm402.com) | Independent open-source Solana-native facilitator with an exactly-once SQLite settlement ledger and self-hosted Docker deployment |
 | [Solvador](https://solvador.com) | Multi-network facilitator with broad mainnet coverage across EVM plus Solana and NEAR, supporting multiple schemes and extensions |
 | [T54 XRPL Facilitator](https://xrpl-x402.t54.ai) | x402 facilitator for the XRP Ledger, covering mainnet and testnet with XRP and RLUSD support |
 


### PR DESCRIPTION
## What

Adds [SVM402 Facilitator](https://facilitator.svm402.com) to the production facilitators table.

## About

- **Independent, open-source** Solana-native x402 facilitator (Apache-2.0): https://github.com/dchu3/sol-x402-facilitator
- Built on the official `@x402/svm` `ExactSvmScheme` — the money layer (verify/settle) is the reference implementation, not hand-written
- Adds an exactly-once **SQLite settlement ledger** implementing `@x402/core`'s `PendingSettlementStore` interface with crash-safe persistence (survives restarts; broadcast-but-unconfirmed settles reconcile instead of re-broadcasting)
- Fail-closed verification, integer-only money handling, capped feePayer gas exposure, self-hosted Docker deployment
- **Live-fire verified on Solana mainnet**: real USDC settles end-to-end (e.g. [tx 4NqCyMpw…](https://solscan.io/tx/4NqCyMpwoHF89ULwBYEvjwBJseNmmsXBRP2GzTzLX9YvRgx7adPYzSt7katr5KFc4gNnL6FxX6o3EMF2GBsajBfe)) through both `/verify` and `/settle`
- In production since 2026-09-01 serving https://svm402.com's paid endpoints as a third-slot facilitator

Placement: alphabetical, between Polygon Facilitator and Solvador.

Happy to provide any additional verification the maintainers need — the `/supported`, `/verify`, `/settle`, `/health` endpoints are all publicly reachable at https://facilitator.svm402.com.