### PR TITLE
fix: replace crypto dependency with @noble/hashes in @x402/svm

### DIFF
--- a/e2e/pnpm-lock.yaml
+++ b/e2e/pnpm-lock.yaml
@@ -1670,6 +1670,9 @@ importers:
 
   ../typescript/packages/mechanisms/svm:
     dependencies:
+      '@noble/hashes':
+        specifier: ^1.8.0
+        version: 1.8.0
       '@solana-program/compute-budget':
         specifier: ^0.11.0
         version: 0.11.0(@solana/kit@5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10))

--- a/examples/typescript/pnpm-lock.yaml
+++ b/examples/typescript/pnpm-lock.yaml
@@ -1186,6 +1186,9 @@ importers:
 
   ../../typescript/packages/mechanisms/svm:
     dependencies:
+      '@noble/hashes':
+        specifier: ^1.8.0
+        version: 1.8.0
       '@solana-program/compute-budget':
         specifier: ^0.11.0
         version: 0.11.0(@solana/kit@5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))

--- a/typescript/.changeset/svm-drop-node-crypto.md
+++ b/typescript/.changeset/svm-drop-node-crypto.md
@@ -1,0 +1,5 @@
+---
+"@x402/svm": patch
+---
+
+Replace `node:crypto`/`Buffer` usage in `transactionMessageHash`, `getChannelDistributionHash`, and payment-channel account discovery with `@noble/hashes/sha256` and `@solana/kit`'s base64 codec. These SHA-256 call sites were only ever needed by facilitator-side code, but lived in modules also imported by `exact/client`/`upto/client`, pulling Node's `crypto` module (and `Buffer`) into browser bundles of any consumer that imports the SVM client and forcing a `crypto`/`buffer` polyfill (e.g. `vite-plugin-node-polyfills`). `@noble/hashes` is a pure-JS, dependency-free SHA-256 implementation that produces byte-identical digests and needs no platform crypto API or polyfill on any target (browser, Node, React Native).

--- a/typescript/packages/mechanisms/svm/package.json
+++ b/typescript/packages/mechanisms/svm/package.json
@@ -47,6 +47,7 @@
   },
   "dependencies": {
     "@x402/core": "workspace:~",
+    "@noble/hashes": "^1.8.0",
     "@solana-program/compute-budget": "^0.11.0",
     "@solana-program/token": "^0.9.0",
     "@solana-program/token-2022": "^0.6.1"

--- a/typescript/packages/mechanisms/svm/src/payment-channels/discovery.ts
+++ b/typescript/packages/mechanisms/svm/src/payment-channels/discovery.ts
@@ -6,7 +6,7 @@
  * distribution recipient that Open/Sealed actions need.
  */
 
-import { address, type Address, type Base58EncodedBytes } from "@solana/kit";
+import { address, type Address, type Base58EncodedBytes, getBase64Encoder } from "@solana/kit";
 
 import type { FacilitatorSvmSigner } from "../signer";
 import type { Channel } from "./generated/accounts/channel";
@@ -102,7 +102,7 @@ async function validateDiscoveredAccount(
 ): Promise<DiscoveredChannel | undefined> {
   if (owner !== expectedProgram) return undefined;
 
-  const bytes = Buffer.from(base64Data, "base64");
+  const bytes = getBase64Encoder().encode(base64Data);
   if (bytes.byteLength < Number(CHANNEL_ACCOUNT_SIZE)) return undefined;
 
   let channel: Channel;

--- a/typescript/packages/mechanisms/svm/src/upto/facilitator/channel.ts
+++ b/typescript/packages/mechanisms/svm/src/upto/facilitator/channel.ts
@@ -7,7 +7,7 @@
  * readable. All RPC access is threaded in by the caller.
  */
 
-import { createHash } from "node:crypto";
+import { sha256 } from "@noble/hashes/sha256";
 import {
   getSetComputeUnitLimitInstruction,
   getSetComputeUnitPriceInstruction,
@@ -587,7 +587,7 @@ function assertChannelAddress(label: string, actual: string, expected: string): 
  * @returns SHA-256 of the program's canonical distribution preimage
  */
 export function getChannelDistributionHash(splits: readonly ChannelSplit[]): Uint8Array {
-  const hasher = createHash("sha256");
+  const hasher = sha256.create();
   const count = new Uint8Array(4);
   new DataView(count.buffer).setUint32(0, splits.length, true);
   hasher.update(count);

--- a/typescript/packages/mechanisms/svm/src/utils.ts
+++ b/typescript/packages/mechanisms/svm/src/utils.ts
@@ -1,8 +1,9 @@
-import { createHash } from "node:crypto";
+import { sha256 } from "@noble/hashes/sha256";
 import { ErrInvalidPayloadTransaction } from "./exact/facilitator/errors";
 import {
   isAddress,
   getBase58Encoder,
+  getBase64Decoder,
   getBase64Encoder,
   getTransactionDecoder,
   getCompiledTransactionMessageDecoder,
@@ -64,7 +65,7 @@ export function validateSvmAddress(address: string): boolean {
  * @returns Base64-encoded SHA-256 hash of the transaction message bytes
  */
 export function transactionMessageHash(transaction: Transaction): string {
-  return createHash("sha256").update(Buffer.from(transaction.messageBytes)).digest("base64");
+  return getBase64Decoder().decode(sha256(Uint8Array.from(transaction.messageBytes)));
 }
 
 /**

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -1636,6 +1636,9 @@ importers:
 
   packages/mechanisms/svm:
     dependencies:
+      '@noble/hashes':
+        specifier: ^1.8.0
+        version: 1.8.0
       '@solana-program/compute-budget':
         specifier: ^0.11.0
         version: 0.11.0(@solana/kit@6.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(utf-8-validate@5.0.10))
@@ -9609,7 +9612,7 @@ snapshots:
     dependencies:
       '@noble/ciphers': 2.1.1
       '@noble/curves': 2.0.1
-      '@noble/hashes': 2.0.1
+      '@noble/hashes': 2.2.0
       ajv: 8.17.1
       algo-msgpack-with-bigint: 2.1.1
       bn.js: 5.2.3


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

`@x402/svm` could not be used in a default browser context due to its dependency on `node:crypto`, making it a backend-only SDK. In order for the frontend to use it, they needed to be a complex frontend that uses plugins (i.e. vite + polyfill plugin).

This PR attempts to resolve this by moving the sha256 hashing dependency away from `node:crypto`, and instead using `@noble/hashes`. `@noble/hashes` is already trusted by the `@x402/evm` package, as well as is used by `viem` the leading cross-enviromment typescript EVM package. 

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

Re-ran unit tests, integration tests, and cross-SDK e2e tests

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 