### PR TITLE
fix(stellar): include feeBumpSigner in facilitator-safety checks

### DIFF
--- a/typescript/.changeset/stellar-facilitator-feebumpsigner-safety-check.md
+++ b/typescript/.changeset/stellar-facilitator-feebumpsigner-safety-check.md
@@ -1,0 +1,5 @@
+---
+"@x402/stellar": patch
+---
+
+Extend the Stellar facilitator's safety checks (`unsafe_tx_or_op_source`, `facilitator_is_payer`, `facilitator_in_auth`) to also cover `feeBumpSigner`, not just `signingAddresses`. `feeBumpSigner` is now checked via a separate `facilitatorSafetyAddresses` set rather than merged into `signingAddresses`, since `signerMap`-based signer selection in `settle()` does not expect it there. Fixes #3332.

--- a/typescript/packages/mechanisms/stellar/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/stellar/src/exact/facilitator/scheme.ts
@@ -93,6 +93,14 @@ export class ExactStellarScheme implements SchemeNetworkFacilitator {
   public readonly feeBumpSigner?: FacilitatorStellarSigner;
   private readonly signerMap: Map<string, FacilitatorStellarSigner>;
   private readonly selectSigner: (addresses: readonly string[]) => string;
+  /**
+   * Addresses the facilitator-safety checks must treat as facilitator-controlled.
+   * Deliberately a separate set from `signingAddresses`: that set also backs
+   * signer *selection* (`signerMap.get(...)` in `settle()`), and `feeBumpSigner`
+   * has no entry in `signerMap`, so merging it into `signingAddresses` directly
+   * would let round-robin selection pick an address `settle()` can't sign with.
+   */
+  private readonly facilitatorSafetyAddresses: ReadonlySet<string>;
 
   /**
    * Creates a new ExactStellarScheme instance.
@@ -142,6 +150,9 @@ export class ExactStellarScheme implements SchemeNetworkFacilitator {
     this.maxTransactionFeeStroops = maxTransactionFeeStroops ?? DEFAULT_MAX_TRANSACTION_FEE_STROOPS;
     this.selectSigner = selectSigner ?? roundRobinSelectSigner();
     this.feeBumpSigner = feeBumpSigner;
+    this.facilitatorSafetyAddresses = this.feeBumpSigner
+      ? new Set([...this.signingAddresses, this.feeBumpSigner.address])
+      : this.signingAddresses;
   }
 
   /**
@@ -426,8 +437,8 @@ export class ExactStellarScheme implements SchemeNetworkFacilitator {
       }
 
       if (
-        this.signingAddresses.has(operation.source ?? "") ||
-        this.signingAddresses.has(transaction.source)
+        this.facilitatorSafetyAddresses.has(operation.source ?? "") ||
+        this.facilitatorSafetyAddresses.has(transaction.source)
       ) {
         return {
           response: invalidVerifyResponse("invalid_exact_stellar_payload_unsafe_tx_or_op_source"),
@@ -465,7 +476,7 @@ export class ExactStellarScheme implements SchemeNetworkFacilitator {
       const toAddress = scValToNative(args[1]) as string;
       const amount = scValToNative(args[2]) as bigint;
 
-      if (this.signingAddresses.has(fromAddress)) {
+      if (this.facilitatorSafetyAddresses.has(fromAddress)) {
         return {
           response: invalidVerifyResponse("invalid_exact_stellar_payload_facilitator_is_payer"),
         };
@@ -538,7 +549,7 @@ export class ExactStellarScheme implements SchemeNetworkFacilitator {
       // Step 10: Validate auth entries (structure, credential type, expiration, facilitator safety, and signature status).
       const authValidation = this.validateAuthEntries(
         invokeOp,
-        this.signingAddresses,
+        this.facilitatorSafetyAddresses,
         fromAddress,
         maxLedger,
         transaction,

--- a/typescript/packages/mechanisms/stellar/test/unit/facilitator-verify.test.ts
+++ b/typescript/packages/mechanisms/stellar/test/unit/facilitator-verify.test.ts
@@ -479,6 +479,55 @@ describe("ExactStellarScheme#Verify (randomly using 1-2 facilitator signers)", (
         expect(result.invalidReason).toBe("invalid_exact_stellar_payload_facilitator_is_payer");
       });
 
+      it("should reject when a configured feeBumpSigner is the payer (from address)", async () => {
+        const feeBumpSigner = createEd25519Signer(
+          "SCKTFQJ2ASXITWPDKJ2KMQB7WOBNFV23OOTT6ZVO6AXVNAA3IJ7TRZFP",
+          STELLAR_TESTNET_CAIP2,
+        );
+        const facilitatorWithFeeBump = new ExactStellarScheme(facilitatorSigners, {
+          areFeesSponsored: true,
+          maxTransactionFeeStroops: 1_000_000,
+          feeBumpSigner,
+        });
+
+        if (!baseSorobanData || !baseOperation.auth?.length) {
+          throw new Error("Missing sorobanData or auth in test transaction");
+        }
+
+        const originalArgs = baseInvokeContractArgs.args();
+        const feeBumpKeypair = Keypair.fromPublicKey(feeBumpSigner.address);
+        const feeBumpScAddress = xdr.ScVal.scvAddress(
+          xdr.ScAddress.scAddressTypeAccount(
+            xdr.PublicKey.publicKeyTypeEd25519(feeBumpKeypair.rawPublicKey()),
+          ),
+        );
+
+        const modifiedInvokeContractArgs = new xdr.InvokeContractArgs({
+          contractAddress: baseInvokeContractArgs.contractAddress(),
+          functionName: baseInvokeContractArgs.functionName(),
+          args: [
+            feeBumpScAddress, // ❌ feeBumpSigner is facilitator-controlled too and must not be the payer
+            originalArgs[1],
+            originalArgs[2],
+          ],
+        });
+        const modifiedFunc = xdr.HostFunction.hostFunctionTypeInvokeContract(
+          modifiedInvokeContractArgs,
+        );
+        const modifiedOperation = Operation.invokeHostFunction({
+          ...baseOperation,
+          func: modifiedFunc,
+        });
+        const modifiedStellarPayload = buildStellarPayloadFromOp(modifiedOperation);
+
+        const result = await facilitatorWithFeeBump.verify(
+          modifiedStellarPayload,
+          validRequirements,
+        );
+        expect(result.isValid).toBe(false);
+        expect(result.invalidReason).toBe("invalid_exact_stellar_payload_facilitator_is_payer");
+      });
+
       it("should reject empty auth entries array", async () => {
         const modifiedOperation = Operation.invokeHostFunction({
           ...baseOperation,


### PR DESCRIPTION
Fixes #3332.

`ExactStellarScheme`'s `getSigners()` documents itself as returning "all facilitator addresses including the fee bump signer when configured", but the set every facilitator-safety check actually consults (`signingAddresses`) never included `feeBumpSigner`. A facilitator configured with `feeBumpSigner` reported that address as facilitator-controlled via the public API, while the three checks that exist specifically to keep a facilitator-controlled address out of the payer/tx-source/op-source/auth-signer role in a client payment didn't cover it — `unsafe_tx_or_op_source`, `facilitator_is_payer`, and `facilitator_in_auth`.

## What changed

- Adds a `facilitatorSafetyAddresses` set (`signingAddresses` plus `feeBumpSigner.address` when configured), computed once in the constructor.
- The three safety checks now consult `facilitatorSafetyAddresses` instead of `signingAddresses` directly.
- Deliberately **not** merged into `signingAddresses` itself: that set also backs signer *selection* in `settle()` (`this.signerMap.get(this.selectSigner([...this.signingAddresses]))`), and `feeBumpSigner` has no entry in `signerMap` — merging it into `signingAddresses` would let round-robin selection pick an address `settle()` can't actually sign with. `getSigners()` and the signer-selection path are unchanged.

## Verified with real code, not just reasoning

Added a regression test (`facilitator-verify.test.ts`, "should reject when a configured feeBumpSigner is the payer (from address)") that constructs a real `ExactStellarScheme` with `feeBumpSigner` set, builds a real transaction where the transfer's `from` address is the fee-bump signer's, and asserts `verify()` rejects it with `invalid_exact_stellar_payload_facilitator_is_payer` — this test fails against `main` and passes with this change.

Ran the full `@x402/stellar` suite before and after:

```
# before (main)
Test Files  9 passed (9)
     Tests  157 passed (157)

# after (this branch)
Test Files  9 passed (9)
     Tests  158 passed (158)
```

`pnpm --filter @x402/stellar build` and `pnpm --filter @x402/stellar lint:check` both pass clean.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
