### PR TITLE
feat(axios): validate paid responses on a detached view

### DIFF
--- a/typescript/.changeset/axios-paid-response-validation.md
+++ b/typescript/.changeset/axios-paid-response-validation.md
@@ -1,0 +1,5 @@
+---
+"@x402/axios": minor
+---
+
+Added an optional caller-owned `validatePaidResponse` hook to `wrapAxiosWithPayment` and `wrapAxiosWithPaymentFromConfig`. It runs after payment-result processing on ordinary and recovery paid responses, gives the validator a detached view, preserves the original Axios response and pre-validator `PAYMENT-RESPONSE` evidence, fail-closes on non-cloneable bodies, and never retries or repays. Behavior is unchanged when the option is omitted.

--- a/typescript/packages/http/axios/README.md
+++ b/typescript/packages/http/axios/README.md
@@ -37,7 +37,7 @@ const data = response.data;
 
 ## API
 
-### `wrapAxiosWithPayment(axiosInstance, client)`
+### `wrapAxiosWithPayment(axiosInstance, client, options?)`
 
 Wraps an Axios instance to handle 402 Payment Required responses automatically.
 
@@ -45,10 +45,21 @@ Wraps an Axios instance to handle 402 Payment Required responses automatically.
 
 - `axiosInstance`: The Axios instance to wrap (typically from `axios.create()`)
 - `client`: An x402Client instance with registered payment schemes
+- `options.validatePaidResponse`: Optional caller-owned check of a successful paid application response. It runs after `processPaymentResult` on both the ordinary paid response and the one bounded recovery response, before the body is returned. The callback receives a detached view of status, headers, and body; the original Axios response is preserved for return or `PaidResponseValidationError`. `PAYMENT-RESPONSE` is optional because output validity and settlement evidence are separate: a post-payment success is still validated when the header is absent. A terminal 402 remains protocol evidence and is not passed to the validator. Non-cloneable or stream-like bodies fail closed without consuming the original body. On failure the SDK throws `PaidResponseValidationError` bound to the original Axios response and the pre-validator `PAYMENT-RESPONSE` value when present; it does not retry or create another payment. Omit the option to keep existing behavior.
 
-### `wrapAxiosWithPaymentFromConfig(axiosInstance, config)`
+```typescript
+const api = wrapAxiosWithPayment(axios.create(), client, {
+  validatePaidResponse: response => {
+    if (!response.data?.report?.weather) {
+      throw new Error("paid body missing report.weather");
+    }
+  },
+});
+```
 
-Convenience wrapper that creates an x402Client from a configuration object.
+### `wrapAxiosWithPaymentFromConfig(axiosInstance, config, options?)`
+
+Convenience wrapper that creates an x402Client from a configuration object. `options` is the same optional `validatePaidResponse` hook as `wrapAxiosWithPayment`.
 
 #### Parameters
 
@@ -59,6 +70,7 @@ Convenience wrapper that creates an x402Client from a configuration object.
     - `client`: The scheme client implementation (e.g., `ExactEvmScheme`, `ExactSvmScheme`)
     - `x402Version`: Optional protocol version (defaults to 2, set to 1 for legacy support)
   - `paymentRequirementsSelector`: Optional function to select payment requirements from multiple options
+- `options.validatePaidResponse`: Optional. Same caller-owned paid-response validator as `wrapAxiosWithPayment`.
 
 #### Returns
 
@@ -194,4 +206,3 @@ const api = wrapAxiosWithPaymentFromConfig(axios.create(), {
   paymentRequirementsSelector: selectCheapestOption,
 });
 ```
-

--- a/typescript/packages/http/axios/src/index.test.ts
+++ b/typescript/packages/http/axios/src/index.test.ts
@@ -6,7 +6,14 @@ import {
   InternalAxiosRequestConfig,
 } from "axios";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { wrapAxiosWithPayment, wrapAxiosWithPaymentFromConfig } from "./index";
+import {
+  PaidResponseValidationError,
+  wrapAxiosWithPayment,
+  wrapAxiosWithPaymentFromConfig,
+  type PaidResponseValidationView,
+  type ValidatePaidResponse,
+  type ValidatePaidResponseContext,
+} from "./index";
 import type { x402Client, x402ClientConfig } from "@x402/core/client";
 import type { PaymentPayload, PaymentRequired, PaymentRequirements } from "@x402/core/types";
 
@@ -30,124 +37,166 @@ vi.mock("@x402/core/client", () => {
   };
 });
 
+const validPaymentRequired: PaymentRequired = {
+  x402Version: 2,
+  resource: {
+    url: "https://api.example.com/resource",
+    description: "Test payment",
+    mimeType: "application/json",
+  },
+  accepts: [
+    {
+      scheme: "exact",
+      network: "eip155:84532" as const,
+      amount: "1000000",
+      asset: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+      payTo: "0x1234567890123456789012345678901234567890",
+      maxTimeoutSeconds: 300,
+      extra: {},
+    } as PaymentRequirements,
+  ],
+};
+
+const validPaymentPayload: PaymentPayload = {
+  x402Version: 2,
+  resource: validPaymentRequired.resource,
+  accepted: validPaymentRequired.accepts[0],
+  payload: { signature: "0xmocksignature" },
+};
+
+const createErrorConfig = (isRetry = false): InternalAxiosRequestConfig =>
+  ({
+    headers: new AxiosHeaders(),
+    url: "https://api.example.com",
+    method: "GET",
+    ...(isRetry ? { __is402Retry: true } : {}),
+  }) as InternalAxiosRequestConfig;
+
+const createAxiosError = (
+  status: number,
+  config?: InternalAxiosRequestConfig,
+  data?: PaymentRequired,
+  headers?: Record<string, string>,
+): AxiosError => {
+  return new AxiosError(
+    "Error",
+    "ERROR",
+    config,
+    {},
+    {
+      status,
+      statusText: status === 402 ? "Payment Required" : "Not Found",
+      data,
+      headers: headers || {},
+      config: config || createErrorConfig(),
+    },
+  );
+};
+
+const createAxiosResponse = (
+  status: number,
+  data?: unknown,
+  headers?: AxiosResponse["headers"],
+): AxiosResponse =>
+  ({
+    status,
+    statusText: status === 402 ? "Payment Required" : "OK",
+    data,
+    headers: headers || {},
+    config: createErrorConfig(),
+  }) as AxiosResponse;
+
+const createMockAxiosInstance = (): AxiosInstance =>
+  ({
+    interceptors: {
+      response: {
+        use: vi.fn(),
+      },
+    },
+    request: vi.fn(),
+  }) as unknown as AxiosInstance;
+
+/**
+ * Installs default x402 client/HTTP-client mocks and returns a mock x402Client.
+ *
+ * @returns Mock x402 client with default paid-flow implementations
+ */
+const createDefaultMockClient = async (): Promise<x402Client> => {
+  const { x402Client: MockX402Client, x402HTTPClient: MockX402HTTPClient } = await import(
+    "@x402/core/client"
+  );
+
+  const mockClient = new MockX402Client() as unknown as x402Client;
+  (mockClient.createPaymentPayload as ReturnType<typeof vi.fn>).mockResolvedValue(
+    validPaymentPayload,
+  );
+  (
+    MockX402HTTPClient.prototype.getPaymentRequiredResponse as ReturnType<typeof vi.fn>
+  ).mockReturnValue(validPaymentRequired);
+  (
+    MockX402HTTPClient.prototype.encodePaymentSignatureHeader as ReturnType<typeof vi.fn>
+  ).mockReturnValue({
+    "PAYMENT-SIGNATURE": "encoded-payment-header",
+  });
+  (
+    MockX402HTTPClient.prototype.handlePaymentRequired as ReturnType<typeof vi.fn>
+  ).mockResolvedValue(null);
+  (MockX402HTTPClient.prototype.processPaymentResult as ReturnType<typeof vi.fn>).mockResolvedValue(
+    { recovered: false },
+  );
+
+  return mockClient;
+};
+
+const getErrorInterceptor = (
+  axiosInstance: AxiosInstance,
+): ((error: AxiosError) => Promise<AxiosResponse>) =>
+  (axiosInstance.interceptors.response.use as ReturnType<typeof vi.fn>).mock.calls[0][1];
+
+const getSuccessHandler = (axiosInstance: AxiosInstance): ((response: AxiosResponse) => unknown) =>
+  (axiosInstance.interceptors.response.use as ReturnType<typeof vi.fn>).mock.calls[0][0];
+
+/**
+ * Asserts the validator received a detached copy, not the live Axios response.
+ *
+ * @param validator - Mock validator
+ * @param response - Original paid Axios response
+ * @param recovered - Whether the paid attempt used the recovery path
+ */
+const expectDetachedValidationView = (
+  validator: ReturnType<typeof vi.fn>,
+  response: AxiosResponse,
+  recovered: boolean,
+): void => {
+  expect(validator).toHaveBeenCalledTimes(1);
+  const [view, context] = validator.mock.calls[0] as [
+    PaidResponseValidationView,
+    ValidatePaidResponseContext,
+  ];
+  expect(view).not.toBe(response);
+  expect(view.status).toBe(response.status);
+  expect(view.statusText).toBe(response.statusText);
+  expect(view.data).toEqual(response.data);
+  if (response.data !== null && typeof response.data === "object") {
+    expect(view.data).not.toBe(response.data);
+  }
+  expect(view.headers).not.toBe(response.headers);
+  expect(context.recovered).toBe(recovered);
+  expect(context.paymentRequired).toEqual(validPaymentRequired);
+  expect(context.paymentRequired).not.toBe(validPaymentRequired);
+};
+
 describe("wrapAxiosWithPayment()", () => {
   let mockAxiosClient: AxiosInstance;
   let mockClient: x402Client;
   let interceptor: (error: AxiosError) => Promise<AxiosResponse>;
 
-  const validPaymentRequired: PaymentRequired = {
-    x402Version: 2,
-    resource: {
-      url: "https://api.example.com/resource",
-      description: "Test payment",
-      mimeType: "application/json",
-    },
-    accepts: [
-      {
-        scheme: "exact",
-        network: "eip155:84532" as const,
-        amount: "1000000",
-        asset: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
-        payTo: "0x1234567890123456789012345678901234567890",
-        maxTimeoutSeconds: 300,
-        extra: {},
-      } as PaymentRequirements,
-    ],
-  };
-
-  const validPaymentPayload: PaymentPayload = {
-    x402Version: 2,
-    resource: validPaymentRequired.resource,
-    accepted: validPaymentRequired.accepts[0],
-    payload: { signature: "0xmocksignature" },
-  };
-
-  const createErrorConfig = (isRetry = false): InternalAxiosRequestConfig =>
-    ({
-      headers: new AxiosHeaders(),
-      url: "https://api.example.com",
-      method: "GET",
-      ...(isRetry ? { __is402Retry: true } : {}),
-    }) as InternalAxiosRequestConfig;
-
-  const createAxiosError = (
-    status: number,
-    config?: InternalAxiosRequestConfig,
-    data?: PaymentRequired,
-    headers?: Record<string, string>,
-  ): AxiosError => {
-    return new AxiosError(
-      "Error",
-      "ERROR",
-      config,
-      {},
-      {
-        status,
-        statusText: status === 402 ? "Payment Required" : "Not Found",
-        data,
-        headers: headers || {},
-        config: config || createErrorConfig(),
-      },
-    );
-  };
-
-  const createAxiosResponse = (
-    status: number,
-    data?: unknown,
-    headers?: Record<string, string>,
-  ): AxiosResponse =>
-    ({
-      status,
-      statusText: status === 402 ? "Payment Required" : "OK",
-      data,
-      headers: headers || {},
-      config: createErrorConfig(),
-    }) as AxiosResponse;
-
   beforeEach(async () => {
     vi.resetAllMocks();
-
-    // Mock axios client
-    mockAxiosClient = {
-      interceptors: {
-        response: {
-          use: vi.fn(),
-        },
-      },
-      request: vi.fn(),
-    } as unknown as AxiosInstance;
-
-    // Create mock client
-    const { x402Client: MockX402Client, x402HTTPClient: MockX402HTTPClient } = await import(
-      "@x402/core/client"
-    );
-
-    mockClient = new MockX402Client() as unknown as x402Client;
-
-    // Setup default mock implementations
-    (mockClient.createPaymentPayload as ReturnType<typeof vi.fn>).mockResolvedValue(
-      validPaymentPayload,
-    );
-
-    (
-      MockX402HTTPClient.prototype.getPaymentRequiredResponse as ReturnType<typeof vi.fn>
-    ).mockReturnValue(validPaymentRequired);
-    (
-      MockX402HTTPClient.prototype.encodePaymentSignatureHeader as ReturnType<typeof vi.fn>
-    ).mockReturnValue({
-      "PAYMENT-SIGNATURE": "encoded-payment-header",
-    });
-    (
-      MockX402HTTPClient.prototype.handlePaymentRequired as ReturnType<typeof vi.fn>
-    ).mockResolvedValue(null);
-    (
-      MockX402HTTPClient.prototype.processPaymentResult as ReturnType<typeof vi.fn>
-    ).mockResolvedValue({ recovered: false });
-
-    // Set up the interceptor
+    mockAxiosClient = createMockAxiosInstance();
+    mockClient = await createDefaultMockClient();
     wrapAxiosWithPayment(mockAxiosClient, mockClient);
-    interceptor = (mockAxiosClient.interceptors.response.use as ReturnType<typeof vi.fn>).mock
-      .calls[0][1];
+    interceptor = getErrorInterceptor(mockAxiosClient);
   });
 
   it("should return the axios client instance", () => {
@@ -160,10 +209,8 @@ describe("wrapAxiosWithPayment()", () => {
   });
 
   it("should pass through successful responses", async () => {
-    const successHandler = (mockAxiosClient.interceptors.response.use as ReturnType<typeof vi.fn>)
-      .mock.calls[0][0];
     const response = { data: "success" } as AxiosResponse;
-    expect(successHandler(response)).toBe(response);
+    expect(getSuccessHandler(mockAxiosClient)(response)).toBe(response);
   });
 
   it("should not handle non-402 errors", async () => {
@@ -196,7 +243,6 @@ describe("wrapAxiosWithPayment()", () => {
     );
     expect(mockAxiosClient.request).toHaveBeenCalled();
 
-    // Verify the retry config has payment headers and retry flag
     const retryConfig = (mockAxiosClient.request as ReturnType<typeof vi.fn>).mock.calls[0][0];
     expect(retryConfig.__is402Retry).toBe(true);
   });
@@ -498,15 +544,7 @@ describe("wrapAxiosWithPaymentFromConfig()", () => {
 
   beforeEach(async () => {
     vi.resetAllMocks();
-
-    mockAxiosClient = {
-      interceptors: {
-        response: {
-          use: vi.fn(),
-        },
-      },
-      request: vi.fn(),
-    } as unknown as AxiosInstance;
+    mockAxiosClient = createMockAxiosInstance();
 
     const { x402Client: MockX402Client } = await import("@x402/core/client");
     (MockX402Client.fromConfig as ReturnType<typeof vi.fn>).mockReturnValue(new MockX402Client());
@@ -533,5 +571,642 @@ describe("wrapAxiosWithPaymentFromConfig()", () => {
 
     const result = wrapAxiosWithPaymentFromConfig(mockAxiosClient, config);
     expect(result).toBe(mockAxiosClient);
+  });
+});
+
+describe("wrapAxiosWithPayment() paid-response validation", () => {
+  let mockAxiosClient: AxiosInstance;
+  let mockClient: x402Client;
+
+  /**
+   * Wraps a mock Axios instance and returns the 402 error interceptor.
+   *
+   * @param validatePaidResponse - Optional caller-owned paid-response validator
+   * @returns Error interceptor installed by wrapAxiosWithPayment
+   */
+  const wrapAndGetInterceptor = (
+    validatePaidResponse?: ValidatePaidResponse,
+  ): ((error: AxiosError) => Promise<AxiosResponse>) => {
+    wrapAxiosWithPayment(mockAxiosClient, mockClient, {
+      validatePaidResponse,
+    });
+    return getErrorInterceptor(mockAxiosClient);
+  };
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    mockAxiosClient = createMockAxiosInstance();
+    mockClient = await createDefaultMockClient();
+  });
+
+  it("should not invoke a validator on a free initial 200", async () => {
+    const validator = vi.fn();
+    wrapAxiosWithPayment(mockAxiosClient, mockClient, {
+      validatePaidResponse: validator,
+    });
+    const response = createAxiosResponse(200, { ok: true });
+
+    expect(getSuccessHandler(mockAxiosClient)(response)).toBe(response);
+    expect(validator).not.toHaveBeenCalled();
+    expect(mockAxiosClient.request).not.toHaveBeenCalled();
+    expect(mockClient.createPaymentPayload).not.toHaveBeenCalled();
+  });
+
+  it("should not invoke a validator on pre-payment hook success", async () => {
+    const { x402HTTPClient: MockX402HTTPClient } = await import("@x402/core/client");
+    const validator = vi.fn();
+    const interceptor = wrapAndGetInterceptor(validator);
+    const hookResponse = createAxiosResponse(200, { hooked: true });
+
+    (
+      MockX402HTTPClient.prototype.handlePaymentRequired as ReturnType<typeof vi.fn>
+    ).mockResolvedValue({ "X-HOOK": "handled" });
+    (mockAxiosClient.request as ReturnType<typeof vi.fn>).mockResolvedValue(hookResponse);
+
+    const error = createAxiosError(402, createErrorConfig(), validPaymentRequired);
+    const result = await interceptor(error);
+
+    expect(result).toBe(hookResponse);
+    expect(validator).not.toHaveBeenCalled();
+    expect(mockClient.createPaymentPayload).not.toHaveBeenCalled();
+    expect(mockAxiosClient.request).toHaveBeenCalledTimes(1);
+  });
+
+  it("should keep current behavior when the validator option is absent", async () => {
+    const interceptor = wrapAndGetInterceptor();
+    const successResponse = createAxiosResponse(
+      200,
+      { report: { weather: "sunny" } },
+      { "PAYMENT-RESPONSE": "settled-header" },
+    );
+    (mockAxiosClient.request as ReturnType<typeof vi.fn>).mockResolvedValue(successResponse);
+
+    const result = await interceptor(
+      createAxiosError(402, createErrorConfig(), validPaymentRequired),
+    );
+
+    expect(result).toBe(successResponse);
+    expect(result.data).toEqual({ report: { weather: "sunny" } });
+    expect(mockAxiosClient.request).toHaveBeenCalledTimes(1);
+    expect(mockClient.createPaymentPayload).toHaveBeenCalledTimes(1);
+  });
+
+  it("should return the original paid response when the validator succeeds on a detached view", async () => {
+    const { x402HTTPClient: MockX402HTTPClient } = await import("@x402/core/client");
+    const validator = vi.fn().mockResolvedValue(undefined);
+    const interceptor = wrapAndGetInterceptor(validator);
+    const successResponse = createAxiosResponse(
+      200,
+      { report: { weather: "sunny" } },
+      { "PAYMENT-RESPONSE": "settled-header" },
+    );
+    (mockAxiosClient.request as ReturnType<typeof vi.fn>).mockResolvedValue(successResponse);
+
+    const result = await interceptor(
+      createAxiosError(402, createErrorConfig(), validPaymentRequired),
+    );
+
+    expect(result).toBe(successResponse);
+    expectDetachedValidationView(validator, successResponse, false);
+    expect(
+      (MockX402HTTPClient.prototype.processPaymentResult as ReturnType<typeof vi.fn>).mock
+        .invocationCallOrder[0],
+    ).toBeLessThan(validator.mock.invocationCallOrder[0]);
+    expect(mockAxiosClient.request).toHaveBeenCalledTimes(1);
+    expect(mockClient.createPaymentPayload).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not validate a terminal post-payment 402", async () => {
+    const { x402HTTPClient: MockX402HTTPClient } = await import("@x402/core/client");
+    const validator = vi.fn();
+    const interceptor = wrapAndGetInterceptor(validator);
+    const terminalResponse = createAxiosResponse(402, validPaymentRequired, {
+      "PAYMENT-REQUIRED": "terminal-payment-required",
+    });
+    (mockAxiosClient.request as ReturnType<typeof vi.fn>).mockResolvedValue(terminalResponse);
+
+    const result = await interceptor(
+      createAxiosError(402, createErrorConfig(), validPaymentRequired),
+    );
+
+    expect(result).toBe(terminalResponse);
+    expect(validator).not.toHaveBeenCalled();
+    expect(mockAxiosClient.request).toHaveBeenCalledTimes(1);
+    expect(mockClient.createPaymentPayload).toHaveBeenCalledTimes(1);
+    expect(MockX402HTTPClient.prototype.processPaymentResult).toHaveBeenCalledTimes(1);
+  });
+
+  it("should preserve settlement evidence and not repay when the validator fails", async () => {
+    const validator = vi.fn().mockImplementation(() => {
+      throw new Error("missing report.weather");
+    });
+    const interceptor = wrapAndGetInterceptor(validator);
+    const successResponse = createAxiosResponse(
+      200,
+      { report: {} },
+      { "PAYMENT-RESPONSE": "settled-header" },
+    );
+    (mockAxiosClient.request as ReturnType<typeof vi.fn>).mockResolvedValue(successResponse);
+
+    const rejection = interceptor(createAxiosError(402, createErrorConfig(), validPaymentRequired));
+
+    await expect(rejection).rejects.toBeInstanceOf(PaidResponseValidationError);
+    const error = await rejection.catch((caught: unknown) => caught);
+    expect(error).toMatchObject({
+      name: "PaidResponseValidationError",
+      message: "missing report.weather",
+      response: successResponse,
+      paymentRequired: validPaymentRequired,
+      recovered: false,
+      paymentResponseHeader: "settled-header",
+    });
+    expect((error as PaidResponseValidationError).cause).toBeInstanceOf(Error);
+    expect(validator).toHaveBeenCalledTimes(1);
+    expect(mockAxiosClient.request).toHaveBeenCalledTimes(1);
+    expect(mockClient.createPaymentPayload).toHaveBeenCalledTimes(1);
+  });
+
+  it("should bind a caller-thrown typed validation error to the actual paid response", async () => {
+    const successResponse = createAxiosResponse(
+      200,
+      { report: {} },
+      { "payment-response": "actual-settled" },
+    );
+    const foreignResponse = createAxiosResponse(
+      200,
+      { foreign: true },
+      { "payment-response": "foreign-settled" },
+    );
+    const foreignPaymentRequired: PaymentRequired = {
+      ...validPaymentRequired,
+      resource: {
+        ...validPaymentRequired.resource,
+        url: "https://foreign.example/resource",
+      },
+    };
+    const callerError = new PaidResponseValidationError(
+      "caller typed failure",
+      foreignResponse,
+      foreignPaymentRequired,
+      true,
+    );
+    const interceptor = wrapAndGetInterceptor(() => {
+      throw new PaidResponseValidationError(
+        callerError.message,
+        callerError.response,
+        callerError.paymentRequired,
+        callerError.recovered,
+      );
+    });
+    (mockAxiosClient.request as ReturnType<typeof vi.fn>).mockResolvedValue(successResponse);
+
+    const rebound = await interceptor(
+      createAxiosError(402, createErrorConfig(), validPaymentRequired),
+    ).catch((caught: unknown) => caught);
+    expect(rebound).toMatchObject({
+      name: "PaidResponseValidationError",
+      message: "caller typed failure",
+      response: successResponse,
+      paymentRequired: validPaymentRequired,
+      recovered: false,
+      paymentResponseHeader: "actual-settled",
+    });
+    expect((rebound as PaidResponseValidationError).cause).toBeInstanceOf(
+      PaidResponseValidationError,
+    );
+    expect(mockAxiosClient.request).toHaveBeenCalledTimes(1);
+    expect(mockClient.createPaymentPayload).toHaveBeenCalledTimes(1);
+  });
+
+  it("should validate a recovery paid success exactly once and not repay on failure", async () => {
+    const { x402HTTPClient: MockX402HTTPClient } = await import("@x402/core/client");
+    const validator = vi.fn().mockImplementation(() => {
+      throw new Error("invalid recovered body");
+    });
+    const interceptor = wrapAndGetInterceptor(validator);
+    const correctiveResponse = createAxiosResponse(402, validPaymentRequired, {
+      "PAYMENT-REQUIRED": "corrective-payment-required",
+    });
+    const recoveredResponse = createAxiosResponse(
+      200,
+      { report: { weather: "cloudy" } },
+      { "PAYMENT-RESPONSE": "recovered-settled" },
+    );
+    const freshPaymentPayload: PaymentPayload = {
+      ...validPaymentPayload,
+      payload: { signature: "0xfreshsignature" },
+    };
+
+    (mockClient.createPaymentPayload as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(validPaymentPayload)
+      .mockResolvedValueOnce(freshPaymentPayload);
+    (MockX402HTTPClient.prototype.processPaymentResult as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ recovered: true })
+      .mockResolvedValueOnce({ recovered: false });
+    (mockAxiosClient.request as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(correctiveResponse)
+      .mockResolvedValueOnce(recoveredResponse);
+
+    const rejection = interceptor(createAxiosError(402, createErrorConfig(), validPaymentRequired));
+    const error = await rejection.catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(PaidResponseValidationError);
+    expect(error).toMatchObject({
+      response: recoveredResponse,
+      recovered: true,
+      paymentResponseHeader: "recovered-settled",
+      paymentRequired: validPaymentRequired,
+    });
+    expectDetachedValidationView(validator, recoveredResponse, true);
+    expect(mockAxiosClient.request).toHaveBeenCalledTimes(2);
+    expect(mockClient.createPaymentPayload).toHaveBeenCalledTimes(2);
+    expect(MockX402HTTPClient.prototype.processPaymentResult).toHaveBeenCalledTimes(2);
+  });
+
+  it("should return a recovered paid body when the validator succeeds", async () => {
+    const { x402HTTPClient: MockX402HTTPClient } = await import("@x402/core/client");
+    const validator = vi.fn();
+    const interceptor = wrapAndGetInterceptor(validator);
+    const correctiveResponse = createAxiosResponse(402, validPaymentRequired);
+    const recoveredResponse = createAxiosResponse(
+      200,
+      { report: { weather: "sunny" } },
+      { "PAYMENT-RESPONSE": "recovered-settled" },
+    );
+    const freshPaymentPayload: PaymentPayload = {
+      ...validPaymentPayload,
+      payload: { signature: "0xfreshsignature" },
+    };
+
+    (mockClient.createPaymentPayload as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(validPaymentPayload)
+      .mockResolvedValueOnce(freshPaymentPayload);
+    (MockX402HTTPClient.prototype.processPaymentResult as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ recovered: true })
+      .mockResolvedValueOnce({ recovered: false });
+    (mockAxiosClient.request as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(correctiveResponse)
+      .mockResolvedValueOnce(recoveredResponse);
+
+    const result = await interceptor(
+      createAxiosError(402, createErrorConfig(), validPaymentRequired),
+    );
+
+    expect(result).toBe(recoveredResponse);
+    expectDetachedValidationView(validator, recoveredResponse, true);
+    const processPaymentResult = MockX402HTTPClient.prototype.processPaymentResult as ReturnType<
+      typeof vi.fn
+    >;
+    expect(processPaymentResult.mock.invocationCallOrder[0]).toBeLessThan(
+      processPaymentResult.mock.invocationCallOrder[1],
+    );
+    expect(processPaymentResult.mock.invocationCallOrder[1]).toBeLessThan(
+      validator.mock.invocationCallOrder[0],
+    );
+    expect(mockAxiosClient.request).toHaveBeenCalledTimes(2);
+    expect(mockClient.createPaymentPayload).toHaveBeenCalledTimes(2);
+  });
+
+  it("should not validate a terminal 402 after one bounded recovery", async () => {
+    const { x402HTTPClient: MockX402HTTPClient } = await import("@x402/core/client");
+    const validator = vi.fn();
+    const interceptor = wrapAndGetInterceptor(validator);
+    const correctiveResponse = createAxiosResponse(402, validPaymentRequired, {
+      "PAYMENT-REQUIRED": "corrective-payment-required",
+    });
+    const terminalResponse = createAxiosResponse(402, validPaymentRequired, {
+      "PAYMENT-REQUIRED": "terminal-payment-required",
+    });
+    const freshPaymentPayload: PaymentPayload = {
+      ...validPaymentPayload,
+      payload: { signature: "0xfreshsignature" },
+    };
+
+    (mockClient.createPaymentPayload as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(validPaymentPayload)
+      .mockResolvedValueOnce(freshPaymentPayload);
+    (MockX402HTTPClient.prototype.processPaymentResult as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ recovered: true })
+      .mockResolvedValueOnce({ recovered: false });
+    (mockAxiosClient.request as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(correctiveResponse)
+      .mockResolvedValueOnce(terminalResponse);
+
+    const result = await interceptor(
+      createAxiosError(402, createErrorConfig(), validPaymentRequired),
+    );
+
+    expect(result).toBe(terminalResponse);
+    expect(validator).not.toHaveBeenCalled();
+    expect(mockAxiosClient.request).toHaveBeenCalledTimes(2);
+    expect(mockClient.createPaymentPayload).toHaveBeenCalledTimes(2);
+    expect(MockX402HTTPClient.prototype.processPaymentResult).toHaveBeenCalledTimes(2);
+  });
+
+  it("should pass validatePaidResponse through wrapAxiosWithPaymentFromConfig", async () => {
+    const { x402Client: MockX402Client, x402HTTPClient: MockX402HTTPClient } = await import(
+      "@x402/core/client"
+    );
+    const validator = vi.fn();
+    const configClient = new MockX402Client() as unknown as x402Client;
+    (MockX402Client.fromConfig as ReturnType<typeof vi.fn>).mockReturnValue(configClient);
+    (configClient.createPaymentPayload as ReturnType<typeof vi.fn>).mockResolvedValue(
+      validPaymentPayload,
+    );
+    (
+      MockX402HTTPClient.prototype.processPaymentResult as ReturnType<typeof vi.fn>
+    ).mockResolvedValue({ recovered: false });
+
+    const successResponse = createAxiosResponse(
+      200,
+      { ok: true },
+      { "PAYMENT-RESPONSE": "from-config-settled" },
+    );
+    (mockAxiosClient.request as ReturnType<typeof vi.fn>).mockResolvedValue(successResponse);
+
+    wrapAxiosWithPaymentFromConfig(
+      mockAxiosClient,
+      { schemes: [] },
+      { validatePaidResponse: validator },
+    );
+    const interceptor = getErrorInterceptor(mockAxiosClient);
+
+    const result = await interceptor(
+      createAxiosError(402, createErrorConfig(), validPaymentRequired),
+    );
+
+    expect(result).toBe(successResponse);
+    expect(validator).toHaveBeenCalledTimes(1);
+    expect(configClient.createPaymentPayload).toHaveBeenCalledTimes(1);
+    expect(mockAxiosClient.request).toHaveBeenCalledTimes(1);
+  });
+
+  it("should keep the original body when a hostile validator mutates the detached view", async () => {
+    const data = { report: { weather: "sunny" } };
+    const headers = { "PAYMENT-RESPONSE": "settled-header" };
+    const successResponse = createAxiosResponse(200, data, headers);
+    const validator = vi.fn().mockImplementation((view: PaidResponseValidationView) => {
+      (view.data as { report: { weather: string } }).report.weather = "pwned";
+      view.headers["PAYMENT-RESPONSE"] = "forged";
+    });
+    const interceptor = wrapAndGetInterceptor(validator);
+    (mockAxiosClient.request as ReturnType<typeof vi.fn>).mockResolvedValue(successResponse);
+
+    const result = await interceptor(
+      createAxiosError(402, createErrorConfig(), validPaymentRequired),
+    );
+
+    expect(result).toBe(successResponse);
+    expect(result.data).toEqual({ report: { weather: "sunny" } });
+    expect(result.headers["PAYMENT-RESPONSE"]).toBe("settled-header");
+  });
+
+  it("should preserve original evidence when validation mutates data, headers, and paymentRequired", async () => {
+    const headers = new AxiosHeaders();
+    headers.set("PAYMENT-RESPONSE", "settled-header");
+    const data = { report: { weather: "sunny" } };
+    const successResponse = createAxiosResponse(200, data, headers);
+    const validator = vi
+      .fn()
+      .mockImplementation(
+        (view: PaidResponseValidationView, context: ValidatePaidResponseContext) => {
+          (view.data as { report: { weather: string } }).report.weather = "pwned";
+          delete view.headers["PAYMENT-RESPONSE"];
+          delete view.headers["payment-response"];
+          view.headers["PAYMENT-RESPONSE"] = "forged";
+          context.paymentRequired.resource.url = "https://evil.example/resource";
+          context.paymentRequired.accepts.splice(0);
+          throw new Error("hostile rejection");
+        },
+      );
+    const interceptor = wrapAndGetInterceptor(validator);
+    (mockAxiosClient.request as ReturnType<typeof vi.fn>).mockResolvedValue(successResponse);
+
+    const error = await interceptor(
+      createAxiosError(402, createErrorConfig(), validPaymentRequired),
+    ).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(PaidResponseValidationError);
+    expect(error).toMatchObject({
+      message: "hostile rejection",
+      response: successResponse,
+      paymentRequired: validPaymentRequired,
+      recovered: false,
+      paymentResponseHeader: "settled-header",
+    });
+    expect((error as PaidResponseValidationError).response.data).toEqual({
+      report: { weather: "sunny" },
+    });
+    expect(headers.get("PAYMENT-RESPONSE")).toBe("settled-header");
+    expect(validPaymentRequired.resource.url).toBe("https://api.example.com/resource");
+    expect(validPaymentRequired.accepts).toHaveLength(1);
+    expect(mockAxiosClient.request).toHaveBeenCalledTimes(1);
+    expect(mockClient.createPaymentPayload).toHaveBeenCalledTimes(1);
+  });
+
+  it("should validate a post-payment success when PAYMENT-RESPONSE is absent", async () => {
+    const { x402HTTPClient: MockX402HTTPClient } = await import("@x402/core/client");
+    const validator = vi.fn();
+    const interceptor = wrapAndGetInterceptor(validator);
+    const successResponse = createAxiosResponse(200, { report: { weather: "sunny" } });
+    (mockAxiosClient.request as ReturnType<typeof vi.fn>).mockResolvedValue(successResponse);
+
+    const result = await interceptor(
+      createAxiosError(402, createErrorConfig(), validPaymentRequired),
+    );
+
+    expect(result).toBe(successResponse);
+    expectDetachedValidationView(validator, successResponse, false);
+    expect(
+      (MockX402HTTPClient.prototype.processPaymentResult as ReturnType<typeof vi.fn>).mock
+        .invocationCallOrder[0],
+    ).toBeLessThan(validator.mock.invocationCallOrder[0]);
+    expect(mockAxiosClient.request).toHaveBeenCalledTimes(1);
+    expect(mockClient.createPaymentPayload).toHaveBeenCalledTimes(1);
+  });
+
+  it("should preserve absent PAYMENT-RESPONSE evidence when validation fails", async () => {
+    const validator = vi.fn().mockImplementation(() => {
+      throw new Error("invalid body");
+    });
+    const interceptor = wrapAndGetInterceptor(validator);
+    const successResponse = createAxiosResponse(200, { report: {} });
+    (mockAxiosClient.request as ReturnType<typeof vi.fn>).mockResolvedValue(successResponse);
+
+    const error = await interceptor(
+      createAxiosError(402, createErrorConfig(), validPaymentRequired),
+    ).catch((caught: unknown) => caught);
+
+    expect(error).toMatchObject({
+      name: "PaidResponseValidationError",
+      message: "invalid body",
+      response: successResponse,
+      paymentRequired: validPaymentRequired,
+      recovered: false,
+    });
+    expect((error as PaidResponseValidationError).paymentResponseHeader).toBeUndefined();
+    expect(mockAxiosClient.request).toHaveBeenCalledTimes(1);
+    expect(mockClient.createPaymentPayload).toHaveBeenCalledTimes(1);
+  });
+
+  it("should preserve pre-validator header absence when hostile validation mutates the original response", async () => {
+    const successResponse = createAxiosResponse(200, { report: {} });
+    const validator = vi.fn().mockImplementation(() => {
+      successResponse.headers["PAYMENT-RESPONSE"] = "forged-after-snapshot";
+      throw new Error("invalid body");
+    });
+    const interceptor = wrapAndGetInterceptor(validator);
+    (mockAxiosClient.request as ReturnType<typeof vi.fn>).mockResolvedValue(successResponse);
+
+    const error = await interceptor(
+      createAxiosError(402, createErrorConfig(), validPaymentRequired),
+    ).catch((caught: unknown) => caught);
+
+    expect(error).toMatchObject({
+      name: "PaidResponseValidationError",
+      message: "invalid body",
+      response: successResponse,
+      paymentRequired: validPaymentRequired,
+      recovered: false,
+    });
+    expect((error as PaidResponseValidationError).paymentResponseHeader).toBeUndefined();
+    expect((error as PaidResponseValidationError).response.headers["PAYMENT-RESPONSE"]).toBe(
+      "forged-after-snapshot",
+    );
+    expect(mockAxiosClient.request).toHaveBeenCalledTimes(1);
+    expect(mockClient.createPaymentPayload).toHaveBeenCalledTimes(1);
+  });
+
+  it("should fail closed on a stream-like body without consuming it", async () => {
+    let consumed = false;
+    const streamBody = {
+      /**
+       * Marks the stream as consumed when piped.
+       *
+       * @param dest - Pipe destination
+       * @returns The destination
+       */
+      pipe(dest: unknown) {
+        consumed = true;
+        return dest;
+      },
+      /**
+       * Marks the stream as consumed when read.
+       *
+       * @returns No buffered chunk
+       */
+      read() {
+        consumed = true;
+        return null;
+      },
+      /**
+       * Registers a listener without consuming.
+       *
+       * @returns This stream-like object
+       */
+      on() {
+        return this;
+      },
+    };
+    const validator = vi.fn();
+    const interceptor = wrapAndGetInterceptor(validator);
+    const successResponse = createAxiosResponse(200, streamBody, {
+      "PAYMENT-RESPONSE": "settled-header",
+    });
+    (mockAxiosClient.request as ReturnType<typeof vi.fn>).mockResolvedValue(successResponse);
+
+    const error = await interceptor(
+      createAxiosError(402, createErrorConfig(), validPaymentRequired),
+    ).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(PaidResponseValidationError);
+    expect(error).toMatchObject({
+      message: "Paid response cannot be detached for validation",
+      response: successResponse,
+      paymentRequired: validPaymentRequired,
+      recovered: false,
+      paymentResponseHeader: "settled-header",
+    });
+    expect((error as PaidResponseValidationError).response.data).toBe(streamBody);
+    expect(consumed).toBe(false);
+    expect(validator).not.toHaveBeenCalled();
+    expect(mockAxiosClient.request).toHaveBeenCalledTimes(1);
+    expect(mockClient.createPaymentPayload).toHaveBeenCalledTimes(1);
+  });
+
+  it("should fail closed on a web-stream-like body without calling getReader", async () => {
+    let consumed = false;
+    const streamBody = {
+      /**
+       * Would consume the body if the SDK called it while detaching.
+       *
+       * @returns A reader stub
+       */
+      getReader() {
+        consumed = true;
+        return {
+          /**
+           * Marks the stream as consumed.
+           *
+           * @returns An empty read result
+           */
+          read() {
+            consumed = true;
+            return Promise.resolve({ done: true, value: undefined });
+          },
+        };
+      },
+    };
+    const validator = vi.fn();
+    const interceptor = wrapAndGetInterceptor(validator);
+    const successResponse = createAxiosResponse(200, streamBody, {
+      "PAYMENT-RESPONSE": "settled-header",
+    });
+    (mockAxiosClient.request as ReturnType<typeof vi.fn>).mockResolvedValue(successResponse);
+
+    const error = await interceptor(
+      createAxiosError(402, createErrorConfig(), validPaymentRequired),
+    ).catch((caught: unknown) => caught);
+
+    expect(error).toMatchObject({
+      name: "PaidResponseValidationError",
+      message: "Paid response cannot be detached for validation",
+      response: successResponse,
+      paymentResponseHeader: "settled-header",
+    });
+    expect(consumed).toBe(false);
+    expect(validator).not.toHaveBeenCalled();
+    expect(mockAxiosClient.request).toHaveBeenCalledTimes(1);
+    expect(mockClient.createPaymentPayload).toHaveBeenCalledTimes(1);
+  });
+
+  it("should fail closed on a non-cloneable body without invoking the validator", async () => {
+    const { x402HTTPClient: MockX402HTTPClient } = await import("@x402/core/client");
+    const body = {
+      report: { weather: "sunny" },
+      fn: () => "secret",
+    };
+    const validator = vi.fn();
+    const interceptor = wrapAndGetInterceptor(validator);
+    const successResponse = createAxiosResponse(200, body, {
+      "PAYMENT-RESPONSE": "settled-header",
+    });
+    (mockAxiosClient.request as ReturnType<typeof vi.fn>).mockResolvedValue(successResponse);
+
+    const error = await interceptor(
+      createAxiosError(402, createErrorConfig(), validPaymentRequired),
+    ).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(PaidResponseValidationError);
+    expect(error).toMatchObject({
+      message: "Paid response cannot be detached for validation",
+      response: successResponse,
+      paymentResponseHeader: "settled-header",
+    });
+    expect((error as PaidResponseValidationError).response.data).toBe(body);
+    expect(validator).not.toHaveBeenCalled();
+    expect(MockX402HTTPClient.prototype.processPaymentResult).toHaveBeenCalledTimes(1);
+    expect(mockAxiosClient.request).toHaveBeenCalledTimes(1);
+    expect(mockClient.createPaymentPayload).toHaveBeenCalledTimes(1);
   });
 });

--- a/typescript/packages/http/axios/src/index.ts
+++ b/typescript/packages/http/axios/src/index.ts
@@ -1,9 +1,108 @@
 import { x402Client, x402ClientConfig, x402HTTPClient } from "@x402/core/client";
 import { type PaymentRequired } from "@x402/core/types";
-import { type AxiosInstance, type AxiosError, type InternalAxiosRequestConfig } from "axios";
+import {
+  type AxiosInstance,
+  type AxiosError,
+  type AxiosResponse,
+  type InternalAxiosRequestConfig,
+} from "axios";
 
 type X402RetryConfig = InternalAxiosRequestConfig & { __is402Retry?: boolean };
 type AxiosHeaderRecord = Record<string, string>;
+
+const PAID_RESPONSE_DETACH_FAILURE = "Paid response cannot be detached for validation";
+
+/**
+ * Detached snapshot given to a caller-owned paid-response validator.
+ *
+ * Mutating this view cannot change the Axios response returned to the caller
+ * or attached to PaidResponseValidationError.
+ */
+export type PaidResponseValidationView = {
+  status: number;
+  statusText: string;
+  headers: Record<string, string>;
+  data: unknown;
+};
+
+/**
+ * Context passed to a caller-owned paid-response validator.
+ */
+export type ValidatePaidResponseContext = {
+  paymentRequired: PaymentRequired;
+  recovered: boolean;
+};
+
+/**
+ * Optional caller-owned check of a paid application response.
+ *
+ * The SDK owns hook placement and evidence preservation. The caller owns
+ * parsing, schema, byte limits, and which fields are required. This is not a
+ * protocol output-schema dialect. The callback receives a detached view, not
+ * the live Axios response.
+ *
+ * @param response - Detached view of the paid response after payment evidence was observed
+ * @param context - Detached payment requirements and whether this is the recovery path
+ */
+export type ValidatePaidResponse = (
+  response: PaidResponseValidationView,
+  context: ValidatePaidResponseContext,
+) => void | Promise<void>;
+
+/**
+ * Optional behavior for wrapAxiosWithPayment.
+ */
+export type WrapAxiosWithPaymentOptions = {
+  /**
+   * When set, runs after processPaymentResult on the ordinary paid response
+   * and the one bounded recovery response, before the body is returned. The
+   * callback receives a detached view; the original Axios response and
+   * pre-validator PAYMENT-RESPONSE value are preserved. PAYMENT-RESPONSE is
+   * optional: a post-payment success is still validated when the header is
+   * absent. Absent by default; current behavior is unchanged.
+   */
+  validatePaidResponse?: ValidatePaidResponse;
+};
+
+/**
+ * Thrown when a caller-owned paid-response validator rejects a paid body, or
+ * when a paid body cannot be detached for validation.
+ *
+ * Settlement / payment-response evidence is the pre-validator snapshot. The
+ * transport does not retry or create another payment after this error.
+ */
+export class PaidResponseValidationError extends Error {
+  readonly paymentRequired: PaymentRequired;
+  readonly paymentResponseHeader?: string;
+  readonly recovered: boolean;
+  readonly response: AxiosResponse;
+
+  /**
+   * Creates an evidence-preserving paid-response validation error.
+   *
+   * @param message - Validation failure message
+   * @param response - Original paid Axios response
+   * @param paymentRequired - Payment requirements used for the paid attempt
+   * @param recovered - Whether this was the bounded recovery response
+   * @param paymentResponseHeader - Pre-validator PAYMENT-RESPONSE snapshot
+   * @param cause - Original validator or detach exception, if any
+   */
+  constructor(
+    message: string,
+    response: AxiosResponse,
+    paymentRequired: PaymentRequired,
+    recovered: boolean,
+    paymentResponseHeader?: string,
+    cause?: unknown,
+  ) {
+    super(message, cause !== undefined ? { cause } : undefined);
+    this.name = "PaidResponseValidationError";
+    this.response = response;
+    this.paymentRequired = paymentRequired;
+    this.recovered = recovered;
+    this.paymentResponseHeader = paymentResponseHeader;
+  }
+}
 
 /**
  * Resolves the final absolute URL for an Axios 402 response.
@@ -70,6 +169,181 @@ function setAxiosHeader(headers: AxiosHeaderRecord, key: string, value: string):
 }
 
 /**
+ * Reads a string header from an Axios response, case-insensitively.
+ *
+ * @param headers - Axios response headers
+ * @param name - Header name
+ * @returns Header value when present as a string
+ */
+function getAxiosResponseHeader(
+  headers: AxiosResponse["headers"],
+  name: string,
+): string | undefined {
+  const value = headers[name] ?? headers[name.toLowerCase()];
+  return typeof value === "string" ? value : undefined;
+}
+
+/**
+ * Reads the settlement / payment-response header from a paid Axios response.
+ *
+ * @param response - Axios response after a payment attempt
+ * @returns PAYMENT-RESPONSE or legacy X-PAYMENT-RESPONSE value when present
+ */
+function getPaymentResponseHeader(response: AxiosResponse): string | undefined {
+  return (
+    getAxiosResponseHeader(response.headers, "PAYMENT-RESPONSE") ??
+    getAxiosResponseHeader(response.headers, "X-PAYMENT-RESPONSE")
+  );
+}
+
+/**
+ * Returns true when a value looks like a stream that cannot be cloned without
+ * consuming it.
+ *
+ * @param value - Response body candidate
+ * @returns Whether the value is stream-like
+ */
+function isStreamLike(value: unknown): boolean {
+  if (value === null || typeof value !== "object") {
+    return false;
+  }
+
+  const streamCtor = (globalThis as { ReadableStream?: new (...args: never[]) => object })
+    .ReadableStream;
+  if (typeof streamCtor === "function" && value instanceof streamCtor) {
+    return true;
+  }
+
+  const record = value as Record<string, unknown>;
+  return typeof record.pipe === "function" || typeof record.getReader === "function";
+}
+
+/**
+ * Structured-clones a value for a detached validation view.
+ *
+ * Stream-like values are rejected without reading them. Clone failure is
+ * fail-closed: callers must not receive a live body or a weakened snapshot.
+ *
+ * @param value - Value to detach
+ * @returns Independent clone of value
+ */
+function cloneValidationValue<T>(value: T): T {
+  if (isStreamLike(value)) {
+    throw new Error(PAID_RESPONSE_DETACH_FAILURE);
+  }
+
+  if (typeof structuredClone !== "function") {
+    throw new Error(PAID_RESPONSE_DETACH_FAILURE);
+  }
+
+  try {
+    return structuredClone(value);
+  } catch (error) {
+    throw new Error(PAID_RESPONSE_DETACH_FAILURE, { cause: error });
+  }
+}
+
+/**
+ * Snapshots Axios response headers into a detached string record.
+ *
+ * @param headers - Axios response headers
+ * @returns Plain header snapshot for the validation view
+ */
+function snapshotHeaderRecord(headers: AxiosResponse["headers"]): Record<string, string> {
+  if (!headers) {
+    return {};
+  }
+
+  const toJSON = (headers as { toJSON?: () => Record<string, unknown> }).toJSON;
+  const source =
+    typeof toJSON === "function" ? toJSON.call(headers) : (headers as Record<string, unknown>);
+
+  if (source === null || typeof source !== "object") {
+    throw new Error(PAID_RESPONSE_DETACH_FAILURE);
+  }
+
+  return Object.entries(source).reduce<Record<string, string>>((acc, [key, value]) => {
+    if (value !== undefined && value !== null && typeof value !== "function") {
+      acc[key] = String(value);
+    }
+
+    return acc;
+  }, {});
+}
+
+/**
+ * Builds a detached validation view of a paid Axios response.
+ *
+ * @param response - Original paid Axios response
+ * @returns Detached status, headers, and body for validator code
+ */
+function createPaidResponseValidationView(response: AxiosResponse): PaidResponseValidationView {
+  return {
+    status: response.status,
+    statusText: response.statusText,
+    headers: snapshotHeaderRecord(response.headers),
+    data: cloneValidationValue(response.data),
+  };
+}
+
+/**
+ * Runs the optional caller-owned paid-response validator.
+ *
+ * The validator receives a detached view. Failure never retries payment. The
+ * original Axios response and pre-validator payment-response header are
+ * retained on PaidResponseValidationError.
+ *
+ * @param validator - Caller-supplied validator, if any
+ * @param response - Original paid Axios response about to be returned
+ * @param context - Payment requirements and recovery flag
+ */
+async function applyValidatePaidResponse(
+  validator: ValidatePaidResponse | undefined,
+  response: AxiosResponse,
+  context: ValidatePaidResponseContext,
+): Promise<void> {
+  if (!validator) {
+    return;
+  }
+
+  const paymentResponseHeader = getPaymentResponseHeader(response);
+  let view: PaidResponseValidationView;
+  let validationContext: ValidatePaidResponseContext;
+
+  try {
+    view = createPaidResponseValidationView(response);
+    validationContext = {
+      paymentRequired: cloneValidationValue(context.paymentRequired),
+      recovered: context.recovered,
+    };
+  } catch (error) {
+    throw new PaidResponseValidationError(
+      PAID_RESPONSE_DETACH_FAILURE,
+      response,
+      context.paymentRequired,
+      context.recovered,
+      paymentResponseHeader,
+      error,
+    );
+  }
+
+  try {
+    await validator(view, validationContext);
+  } catch (error) {
+    const message =
+      error instanceof Error && error.message ? error.message : "Paid response validation failed";
+    throw new PaidResponseValidationError(
+      message,
+      response,
+      context.paymentRequired,
+      context.recovered,
+      paymentResponseHeader,
+      error,
+    );
+  }
+}
+
+/**
  * Clones an Axios internal request config so a retry can treat HTTP 402 as a successful
  * response status for validation (so the interceptor can handle payment flow).
  *
@@ -106,6 +380,9 @@ function createX402RetryConfig(config: InternalAxiosRequestConfig): X402RetryCon
  *
  * @param axiosInstance - The Axios instance to wrap
  * @param client - Configured x402Client instance for handling payments
+ * @param options - Optional caller-owned paid-response validation. The
+ *   validator receives a detached view; the original response is returned or
+ *   attached to PaidResponseValidationError.
  * @returns The wrapped Axios instance that handles 402 responses automatically
  *
  * @example
@@ -129,12 +406,15 @@ function createX402RetryConfig(config: InternalAxiosRequestConfig): X402RetryCon
  * @throws {Error} If the request configuration is missing
  * @throws {Error} If a payment has already been attempted for this request
  * @throws {Error} If there's an error creating the payment header
+ * @throws {PaidResponseValidationError} If the optional paid-response validator rejects
  */
 export function wrapAxiosWithPayment(
   axiosInstance: AxiosInstance,
   client: x402Client | x402HTTPClient,
+  options?: WrapAxiosWithPaymentOptions,
 ): AxiosInstance {
   const httpClient = client instanceof x402HTTPClient ? client : new x402HTTPClient(client);
+  const validatePaidResponse = options?.validatePaidResponse;
 
   axiosInstance.interceptors.response.use(
     response => response,
@@ -256,9 +536,21 @@ export function wrapAxiosWithPayment(
             return typeof value === "string" ? value : undefined;
           };
           await httpClient.processPaymentResult(freshPayload, getRetryHeader, retryResponse.status);
+          if (retryResponse.status !== 402) {
+            await applyValidatePaidResponse(validatePaidResponse, retryResponse, {
+              paymentRequired,
+              recovered: true,
+            });
+          }
           return retryResponse;
         }
 
+        if (secondResponse.status !== 402) {
+          await applyValidatePaidResponse(validatePaidResponse, secondResponse, {
+            paymentRequired,
+            recovered: false,
+          });
+        }
         return secondResponse;
       } catch (retryError) {
         return Promise.reject(retryError);
@@ -274,6 +566,7 @@ export function wrapAxiosWithPayment(
  *
  * @param axiosInstance - The Axios instance to wrap
  * @param config - Configuration options including scheme registrations and selectors
+ * @param options - Same optional validatePaidResponse as wrapAxiosWithPayment
  * @returns The wrapped Axios instance that handles 402 responses automatically
  *
  * @example
@@ -297,9 +590,10 @@ export function wrapAxiosWithPayment(
 export function wrapAxiosWithPaymentFromConfig(
   axiosInstance: AxiosInstance,
   config: x402ClientConfig,
+  options?: WrapAxiosWithPaymentOptions,
 ): AxiosInstance {
   const client = x402Client.fromConfig(config);
-  return wrapAxiosWithPayment(axiosInstance, client);
+  return wrapAxiosWithPayment(axiosInstance, client, options);
 }
 
 // Re-export types and utilities for convenience


### PR DESCRIPTION
## Description

Closes #3330.

Adds an optional caller-owned `validatePaidResponse` callback to `wrapAxiosWithPayment` and `wrapAxiosWithPaymentFromConfig`.

The callback runs after payment-result processing on ordinary and bounded recovery paid-success responses, before the body is returned. It receives a detached view, while the original Axios response and the pre-validator settlement-header value remain available on `PaidResponseValidationError`.

The implementation also:

- skips validation for terminal 402 responses
- validates successful paid responses even when `PAYMENT-RESPONSE` is absent
- fails closed on stream-like or otherwise non-cloneable bodies without consuming the original
- never retries or creates another payment after validation failure
- keeps current behavior unchanged when the option is omitted

The caller still owns parsing, size limits, schema choice, and required fields. This does not introduce an output-schema dialect.

This is the Axios-specific counterpart to the separate fetch proposal in #3260.

### AI usage disclosure

Grok 4.6 xhigh produced the initial implementation and a focused amendment. I independently reviewed the final diff, reproduced and fixed an evidence-snapshot edge case, squashed the result into the signed commit, and reran the exact package gates below.

## Tests

- `pnpm test`: 42 passed
- `pnpm lint:check`
- `pnpm format:check`
- `pnpm build`: ESM, CJS, source maps, and declarations

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing package tests pass
- [x] My commit is signed
- [x] I added a TypeScript changeset