### PR TITLE
docs(stellar): cross-reference areFeesSponsored's unsupported-false limitation on the constructor

### DIFF
--- a/typescript/packages/mechanisms/stellar/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/stellar/src/exact/facilitator/scheme.ts
@@ -100,7 +100,9 @@ export class ExactStellarScheme implements SchemeNetworkFacilitator {
    * @param signers - One or more Stellar signers managed by the facilitator for settlement
    * @param options - Configuration options
    * @param options.rpcConfig - Optional RPC configuration with custom RPC URL
-   * @param options.areFeesSponsored - Indicates if fees are sponsored (default: true)
+   * @param options.areFeesSponsored - Indicates if fees are sponsored (default: true). The spec
+   *   currently only supports `true`; setting `false` here still constructs successfully, but the
+   *   official client rejects any payment built against the resulting `areFeesSponsored: false`.
    * @param options.maxTransactionFeeStroops - Safety ceiling in stroops; verify rejects if the simulation-derived fee exceeds this (default: 50_000)
    * @param options.selectSigner - Callback to select which signer to use (default: round-robin)
    * @param options.feeBumpSigner - Optional signer used as fee source in a fee bump transaction wrapper.
@@ -119,7 +121,7 @@ export class ExactStellarScheme implements SchemeNetworkFacilitator {
     }: {
       /** Optional RPC configuration with custom RPC URL */
       rpcConfig?: RpcConfig;
-      /** Indicates if fees are sponsored (default: true) */
+      /** Indicates if fees are sponsored (default: true). See the constructor's own @param doc above: `false` is accepted here but not yet usable end-to-end. */
       areFeesSponsored?: boolean;
       /** Safety ceiling in stroops; verify rejects if the simulation-derived fee exceeds this (default: 50_000) */
       maxTransactionFeeStroops?: number;


### PR DESCRIPTION
Addresses #3333.

`getExtra()`'s own JSDoc already says "As of now, the spec only supports `areFeesSponsored: true`", but the constructor's `areFeesSponsored` option — the thing that actually lets an operator set it to `false` — carries no cross-reference to that limitation and no runtime guard. Constructing a facilitator with `areFeesSponsored: false` boots without error, advertises it via `/supported`, and then every settlement attempt through the official client fails elsewhere (`Exact scheme requires areFeesSponsored to be true`) with a message that gives no indication the facilitator's own config is the actual cause.

## Why this is doc-only, not a behavior fix

My first instinct was to throw at construction time when `areFeesSponsored: false` is passed, until the non-sponsored flow ships. That would be wrong: `test/unit/facilitator-accessors.test.ts` has an existing, clearly deliberate test — `"should use custom areFeesSponsored"` — that constructs `new ExactStellarScheme([signer], { areFeesSponsored: false })` and asserts it succeeds. A construction-time throw would directly break that test, which reads as intentional (a named, single-purpose test, not incidental coverage), not an oversight.

So this PR only adds the missing cross-reference where a caller reading the constructor's own types would actually see it, matching what `getExtra()` already documents two methods away. No behavior change, no test changes needed.

## Verified with real code, not just reasoning

Ran the full `@x402/stellar` suite before and after — no change, as expected for a doc-only edit:

```
Test Files  10 passed (10)
     Tests  162 passed (162)
```

`pnpm --filter @x402/stellar build` and `pnpm --filter @x402/stellar lint:check` both pass clean.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
