### PR TITLE
feat(mcp): validate paid tool results on a detached view

### DIFF
--- a/typescript/.changeset/mcp-paid-response-validation.md
+++ b/typescript/.changeset/mcp-paid-response-validation.md
@@ -1,0 +1,5 @@
+---
+"@x402/mcp": minor
+---
+
+Add an optional caller-owned validation hook for final paid MCP tool results, including bounded recovery responses, without changing payment execution or the default public result shape.

--- a/typescript/packages/mcp/src/client/index.ts
+++ b/typescript/packages/mcp/src/client/index.ts
@@ -1,1 +1,7 @@
 export * from "./x402MCPClient";
+export { PaidResponseValidationError, applyValidatePaidToolResult } from "./paidResponseValidation";
+export type {
+  PaidResponseValidationView,
+  ValidatePaidResponseContext,
+  ValidatePaidResponse,
+} from "../types";

--- a/typescript/packages/mcp/src/client/paidResponseValidation.ts
+++ b/typescript/packages/mcp/src/client/paidResponseValidation.ts
@@ -1,0 +1,186 @@
+import type { PaymentPayload, PaymentRequired, SettleResponse } from "@x402/core/types";
+
+import type {
+  MCPResultWithMeta,
+  PaidResponseValidationView,
+  ValidatePaidResponse,
+  ValidatePaidResponseContext,
+} from "../types";
+
+const PAID_RESPONSE_DETACH_FAILURE =
+  "Paid tool result cannot be detached for validation";
+
+/**
+ * Thrown when a caller-owned paid-response validator rejects a paid tool
+ * result, or when a paid result cannot be detached for validation.
+ *
+ * Settlement evidence is preserved on {@link PaidResponseValidationError.result}
+ * and {@link PaidResponseValidationError.paymentResponse} when present. The
+ * client does not retry or create another payment after this error.
+ */
+export class PaidResponseValidationError extends Error {
+  readonly paymentRequired?: PaymentRequired;
+  readonly paymentPayload: PaymentPayload;
+  readonly recovered: boolean;
+  readonly paymentResponse?: SettleResponse;
+  readonly result: MCPResultWithMeta;
+
+  /**
+   * Creates a paid-response validation error with preserved evidence.
+   *
+   * @param message - Human-readable failure message
+   * @param result - Original paid tool result
+   * @param paymentPayload - Payment payload used for the paid attempt
+   * @param recovered - Whether this was the bounded recovery path
+   * @param paymentRequired - Seller requirement when known
+   * @param paymentResponse - Settlement metadata when present on the paid result
+   * @param cause - Underlying validation or detach failure
+   */
+  constructor(
+    message: string,
+    result: MCPResultWithMeta,
+    paymentPayload: PaymentPayload,
+    recovered: boolean,
+    paymentRequired?: PaymentRequired,
+    paymentResponse?: SettleResponse,
+    cause?: unknown,
+  ) {
+    super(message, cause !== undefined ? { cause } : undefined);
+    this.name = "PaidResponseValidationError";
+    this.result = result;
+    this.paymentPayload = paymentPayload;
+    this.recovered = recovered;
+    this.paymentRequired = paymentRequired;
+    this.paymentResponse = paymentResponse;
+  }
+}
+
+/**
+ * Deep-clones a value for detached validator input.
+ *
+ * @param value - Value to clone
+ * @returns Detached clone
+ */
+function cloneValidationValue<T>(value: T): T {
+  if (typeof structuredClone !== "function") {
+    throw new Error(PAID_RESPONSE_DETACH_FAILURE);
+  }
+
+  try {
+    return structuredClone(value);
+  } catch (error) {
+    throw new Error(PAID_RESPONSE_DETACH_FAILURE, { cause: error });
+  }
+}
+
+/**
+ * Builds a detached validation view from a paid tool result.
+ *
+ * @param result - Live paid tool result
+ * @returns Detached view for the validator callback
+ */
+function createPaidResponseValidationView(
+  result: MCPResultWithMeta,
+): PaidResponseValidationView {
+  const view: PaidResponseValidationView = {
+    content: cloneValidationValue(result.content ?? []),
+    ...(result.isError !== undefined ? { isError: result.isError } : {}),
+  };
+
+  if (result.structuredContent !== undefined) {
+    view.structuredContent = cloneValidationValue(result.structuredContent);
+  }
+
+  return view;
+}
+
+/**
+ * Preserves the live paid result attached to errors (validator receives clones only).
+ *
+ * @param result - Live paid tool result
+ * @returns Evidence snapshot referencing the original fields
+ */
+function preserveResultEvidence(result: MCPResultWithMeta): MCPResultWithMeta {
+  return {
+    content: result.content ?? [],
+    ...(result.isError !== undefined ? { isError: result.isError } : {}),
+    ...(result.structuredContent !== undefined
+      ? { structuredContent: result.structuredContent }
+      : {}),
+    ...(result._meta !== undefined ? { _meta: result._meta } : {}),
+  };
+}
+
+/**
+ * Builds a detached validation context for the validator callback.
+ *
+ * @param context - Live validation context
+ * @returns Detached context for the validator callback
+ */
+function buildValidationContext(
+  context: ValidatePaidResponseContext,
+): ValidatePaidResponseContext {
+  const paymentResponse = context.paymentResponse;
+  return {
+    recovered: context.recovered,
+    paymentPayload: cloneValidationValue(context.paymentPayload),
+    ...(context.paymentRequired !== undefined
+      ? { paymentRequired: cloneValidationValue(context.paymentRequired) }
+      : {}),
+    ...(paymentResponse !== undefined
+      ? { paymentResponse: cloneValidationValue(paymentResponse) }
+      : {}),
+  };
+}
+
+/**
+ * Runs the optional caller-owned paid-response validator on a paid tool result.
+ *
+ * @param validator - Caller-supplied validator, if any
+ * @param result - Live paid tool result about to be returned
+ * @param context - Validation context with optional seller and settlement fields
+ */
+export async function applyValidatePaidToolResult(
+  validator: ValidatePaidResponse | undefined,
+  result: MCPResultWithMeta,
+  context: ValidatePaidResponseContext,
+): Promise<void> {
+  if (!validator) {
+    return;
+  }
+
+  const paymentResponse = context.paymentResponse;
+  let view: PaidResponseValidationView;
+  let validationContext: ValidatePaidResponseContext;
+
+  try {
+    view = createPaidResponseValidationView(result);
+    validationContext = buildValidationContext(context);
+  } catch (error) {
+    throw new PaidResponseValidationError(
+      PAID_RESPONSE_DETACH_FAILURE,
+      preserveResultEvidence(result),
+      context.paymentPayload,
+      context.recovered,
+      context.paymentRequired,
+      paymentResponse,
+      error,
+    );
+  }
+
+  try {
+    await validator(view, validationContext);
+  } catch (error) {
+    const message =
+      error instanceof Error && error.message ? error.message : "Paid response validation failed";
+    throw new PaidResponseValidationError(
+      message,
+      preserveResultEvidence(result),
+      context.paymentPayload,
+      context.recovered,
+      context.paymentRequired,
+      paymentResponse,
+      error,
+    );
+  }
+}

--- a/typescript/packages/mcp/src/client/x402MCPClient.ts
+++ b/typescript/packages/mcp/src/client/x402MCPClient.ts
@@ -28,6 +28,7 @@ import {
   isPaymentRequiredError,
 } from "../types";
 import { extractPaymentResponseFromMeta } from "../utils";
+import { applyValidatePaidToolResult } from "./paidResponseValidation";
 
 // ============================================================================
 // MCP SDK Result Types
@@ -83,6 +84,49 @@ function isMCPCallToolResult(result: unknown): result is MCPCallToolResult {
   return Array.isArray(obj.content);
 }
 
+/**
+ * Maps an MCP SDK tool result into the internal result-with-meta shape.
+ *
+ * @param result - Raw MCP SDK tool result
+ * @returns Internal result including structured content and meta when present
+ */
+function toResultWithMeta(result: MCPCallToolResult): MCPResultWithMeta {
+  return {
+    content: result.content,
+    ...(result.isError !== undefined ? { isError: result.isError } : {}),
+    ...(result.structuredContent !== undefined
+      ? { structuredContent: result.structuredContent }
+      : {}),
+    ...(result._meta !== undefined ? { _meta: result._meta } : {}),
+  };
+}
+
+/**
+ * Maps an MCP SDK tool result into the public x402 MCP tool call result.
+ *
+ * @param result - Raw MCP SDK tool result
+ * @param paymentMade - Whether a payment was submitted for this call
+ * @param paymentResponse - Settlement metadata when present on the paid result
+ * @param includeStructuredContent - When true, expose structured content on the public result
+ * @returns Public tool call result
+ */
+function toToolCallResult(
+  result: MCPCallToolResult,
+  paymentMade: boolean,
+  paymentResponse?: SettleResponse,
+  includeStructuredContent = false,
+): x402MCPToolCallResult {
+  return {
+    content: result.content,
+    ...(includeStructuredContent && result.structuredContent !== undefined
+      ? { structuredContent: result.structuredContent }
+      : {}),
+    ...(result.isError !== undefined ? { isError: result.isError } : {}),
+    ...(paymentResponse !== undefined ? { paymentResponse } : {}),
+    paymentMade,
+  };
+}
+
 // ============================================================================
 // Hook Types
 // ============================================================================
@@ -113,9 +157,11 @@ export type AfterPaymentHook = (context: {
 export interface x402MCPToolCallResult {
   /** The tool result content, forwarded directly from MCP SDK */
   content: MCPContentItem[];
+  /** Structured tool result when returned after caller-owned validation accepts */
+  structuredContent?: Record<string, unknown>;
   /** Whether the tool returned an error */
   isError?: boolean;
-  /** Payment settlement response if payment was made */
+  /** Payment settlement response when the paid result included it */
   paymentResponse?: SettleResponse;
   /** Whether payment was required and submitted */
   paymentMade: boolean;
@@ -172,7 +218,8 @@ export interface x402MCPToolCallResult {
 export class x402MCPClient {
   private readonly mcpClient: Client;
   private readonly _paymentClient: x402Client;
-  private readonly options: Required<x402MCPClientOptions>;
+  private readonly options: Required<Omit<x402MCPClientOptions, "validatePaidResponse">> &
+    Pick<x402MCPClientOptions, "validatePaidResponse">;
   private readonly paymentRequiredHooks: PaymentRequiredHook[] = [];
   private readonly beforePaymentHooks: BeforePaymentHook[] = [];
   private readonly afterPaymentHooks: AfterPaymentHook[] = [];
@@ -194,6 +241,7 @@ export class x402MCPClient {
     this.options = {
       autoPayment: options.autoPayment ?? true,
       onPaymentRequested: options.onPaymentRequested ?? (() => true),
+      validatePaidResponse: options.validatePaidResponse,
     };
   }
 
@@ -502,11 +550,7 @@ export class x402MCPClient {
 
     if (!paymentRequired) {
       // Not a payment required response, forward original MCP response as-is
-      return {
-        content: result.content,
-        isError: result.isError,
-        paymentMade: false,
-      };
+      return toToolCallResult(result, false);
     }
 
     // Payment required - run onPaymentRequired hooks first
@@ -525,7 +569,13 @@ export class x402MCPClient {
         }
         if (hookResult.payment) {
           // Use the hook-provided payment
-          return this.callToolWithPayment(name, args, hookResult.payment, options);
+          return this.callToolWithPayment(
+            name,
+            args,
+            hookResult.payment,
+            options,
+            paymentRequired,
+          );
         }
       }
     }
@@ -564,7 +614,7 @@ export class x402MCPClient {
     const paymentPayload = await this._paymentClient.createPaymentPayload(paymentRequired);
 
     // Retry with payment
-    return this.callToolWithPayment(name, args, paymentPayload, options);
+    return this.callToolWithPayment(name, args, paymentPayload, options, paymentRequired);
   }
 
   /**
@@ -580,6 +630,7 @@ export class x402MCPClient {
    * @param options.timeout - Request timeout in milliseconds (default: 60000)
    * @param options.signal - AbortSignal for cancellation
    * @param options.resetTimeoutOnProgress - If true, progress notifications reset the timeout
+   * @param sellerPaymentRequired - Seller requirement from the original 402 when known
    * @returns The tool result with payment metadata
    */
   async callToolWithPayment(
@@ -587,8 +638,8 @@ export class x402MCPClient {
     args: Record<string, unknown>,
     paymentPayload: PaymentPayload,
     options?: { timeout?: number; signal?: AbortSignal; resetTimeoutOnProgress?: boolean },
+    sellerPaymentRequired?: PaymentRequired,
   ): Promise<x402MCPToolCallResult> {
-    // Build the call parameters with payment metadata
     // Note: The MCP SDK's callTool accepts _meta but the types don't always expose it
     const callParams = {
       name,
@@ -607,11 +658,7 @@ export class x402MCPClient {
     }
 
     // Build result with meta for extraction (preserve _meta if present)
-    const resultWithMeta: MCPResultWithMeta = {
-      content: result.content,
-      isError: result.isError,
-      _meta: result._meta,
-    };
+    const resultWithMeta = toResultWithMeta(result);
 
     // Extract payment response from _meta
     const paymentResponse = extractPaymentResponseFromMeta(resultWithMeta);
@@ -626,13 +673,13 @@ export class x402MCPClient {
       });
     }
 
-    const paymentRequired = this.extractPaymentRequiredFromResult(result);
+    const embeddedPaymentRequired = this.extractPaymentRequiredFromResult(result);
     const recoveryResult = paymentPayload.accepted
       ? await this._paymentClient.handlePaymentResponse({
         paymentPayload,
         requirements: paymentPayload.accepted,
         ...(paymentResponse ? { settleResponse: paymentResponse } : {}),
-        ...(paymentRequired ? { paymentRequired } : {}),
+        ...(embeddedPaymentRequired ? { paymentRequired: embeddedPaymentRequired } : {}),
       })
       : undefined;
 
@@ -640,11 +687,11 @@ export class x402MCPClient {
     // state from it, then we retry once with a fresh payload from that response.
     // Corrective terms (amount/asset/payTo) are server-controlled — re-run the
     // same approval / abort gates used for the first payment before signing again.
-    if (recoveryResult?.recovered && paymentRequired) {
+    if (recoveryResult?.recovered && embeddedPaymentRequired) {
       const correctiveRequiredContext: PaymentRequiredContext = {
         toolName: name,
         arguments: args,
-        paymentRequired,
+        paymentRequired: embeddedPaymentRequired,
       };
       let correctivePayload: PaymentPayload | undefined;
       for (const hook of this.paymentRequiredHooks) {
@@ -661,7 +708,7 @@ export class x402MCPClient {
         const correctiveRequestedContext: PaymentRequestedContext = {
           toolName: name,
           arguments: args,
-          paymentRequired,
+          paymentRequired: embeddedPaymentRequired,
         };
         const correctiveApproved =
           await this.options.onPaymentRequested(correctiveRequestedContext);
@@ -671,7 +718,7 @@ export class x402MCPClient {
         for (const hook of this.beforePaymentHooks) {
           await hook(correctiveRequestedContext);
         }
-        correctivePayload = await this._paymentClient.createPaymentPayload(paymentRequired);
+        correctivePayload = await this._paymentClient.createPaymentPayload(embeddedPaymentRequired);
       }
 
       const freshPayload = correctivePayload;
@@ -688,11 +735,7 @@ export class x402MCPClient {
         throw new Error("Invalid MCP tool result: missing content array");
       }
 
-      const retryResultWithMeta: MCPResultWithMeta = {
-        content: retryResult.content,
-        isError: retryResult.isError,
-        _meta: retryResult._meta,
-      };
+      const retryResultWithMeta = toResultWithMeta(retryResult);
       const retryPaymentResponse = extractPaymentResponseFromMeta(retryResultWithMeta);
 
       for (const hook of this.afterPaymentHooks) {
@@ -704,33 +747,52 @@ export class x402MCPClient {
         });
       }
 
-      const retryCorrectivePaymentRequired = this.extractPaymentRequiredFromResult(retryResult);
+      const retryEmbeddedPaymentRequired = this.extractPaymentRequiredFromResult(retryResult);
       if (freshPayload.accepted) {
         await this._paymentClient.handlePaymentResponse({
           paymentPayload: freshPayload,
           requirements: freshPayload.accepted,
           ...(retryPaymentResponse ? { settleResponse: retryPaymentResponse } : {}),
-          ...(retryCorrectivePaymentRequired
-            ? { paymentRequired: retryCorrectivePaymentRequired }
+          ...(retryEmbeddedPaymentRequired
+            ? { paymentRequired: retryEmbeddedPaymentRequired }
             : {}),
         });
       }
 
-      return {
-        content: retryResult.content,
-        isError: retryResult.isError,
-        paymentResponse: retryPaymentResponse ?? undefined,
-        paymentMade: true,
-      };
+      if (!retryEmbeddedPaymentRequired) {
+        await this.validatePaidToolResultIfNeeded(
+          retryResultWithMeta,
+          embeddedPaymentRequired,
+          freshPayload,
+          true,
+          retryPaymentResponse ?? undefined,
+        );
+      }
+
+      return toToolCallResult(
+        retryResult,
+        true,
+        retryPaymentResponse ?? undefined,
+        this.options.validatePaidResponse !== undefined,
+      );
     }
 
-    // Forward original MCP response content as-is
-    return {
-      content: result.content,
-      isError: result.isError,
-      paymentResponse: paymentResponse ?? undefined,
-      paymentMade: true,
-    };
+    if (!embeddedPaymentRequired) {
+      await this.validatePaidToolResultIfNeeded(
+        resultWithMeta,
+        sellerPaymentRequired,
+        paymentPayload,
+        false,
+        paymentResponse ?? undefined,
+      );
+    }
+
+    return toToolCallResult(
+      result,
+      true,
+      paymentResponse ?? undefined,
+      this.options.validatePaidResponse !== undefined,
+    );
   }
 
   /**
@@ -790,6 +852,30 @@ export class x402MCPClient {
   // ============================================================================
   // Private Methods
   // ============================================================================
+
+  /**
+   * Runs optional caller-owned validation on a final paid application result.
+   *
+   * @param resultWithMeta - Live paid tool result
+   * @param sellerPaymentRequired - Seller requirement when known
+   * @param paymentPayload - Payment payload used for the paid attempt
+   * @param recovered - Whether this is the bounded recovery path
+   * @param paymentResponse - Settlement metadata when present on the paid result
+   */
+  private async validatePaidToolResultIfNeeded(
+    resultWithMeta: MCPResultWithMeta,
+    sellerPaymentRequired: PaymentRequired | undefined,
+    paymentPayload: PaymentPayload,
+    recovered: boolean,
+    paymentResponse?: SettleResponse,
+  ): Promise<void> {
+    await applyValidatePaidToolResult(this.options.validatePaidResponse, resultWithMeta, {
+      recovered,
+      paymentPayload,
+      ...(sellerPaymentRequired !== undefined ? { paymentRequired: sellerPaymentRequired } : {}),
+      ...(paymentResponse !== undefined ? { paymentResponse } : {}),
+    });
+  }
 
   /**
    * Extracts PaymentRequired from a tool result (structured 402 response).
@@ -931,6 +1017,9 @@ export interface x402MCPClientConfig {
    * Return true to proceed with payment, false to abort.
    */
   onPaymentRequested?: (context: PaymentRequestedContext) => Promise<boolean> | boolean;
+
+  /** Optional caller-owned paid-response validation (see x402MCPClientOptions). */
+  validatePaidResponse?: x402MCPClientOptions["validatePaidResponse"];
 
   /**
    * Additional MCP client options
@@ -1079,5 +1168,6 @@ export function createx402MCPClient(config: x402MCPClientConfig): x402MCPClient 
   return new x402MCPClient(mcpClient, paymentClient, {
     autoPayment: config.autoPayment,
     onPaymentRequested: config.onPaymentRequested,
+    validatePaidResponse: config.validatePaidResponse,
   });
 }

--- a/typescript/packages/mcp/src/index.ts
+++ b/typescript/packages/mcp/src/index.ts
@@ -17,6 +17,7 @@ export type {
   x402MCPClientConfig,
   MCPContentItem,
 } from "./client";
+export { PaidResponseValidationError } from "./client";
 
 // Server exports
 export { createPaymentWrapper } from "./server";
@@ -61,6 +62,9 @@ export type {
   PaymentRequiredContext,
   PaymentRequiredHookResult,
   PaymentRequiredHook,
+  PaidResponseValidationView,
+  ValidatePaidResponseContext,
+  ValidatePaidResponse,
 } from "./types";
 
 // Utility exports

--- a/typescript/packages/mcp/src/types/mcp.ts
+++ b/typescript/packages/mcp/src/types/mcp.ts
@@ -152,6 +152,35 @@ export type PaymentRequiredHook = (
 ) => Promise<PaymentRequiredHookResult | void> | PaymentRequiredHookResult | void;
 
 /**
+ * Detached snapshot given to a caller-owned paid-response validator.
+ */
+export type PaidResponseValidationView = {
+  content: ToolContentItem[];
+  isError?: boolean;
+  structuredContent?: Record<string, unknown>;
+};
+
+/**
+ * Context passed to a caller-owned paid-response validator.
+ */
+export type ValidatePaidResponseContext = {
+  /** Seller requirement from the original 402 when known (e.g. via `callTool`). */
+  paymentRequired?: PaymentRequired;
+  recovered: boolean;
+  /** Settlement metadata when the paid result included it. */
+  paymentResponse?: SettleResponse;
+  paymentPayload: PaymentPayload;
+};
+
+/**
+ * Optional caller-owned check of a paid application tool result.
+ */
+export type ValidatePaidResponse = (
+  result: PaidResponseValidationView,
+  context: ValidatePaidResponseContext,
+) => void | Promise<void>;
+
+/**
  * Options for x402MCPClient
  */
 export interface x402MCPClientOptions {
@@ -173,6 +202,15 @@ export interface x402MCPClientOptions {
    * This can be used to implement human-in-the-loop approval.
    */
   onPaymentRequested?: (context: PaymentRequestedContext) => Promise<boolean> | boolean;
+
+  /**
+   * When set, runs on the final paid application result after any present
+   * settlement metadata has been processed (ordinary and bounded recovery paths),
+   * before the result is returned. The callback receives a detached view; the
+   * original tool result and settlement evidence are preserved on
+   * PaidResponseValidationError. Absent by default; current behavior is unchanged.
+   */
+  validatePaidResponse?: ValidatePaidResponse;
 }
 
 /**
@@ -257,9 +295,11 @@ export interface ToolContentItem {
 export interface MCPToolResultWithPayment {
   /** Standard MCP tool result content */
   content: ToolContentItem[];
+  /** Structured tool result when provided by the server */
+  structuredContent?: Record<string, unknown>;
   /** Whether the tool execution resulted in an error */
   isError?: boolean;
-  /** Payment response metadata (settlement info) */
+  /** Payment response metadata when the paid result included it */
   paymentResponse?: SettleResponse;
 }
 
@@ -297,6 +337,8 @@ export interface MCPMetaWithPaymentResponse {
 export interface MCPResultWithMeta {
   /** Tool result content */
   content?: ToolContentItem[];
+  /** Structured tool result when provided by the server */
+  structuredContent?: Record<string, unknown>;
   /** Whether the result is an error */
   isError?: boolean;
   /** Metadata including potential payment response */

--- a/typescript/packages/mcp/test/unit/client.test.ts
+++ b/typescript/packages/mcp/test/unit/client.test.ts
@@ -2,12 +2,18 @@
  * Unit tests for x402MCPClient
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { x402MCPClient, createx402MCPClient, wrapMCPClientWithPayment } from "../../src/client";
+import {
+  x402MCPClient,
+  createx402MCPClient,
+  wrapMCPClientWithPayment,
+  PaidResponseValidationError,
+} from "../../src/client";
 import {
   MCP_PAYMENT_REQUIRED_CODE,
   MCP_PAYMENT_META_KEY,
   JSONRPC_PAYMENT_REQUIRED_CODE,
 } from "../../src/types";
+import type { x402MCPClientOptions } from "../../src/types";
 import type { PaymentPayload, PaymentRequired, SettleResponse } from "@x402/core/types";
 import { x402Client } from "@x402/core/client";
 
@@ -1084,6 +1090,305 @@ describe("x402MCPClient McpError(-32042) handling", () => {
       mockMcpClient.callTool.mockRejectedValueOnce(networkError);
 
       await expect(client.getToolPaymentRequirements("tool")).rejects.toThrow(networkError);
+    });
+  });
+});
+
+describe("x402MCPClient paid-response validation", () => {
+  let mockMcpClient: MockMCPClient;
+  let mockPaymentClient: MockPaymentClient;
+
+  const paidApplicationResult = {
+    content: [{ type: "text", text: "paid body" }],
+    structuredContent: { ok: true, value: 42 },
+    _meta: { "x402/payment-response": mockSettleResponse, trace: "abc" },
+  };
+
+  const createValidationClient = (options?: x402MCPClientOptions) =>
+    new x402MCPClient(
+      mockMcpClient as unknown as Parameters<typeof wrapMCPClientWithPayment>[0],
+      mockPaymentClient as unknown as Parameters<typeof wrapMCPClientWithPayment>[1],
+      options,
+    );
+
+  beforeEach(() => {
+    mockMcpClient = createMockMCPClient();
+    mockPaymentClient = createMockPaymentClient();
+  });
+
+  it("preserves default paid success when no validator is configured", async () => {
+    const client = createValidationClient();
+
+    mockMcpClient.callTool
+      .mockResolvedValueOnce(createEmbeddedPaymentError(mockPaymentRequired))
+      .mockResolvedValueOnce(paidApplicationResult);
+
+    const result = await client.callTool("paid_tool");
+
+    expect(result).toEqual({
+      content: paidApplicationResult.content,
+      paymentResponse: mockSettleResponse,
+      paymentMade: true,
+    });
+    expect(result).not.toHaveProperty("structuredContent");
+    expect(mockPaymentClient.createPaymentPayload).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns a valid paid body when the validator accepts it", async () => {
+    const validatePaidResponse = vi.fn();
+    const client = createValidationClient({ validatePaidResponse });
+
+    mockMcpClient.callTool
+      .mockResolvedValueOnce(createEmbeddedPaymentError(mockPaymentRequired))
+      .mockResolvedValueOnce(paidApplicationResult);
+
+    const result = await client.callTool("paid_tool");
+
+    expect(result.structuredContent).toEqual({ ok: true, value: 42 });
+    expect(validatePaidResponse).toHaveBeenCalledWith(
+      {
+        content: paidApplicationResult.content,
+        structuredContent: paidApplicationResult.structuredContent,
+      },
+      expect.objectContaining({
+        paymentRequired: mockPaymentRequired,
+        recovered: false,
+        paymentPayload: mockPaymentPayload,
+        paymentResponse: mockSettleResponse,
+      }),
+    );
+    expect(mockPaymentClient.createPaymentPayload).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws PaidResponseValidationError without retrying payment on invalid output", async () => {
+    const client = createValidationClient({
+      validatePaidResponse: () => {
+        throw new Error("missing required field");
+      },
+    });
+
+    mockMcpClient.callTool
+      .mockResolvedValueOnce(createEmbeddedPaymentError(mockPaymentRequired))
+      .mockResolvedValueOnce(paidApplicationResult);
+
+    await expect(client.callTool("paid_tool")).rejects.toMatchObject({
+      name: "PaidResponseValidationError",
+      message: "missing required field",
+      paymentResponse: mockSettleResponse,
+      paymentPayload: mockPaymentPayload,
+      paymentRequired: mockPaymentRequired,
+      recovered: false,
+      result: {
+        content: paidApplicationResult.content,
+        structuredContent: paidApplicationResult.structuredContent,
+        _meta: paidApplicationResult._meta,
+      },
+    });
+    expect(mockPaymentClient.createPaymentPayload).toHaveBeenCalledTimes(1);
+  });
+
+  it("validates the bounded recovery result with recovered=true", async () => {
+    const correctivePaymentRequired: PaymentRequired = {
+      ...mockPaymentRequired,
+      accepts: [
+        {
+          ...mockPaymentRequired.accepts[0],
+          extra: {
+            ...mockPaymentRequired.accepts[0].extra,
+            channelState: { chargedCumulativeAmount: "2000" },
+          },
+        },
+      ],
+    };
+    const freshPayload: PaymentPayload = {
+      ...mockPaymentPayload,
+      payload: { ...mockPaymentPayload.payload, signature: "0xfresh" },
+    };
+    const validatePaidResponse = vi.fn();
+    const client = createValidationClient({ validatePaidResponse });
+
+    mockPaymentClient.createPaymentPayload
+      .mockResolvedValueOnce(mockPaymentPayload)
+      .mockResolvedValueOnce(freshPayload);
+    mockPaymentClient.handlePaymentResponse
+      .mockResolvedValueOnce({ recovered: true })
+      .mockResolvedValueOnce(undefined);
+    mockMcpClient.callTool
+      .mockResolvedValueOnce(createEmbeddedPaymentError(mockPaymentRequired))
+      .mockResolvedValueOnce(createEmbeddedPaymentError(correctivePaymentRequired))
+      .mockResolvedValueOnce({
+        content: [{ type: "text", text: "recovered body" }],
+        structuredContent: { recovered: true },
+        _meta: { "x402/payment-response": mockSettleResponse },
+      });
+
+    await client.callTool("paid_tool");
+
+    expect(validatePaidResponse).toHaveBeenCalledWith(
+      {
+        content: [{ type: "text", text: "recovered body" }],
+        structuredContent: { recovered: true },
+      },
+      expect.objectContaining({
+        paymentRequired: correctivePaymentRequired,
+        recovered: true,
+        paymentPayload: freshPayload,
+        paymentResponse: mockSettleResponse,
+      }),
+    );
+    expect(mockPaymentClient.createPaymentPayload).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not create another payment when recovery output fails validation", async () => {
+    const correctivePaymentRequired: PaymentRequired = {
+      ...mockPaymentRequired,
+      accepts: [
+        {
+          ...mockPaymentRequired.accepts[0],
+          extra: {
+            ...mockPaymentRequired.accepts[0].extra,
+            channelState: { chargedCumulativeAmount: "2000" },
+          },
+        },
+      ],
+    };
+    const freshPayload: PaymentPayload = {
+      ...mockPaymentPayload,
+      payload: { ...mockPaymentPayload.payload, signature: "0xfresh" },
+    };
+    const client = createValidationClient({
+      validatePaidResponse: (_view, context) => {
+        if (context.recovered) {
+          throw new Error("invalid recovery output");
+        }
+      },
+    });
+
+    mockPaymentClient.createPaymentPayload
+      .mockResolvedValueOnce(mockPaymentPayload)
+      .mockResolvedValueOnce(freshPayload);
+    mockPaymentClient.handlePaymentResponse
+      .mockResolvedValueOnce({ recovered: true })
+      .mockResolvedValueOnce(undefined);
+    mockMcpClient.callTool
+      .mockResolvedValueOnce(createEmbeddedPaymentError(mockPaymentRequired))
+      .mockResolvedValueOnce(createEmbeddedPaymentError(correctivePaymentRequired))
+      .mockResolvedValueOnce({
+        content: [{ type: "text", text: "recovered body" }],
+        _meta: { "x402/payment-response": mockSettleResponse },
+      });
+
+    await expect(client.callTool("paid_tool")).rejects.toThrow("invalid recovery output");
+    expect(mockPaymentClient.createPaymentPayload).toHaveBeenCalledTimes(2);
+  });
+
+  it("fail-closes when the paid result cannot be detached for validation", async () => {
+    const cloneSpy = vi.spyOn(globalThis, "structuredClone").mockImplementation(() => {
+      throw new Error("clone blocked");
+    });
+
+    try {
+      const client = createValidationClient({
+        validatePaidResponse: () => {},
+      });
+
+      mockMcpClient.callTool
+        .mockResolvedValueOnce(createEmbeddedPaymentError(mockPaymentRequired))
+        .mockResolvedValueOnce(paidApplicationResult);
+
+      await expect(client.callTool("paid_tool")).rejects.toBeInstanceOf(
+        PaidResponseValidationError,
+      );
+      expect(mockPaymentClient.createPaymentPayload).toHaveBeenCalledTimes(1);
+    } finally {
+      cloneSpy.mockRestore();
+    }
+  });
+
+  it("does not let validator mutation alter the returned paid result", async () => {
+    const client = createValidationClient({
+      validatePaidResponse: view => {
+        view.content[0]!.text = "mutated";
+        view.structuredContent!.value = 999;
+      },
+    });
+
+    mockMcpClient.callTool
+      .mockResolvedValueOnce(createEmbeddedPaymentError(mockPaymentRequired))
+      .mockResolvedValueOnce(paidApplicationResult);
+
+    const result = await client.callTool("paid_tool");
+
+    expect(result.content).toEqual(paidApplicationResult.content);
+    expect(result.structuredContent).toEqual(paidApplicationResult.structuredContent);
+    expect(result.paymentResponse).toEqual(mockSettleResponse);
+  });
+
+  it("preserves original authority and settlement evidence when validator mutates context and rejects", async () => {
+    const client = createValidationClient({
+      validatePaidResponse: (_view, context) => {
+        if (context.paymentRequired) {
+          context.paymentRequired.resource.url = "https://mutated.example";
+        }
+        context.paymentPayload.payload.signature = "0xmutated";
+        if (context.paymentResponse) {
+          context.paymentResponse.success = false;
+          context.paymentResponse.transaction = "0xmutated";
+        }
+        throw new Error("rejected after mutation");
+      },
+    });
+
+    mockMcpClient.callTool
+      .mockResolvedValueOnce(createEmbeddedPaymentError(mockPaymentRequired))
+      .mockResolvedValueOnce(paidApplicationResult);
+
+    await expect(client.callTool("paid_tool")).rejects.toMatchObject({
+      name: "PaidResponseValidationError",
+      message: "rejected after mutation",
+      paymentRequired: mockPaymentRequired,
+      paymentPayload: mockPaymentPayload,
+      paymentResponse: mockSettleResponse,
+      recovered: false,
+      result: {
+        content: paidApplicationResult.content,
+        structuredContent: paidApplicationResult.structuredContent,
+        _meta: paidApplicationResult._meta,
+      },
+    });
+    expect(mockPaymentClient.createPaymentPayload).toHaveBeenCalledTimes(1);
+  });
+
+  it("validates direct callToolWithPayment without fabricating paymentRequired", async () => {
+    const validatePaidResponse = vi.fn();
+    const client = createValidationClient({ validatePaidResponse });
+
+    mockMcpClient.callTool.mockResolvedValueOnce(paidApplicationResult);
+
+    await client.callToolWithPayment("tool", {}, mockPaymentPayload);
+
+    expect(validatePaidResponse).toHaveBeenCalledTimes(1);
+    expect(validatePaidResponse.mock.calls[0]?.[1]).not.toHaveProperty("paymentRequired");
+  });
+
+  it("validates paid output without settlement metadata when none is present", async () => {
+    const validatePaidResponse = vi.fn();
+    const client = createValidationClient({ validatePaidResponse });
+
+    mockMcpClient.callTool
+      .mockResolvedValueOnce(createEmbeddedPaymentError(mockPaymentRequired))
+      .mockResolvedValueOnce({
+        content: [{ type: "text", text: "paid without receipt" }],
+        structuredContent: { ok: true },
+      });
+
+    await client.callTool("paid_tool");
+
+    expect(validatePaidResponse).toHaveBeenCalledTimes(1);
+    expect(validatePaidResponse.mock.calls[0]?.[1]).not.toHaveProperty("paymentResponse");
+    expect(validatePaidResponse.mock.calls[0]?.[1]).toMatchObject({
+      paymentRequired: mockPaymentRequired,
+      recovered: false,
     });
   });
 });


### PR DESCRIPTION
## Description

Add an optional caller-owned `validatePaidResponse` hook to `@x402/mcp`.

The hook runs on the final paid MCP tool result after any available settlement metadata has been processed, on both the ordinary path and the existing bounded recovery path. It receives detached copies of the application result and payment context. If validation rejects, `PaidResponseValidationError` preserves the original result and available payment evidence without issuing another payment.

The hook is absent by default. Existing callers keep the same public result shape and payment behavior. Seller `PaymentRequired` terms are passed only when the caller actually observed them, never synthesized from the payment payload.

AI-assisted implementation was used. I reviewed the complete final diff and independently replayed the package gates from a fresh clone of the signed public commit.

## Tests

- `npx --yes pnpm@11.25.0 install --filter @x402/mcp...`
- `npx --yes pnpm@11.25.0 --filter @x402/core build`
- `npx --yes pnpm@11.25.0 lint:check` in `typescript/packages/mcp`
- `npx --yes pnpm@11.25.0 format:check` in `typescript/packages/mcp`
- `npx --yes pnpm@11.25.0 test` in `typescript/packages/mcp`: 124 tests passed
- `npx --yes pnpm@11.25.0 build` in `typescript/packages/mcp`
- `git diff --check`

Focused coverage includes detached mutation isolation, rejected-output evidence preservation, absent settlement metadata, absent seller requirements for direct paid calls, the bounded recovery path, no extra payment after validation failure, and unchanged no-hook behavior.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing package tests pass
- [x] My commit is signed
- [x] I added a changelog fragment for the user-facing change
