### PR TITLE
docs: add x402-list to third-party extensions

### DIFF
--- a/docs/dev-tools/third-party-extensions.md
+++ b/docs/dev-tools/third-party-extensions.md
@@ -10,3 +10,4 @@ description: "Packages built by ecosystem partners that extend x402 beyond the c
 | [PEAC Protocol](https://x402.peacprotocol.org) | Verifiable receipts for x402 payments | TypeScript | [GitHub](https://github.com/peacprotocol/peac) · [npm](https://www.npmjs.com/package/@peac/adapter-x402) |
 | [x402r](https://x402r.org) | Non-custodial refund and arbitration protocol | Typescript | [GitHub](https://github.com/BackTrackCo/x402r-sdk) · [npm](https://www.npmjs.com/package/@x402r/sdk ) |
 | [zauth](https://zauthx402.com) | Monitoring, verification, and refund SDK | TypeScript | [GitHub](https://github.com/zauthofficial/zauthSDK) · [npm](https://www.npmjs.com/package/@zauthx402/sdk) |
+| [x402-list](https://x402-list.com) | Discovery directory of x402 services with live payability monitoring and an MCP search endpoint | TypeScript | [OpenAPI](https://x402-list.com/api/v1/openapi.json) · [MCP](https://mcp.x402-list.com/mcp) |


### PR DESCRIPTION
## Description

Adds x402-list to the third-party extensions table. x402-list is a discovery
directory for x402 services with live payability monitoring and an MCP search
endpoint for agents.

Row links:
- OpenAPI: https://x402-list.com/api/v1/openapi.json
- MCP: https://mcp.x402-list.com/mcp

Docs-only: one row added, no code or spec touched.

## Tests

Docs-only change. Verified the two linked endpoints respond:
- OpenAPI returns 200 (application/json)
- MCP answers a JSON-RPC `initialize` over Streamable HTTP (200)

## Checklist

- [x] I have formatted and linted my code (docs-only, no code changed)
- [x] All new and existing tests pass (docs-only)
- [x] My commits are signed (required for merge)
- [x] Changelog: docs-only change, skipped per template guidance
