### PR TITLE
fix(core): enforce settlement override ceiling against PaymentRequirements.amount

### DIFF
--- a/typescript/.changeset/settlement-override-authorized-maximum.md
+++ b/typescript/.changeset/settlement-override-authorized-maximum.md
@@ -1,0 +1,5 @@
+---
+"@x402/core": patch
+---
+
+`resolveSettlementOverrideAmount()` now enforces the settlement override ceiling against `PaymentRequirements.amount` across raw, percent, and dollar override formats. Previously a settlement override could resolve above the requirement's authorized maximum, which contradicts the documented `SettlementOverrides.amount` contract and the `upto` scheme's maximum-amount rule.

--- a/typescript/packages/core/src/server/x402ResourceServer.ts
+++ b/typescript/packages/core/src/server/x402ResourceServer.ts
@@ -277,29 +277,42 @@ export function resolveSettlementOverrideAmount(
   requirements: PaymentRequirements,
   decimals?: number,
 ): string {
+  let resolved: string;
+
   // Percent format: "50%" or "33.33%"
   const percentMatch = rawAmount.match(/^(\d+(?:\.\d{0,2})?)%$/);
   if (percentMatch) {
     const [intPart, decPart = ""] = percentMatch[1].split(".");
     const scaledPercent = BigInt(intPart) * 100n + BigInt(decPart.padEnd(2, "0").slice(0, 2));
     const base = BigInt(requirements.amount);
-    return ((base * scaledPercent) / 10000n).toString();
-  }
-
-  // Dollar price format: "$0.05"
-  const dollarMatch = rawAmount.match(/^\$(\d+(?:\.\d+)?)$/);
-  if (dollarMatch) {
-    if (decimals === undefined) {
-      throw new Error(
-        `Cannot convert dollar settlement override "${rawAmount}" to atomic units: ` +
-          `asset decimals are unknown. Pass an atomic amount or register the asset.`,
-      );
+    resolved = ((base * scaledPercent) / 10000n).toString();
+  } else {
+    // Dollar price format: "$0.05"
+    const dollarMatch = rawAmount.match(/^\$(\d+(?:\.\d+)?)$/);
+    if (dollarMatch) {
+      if (decimals === undefined) {
+        throw new Error(
+          `Cannot convert dollar settlement override "${rawAmount}" to atomic units: ` +
+            `asset decimals are unknown. Pass an atomic amount or register the asset.`,
+        );
+      }
+      resolved = convertToTokenAmount(dollarMatch[1], decimals);
+    } else {
+      // Raw atomic units (existing behavior)
+      resolved = rawAmount;
     }
-    return convertToTokenAmount(dollarMatch[1], decimals);
   }
 
-  // Raw atomic units (existing behavior)
-  return rawAmount;
+  // SettlementOverrides.amount's own contract: the resolved amount must be
+  // <= the authorized maximum in PaymentRequirements, for every format above.
+  if (BigInt(resolved) > BigInt(requirements.amount)) {
+    throw new Error(
+      `Settlement override amount "${rawAmount}" resolves to ${resolved} atomic units, ` +
+        `which exceeds the authorized maximum of ${requirements.amount} in PaymentRequirements.`,
+    );
+  }
+
+  return resolved;
 }
 
 type HookAdapterHandles = {

--- a/typescript/packages/core/test/integrations/upto.test.ts
+++ b/typescript/packages/core/test/integrations/upto.test.ts
@@ -151,7 +151,7 @@ describe("Upto Integration Tests", () => {
         accepts: {
           scheme: "cash",
           payTo: "merchant@example.com",
-          price: "$10.00",
+          price: "$10",
           network: "x402:cash" as Network,
         },
         description: "AI generation with upto billing",

--- a/typescript/packages/core/test/unit/server/x402ResourceServer.test.ts
+++ b/typescript/packages/core/test/unit/server/x402ResourceServer.test.ts
@@ -1725,7 +1725,7 @@ describe("x402ResourceServer", () => {
       const requirements = buildPaymentRequirements({
         scheme: "exact",
         network: "eip155:8453" as Network,
-        amount: "1000000",
+        amount: "10000000",
       });
 
       await server.settlePayment(payload, requirements, undefined, undefined, { amount: "$0.05" });
@@ -3354,36 +3354,70 @@ describe("resolveSettlementOverrideAmount", () => {
   });
 
   describe("dollar price format", () => {
+    // Dollar amounts resolve independently of requirements.amount, so this
+    // block uses its own, larger fixture to stay under the authorized-maximum
+    // check below regardless of decimals (unlike raw/percent, whose values
+    // are inherently derived from — or smaller than — baseRequirements.amount).
+    const dollarRequirements = buildPaymentRequirements({ amount: "10000000" });
+
     it("converts '$1.00' using provided 6 decimals", () => {
-      expect(resolveSettlementOverrideAmount("$1.00", baseRequirements, 6)).toBe("1000000");
+      expect(resolveSettlementOverrideAmount("$1.00", dollarRequirements, 6)).toBe("1000000");
     });
 
     it("converts '$0.05' using provided 6 decimals", () => {
-      expect(resolveSettlementOverrideAmount("$0.05", baseRequirements, 6)).toBe("50000");
+      expect(resolveSettlementOverrideAmount("$0.05", dollarRequirements, 6)).toBe("50000");
     });
 
     it("converts '$0.05' using 8 decimals when provided", () => {
-      expect(resolveSettlementOverrideAmount("$0.05", baseRequirements, 8)).toBe("5000000");
+      expect(resolveSettlementOverrideAmount("$0.05", dollarRequirements, 8)).toBe("5000000");
     });
 
     it("converts '$0.001' using provided 6 decimals", () => {
-      expect(resolveSettlementOverrideAmount("$0.001", baseRequirements, 6)).toBe("1000");
+      expect(resolveSettlementOverrideAmount("$0.001", dollarRequirements, 6)).toBe("1000");
     });
 
     it("converts '$0' to '0'", () => {
-      expect(resolveSettlementOverrideAmount("$0", baseRequirements, 6)).toBe("0");
+      expect(resolveSettlementOverrideAmount("$0", dollarRequirements, 6)).toBe("0");
     });
 
     it("pads and truncates toward zero without rounding", () => {
-      expect(resolveSettlementOverrideAmount("$1.0000005", baseRequirements, 6)).toBe("1000000");
-      expect(resolveSettlementOverrideAmount("$0.0000005", baseRequirements, 6)).toBe("0");
-      expect(resolveSettlementOverrideAmount("$0.0000009", baseRequirements, 6)).toBe("0");
+      expect(resolveSettlementOverrideAmount("$1.0000005", dollarRequirements, 6)).toBe("1000000");
+      expect(resolveSettlementOverrideAmount("$0.0000005", dollarRequirements, 6)).toBe("0");
+      expect(resolveSettlementOverrideAmount("$0.0000009", dollarRequirements, 6)).toBe("0");
     });
 
     it("throws when decimals are unknown", () => {
-      expect(() => resolveSettlementOverrideAmount("$1.00", baseRequirements)).toThrow(
+      expect(() => resolveSettlementOverrideAmount("$1.00", dollarRequirements)).toThrow(
         /asset decimals are unknown/,
       );
+    });
+  });
+
+  describe("authorized maximum enforcement", () => {
+    it("throws when a raw atomic-unit override exceeds requirements.amount", () => {
+      expect(() => resolveSettlementOverrideAmount("2001", baseRequirements)).toThrow(
+        /exceeds the authorized maximum/,
+      );
+    });
+
+    it("throws when a percent override resolves above 100% of requirements.amount", () => {
+      expect(() => resolveSettlementOverrideAmount("500%", baseRequirements)).toThrow(
+        /exceeds the authorized maximum/,
+      );
+    });
+
+    it("throws when a dollar override resolves above requirements.amount", () => {
+      const reqs = buildPaymentRequirements({ amount: "999999" });
+      expect(() => resolveSettlementOverrideAmount("$1.00", reqs, 6)).toThrow(
+        /exceeds the authorized maximum/,
+      );
+    });
+
+    it("does not throw when the resolved amount equals requirements.amount exactly", () => {
+      expect(() => resolveSettlementOverrideAmount("100%", baseRequirements)).not.toThrow();
+      expect(() =>
+        resolveSettlementOverrideAmount(baseRequirements.amount, baseRequirements),
+      ).not.toThrow();
     });
   });
 });


### PR DESCRIPTION
Fixes #3334.

`SettlementOverrides.amount`'s own JSDoc states: "The resolved amount must be <= the authorized maximum in `PaymentRequirements`." `resolveSettlementOverrideAmount()` never enforced this for any of its three supported formats (raw atomic units, percent, dollar) — a percent override like `"500%"` or a dollar override priced above the authorized ceiling resolved cleanly and was forwarded straight to the facilitator client's `settle()`, with no error raised anywhere in `@x402/core`.

## What changed

- `resolveSettlementOverrideAmount()` now resolves whichever format was used into a local `resolved` value, then compares it against `BigInt(requirements.amount)` once at the end and throws a clear error if it's exceeded — covering all three formats uniformly rather than duplicating the check per branch.
- Fixed two existing test fixtures that happened to combine a small `requirements.amount` with a dollar-format override large enough to newly trip this check (the "dollar price format" describe block's shared fixture, and the `"should resolve dollar override using scheme getAssetDecimals"` test) — bumped their `amount` fixtures, no assertions changed.
- Fixed one integration fixture (`test/integrations/upto.test.ts`) whose declared price, `"$10.00"`, produced a non-integer `PaymentRequirements.amount` ("10.00") that the new check's `BigInt()` parse can't accept — changed to `"$10"` to match the atomic-unit-string convention every other fixture in the suite already follows. Verified this doesn't affect any assertion in the three tests that use that route.
- Added a new `"authorized maximum enforcement"` describe block covering all three formats exceeding the ceiling, plus the exact-equal boundary not throwing.

## Verified with real code, not just reasoning

Ran the actual `@x402/core` server module via `settlePayment()`/`resolveSettlementOverrideAmount()` directly before writing the fix, to confirm the gap for real:

```
=== settlementOverrides.amount = "500%" against requirements.amount = "1000000" ===
Resolved/forwarded amount was: 5000000   (5x the authorized maximum, no error)

=== settlementOverrides.amount = "$1000000" against a 7-decimal requirements.amount = "1000000" ===
Resolved/forwarded amount was: 10000000000000   (no error)
```

After the fix, ran the full `@x402/core` suite (not just the touched file — a prior pass over #1699 in a different repo taught me to check the whole suite, not just the file I edited):

```
# before this branch
Test Files  22 passed (22)
     Tests  691 passed (691)

# after this branch
Test Files  22 passed (22)
     Tests  695 passed (695)
```

`pnpm --filter @x402/core build` and `pnpm --filter @x402/core lint:check` both pass clean. Also grepped the whole `typescript/` workspace for other consumers of `resolveSettlementOverrideAmount`/`SettlementOverrides` (the `http/*` packages just re-export `x402HTTPResourceServer`, no independent override logic) and ran `@x402/express`/`@x402/fastify`/`@x402/next`/`@x402/hono`'s own suites — one pre-existing, unrelated failure in `@x402/express` (a wildcard-route 402 status test) reproduces identically on `main` with this branch's changes stashed, confirming it's not caused by this change.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
