### PR TITLE
docs: add Accrue to the facilitators table

### DIFF
--- a/docs/dev-tools/facilitators.md
+++ b/docs/dev-tools/facilitators.md
@@ -19,6 +19,7 @@ If you are evaluating a mainnet EVM route, decide on your production facilitator
 
 | Name | Description |
 | ---- | ----------- | 
+| [Accrue](https://x402.accrue.fund) | Public x402 facilitator settling USDC across Solana, Base and other EVM chains |
 | [Built on Stellar](https://developers.stellar.org/docs/build/apps/x402/built-on-stellar) | Free, public x402 facilitator for Stellar |
 | [CDP Facilitator](https://docs.cdp.coinbase.com/x402/docs/quickstart-sellers) | Coinbase-hosted facilitator with KYT/OFAC checks on every transaction |
 | [Celo Facilitator](https://docs.celo.org/build-on-celo/build-with-ai/x402) | Gasless x402 facilitator for Celo Mainnet, accepting USDC and USD₮ via EIP-3009 |


### PR DESCRIPTION
Adds [Accrue](https://x402.accrue.fund) to the facilitators table (alphabetical, one row, matching the existing format).

Accrue is a public facilitator in production settling live x402 traffic — USDC on Solana and Base plus other EVM chains (Polygon, Arbitrum, Optimism, Worldchain, Robinhood Chain). It is the settlement layer behind the openzoo.fun inference endpoints, so its accepts[]/settle flow is exercised on real mainnet volume daily and is independently measured on-chain by x402-list.com (https://x402-list.com/api/v1/facilitators).

Disclosure: I operate Accrue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)