### PR TITLE
feat(ts): add delegated receiver authorizer for SVM upto

### DIFF
--- a/docs/schemes/upto.mdx
+++ b/docs/schemes/upto.mdx
@@ -55,7 +55,7 @@ Set the route `price` to the maximum authorized amount. In the handler, use sett
       .register(
         "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",
         new UptoSvmScheme({
-          receiverAuthorizerSigner,
+          receiverAuthorizerSigner, // omit for facilitator-delegated mode
           rpcUrl: process.env.SVM_RPC_URL, // optional: embeds recentBlockhash in 402
         }),
       );
@@ -312,7 +312,14 @@ Setting the amount to `"0"` means no charge for that request. On SVM, a zero-amo
 
 `upto` on Solana uses the [payment-channels program](https://github.com/solana-foundation/payment-channels). The client escrows the ceiling amount in an onchain channel (`open`), and the server settles the actual amount with a signed voucher (`settle_and_seal` + `distribute`). The facilitator sponsors transaction fees and channel rent as a zero-share channel payee, and can always close abandoned channels to recover rent.
 
-The server must supply a `receiverAuthorizerSigner` — a hot key that signs settlement vouchers after metering. This key does not need to hold SOL or tokens.
+Every channel commits to a `receiverAuthorizer` (`authorized_signer`) that signs settlement vouchers. Pick one:
+
+| Mode | Server config | When to use |
+| ---- | ------------- | ----------- |
+| **Self-managed** (recommended) | Pass `receiverAuthorizerSigner` | Any facilitator can relay your signed vouchers; channels survive facilitator changes |
+| **Facilitator-delegated** | Omit `receiverAuthorizerSigner` | Simpler ops (no server hot key); requires a facilitator that advertises `receiverAuthorizer` and authenticates your settle requests out of band |
+
+Self-managed: pass a hot Ed25519 key that does not need SOL or tokens. Facilitator-delegated: the server picks up `extra.receiverAuthorizer` from the facilitator's `/supported` response; the facilitator signs claim vouchers after correlating deposit and claim settles to the same authenticated caller. The server validates this at startup — if no local signer is configured and the facilitator does not advertise a valid `receiverAuthorizer`, `initialize()` fails before the first request.
 
 For custom facilitator implementations, use `UptoSvmScheme` from the facilitator package. The scheme's rent cleanup manager asynchronously seals and reclaims rent from abandoned channels:
 
@@ -329,6 +336,10 @@ For custom facilitator implementations, use `UptoSvmScheme` from the facilitator
     );
     const svmUptoScheme = new UptoSvmScheme(svmSigner, {
       maxChannelLifetimeSecs: 3600,
+      // Optional: advertise receiverAuthorizer for delegated server mode.
+      // Requires resolveCallerIdentity — construction throws without it.
+      // authorizerSigner,
+      // resolveCallerIdentity: ctx => authenticateSettleCaller(ctx),
     });
 
     facilitator.register("solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1", svmUptoScheme);

--- a/examples/typescript/facilitator/upto/README.md
+++ b/examples/typescript/facilitator/upto/README.md
@@ -48,6 +48,71 @@ Tune policy with:
 
 For production, replace `InMemoryUptoChannelStorage` with a durable store so cleanup survives restarts and works across facilitator replicas.
 
+## SVM receiver authorizer (optional delegation)
+
+This example registers `UptoSvmScheme` with a **fee payer only** — no `authorizerSigner` is configured, so `/supported` advertises `extra.feePayer` but not `extra.receiverAuthorizer`. Servers must sign their own claim vouchers (self-managed mode).
+
+To let resource servers delegate voucher signing to your facilitator, extend the SVM registration with a separate Ed25519 key and a `resolveCallerIdentity` hook. Delegation is not negotiated in x402 — it requires an out-of-band agreement with each resource server, and authenticated settle requests so claim vouchers are signed only for that server.
+
+| Signer | Role | Onchain effect |
+| ------ | ---- | -------------- |
+| `SVM_PRIVATE_KEY` | **Fee payer** — co-signs channel `open`, submits claim/cleanup txs | Pays SOL for opens, settlement, and rent cleanup |
+| `authorizerSigner` (optional) | **Receiver authorizer** — signs claim vouchers when servers delegate | Committed as the channel `authorized_signer` for delegating servers |
+
+When `authorizerSigner` is set, `GET /supported` includes both `feePayer` and `receiverAuthorizer`:
+
+```json
+{
+  "kinds": [
+    {
+      "x402Version": 2,
+      "scheme": "upto",
+      "network": "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",
+      "extra": {
+        "feePayer": "...",
+        "receiverAuthorizer": "..."
+      }
+    }
+  ]
+}
+```
+
+Wire it in your facilitator:
+
+```typescript
+import { AsyncLocalStorage } from "node:async_hooks";
+import { createKeyPairSignerFromBytes } from "@solana/kit";
+import { base58 } from "@scure/base";
+import { UptoSvmScheme } from "@x402/svm/upto/facilitator";
+
+const authorizerSigner = await createKeyPairSignerFromBytes(
+  base58.decode(process.env.SVM_RECEIVER_AUTHORIZER_PRIVATE_KEY!),
+);
+
+// Request-scoped identity for resolveCallerIdentity (replace with JWT/SIWX/mTLS in production).
+const callerIdentity = new AsyncLocalStorage<string | undefined>();
+
+const scheme = new UptoSvmScheme(svmSigner, {
+  channelStorage,
+  maxChannelLifetimeSecs,
+  authorizerSigner,
+  resolveCallerIdentity: () => callerIdentity.getStore(),
+  // Optional for multi-replica facilitators; default is in-memory.
+  // delegatedAuthStore: sharedRedisDelegatedAuthStore,
+});
+
+// In POST /settle, authenticate the server and run settle inside the store:
+app.post("/settle", async (req, res) => {
+  const identity = authenticateServerSettleRequest(req); // your JWT / API credential check
+  const response = await callerIdentity.run(identity, () =>
+    facilitator.settle(paymentPayload, paymentRequirements),
+  );
+  res.json(response);
+});
+```
+
+> ⚠️ A facilitator that advertises `receiverAuthorizer` **must** authenticate that each claim settle comes from the same service whose deposit settle opened the channel (SIWX, JWT, mTLS, or an API credential correlated across both settles). The scheme records that identity at deposit and requires an exact match at claim. **Do not advertise `receiverAuthorizer` without real authentication.** The default identity binding store is in-memory; inject a shared `delegatedAuthStore` for multi-replica facilitators.
+
 ## API Endpoints
 
 Standard x402 facilitator surface: `POST /verify`, `POST /settle`, `GET /supported`.

--- a/specs/schemes/upto/scheme_upto_svm.md
+++ b/specs/schemes/upto/scheme_upto_svm.md
@@ -27,7 +27,8 @@ The x402 roles map to the payment-channel program as follows:
   stablecoin deposit.
 - **Server**: resource provider; receives funds at `payTo`; determines the
   actual metered charge after serving the resource.
-- **Receiver authorizer**: server-controlled hot key advertised as
+- **Receiver authorizer**: server-controlled hot key, or the facilitator's
+  advertised `receiverAuthorizer` when the server delegates; advertised as
   `extra.receiverAuthorizer`; set as channel `authorized_signer`; signs the
   settlement voucher that authorizes any nonzero charge. It does not need to
   hold SOL or token funds, and it never signs a transaction: the voucher
@@ -59,6 +60,11 @@ a facilitator that seals early (`has_voucher = 0`) freezes the watermark, and
 the unsettled remainder is refunded to the client. The server MUST therefore
 treat unsettled voucher value as facilitator credit risk and settle promptly.
 See [Security Properties](#8-security-properties).
+
+When the server delegates `receiverAuthorizer` to the facilitator, the
+lifecycle and payment authorities collapse into one party. The server
+additionally trusts the facilitator to settle the amount it asked for and no
+more.
 
 ## 2. Mapping the five core requirements to SVM
 
@@ -151,7 +157,7 @@ from `exact`.
 |---|---|---|---|
 | `paymentFlow` | string | no | Only supported value is `"escrow"`; omit to use that default. |
 | `feePayer` | string | yes | Base58 sponsor key from facilitator `/supported`. Set as channel `payee` (zero share) and `rent_payer`. Co-signs `open` as transaction fee payer, and signs settlement transactions as both fee payer and channel `payee`. MAY equal `receiverAuthorizer` for self-facilitation. |
-| `receiverAuthorizer` | string | yes | Server-defined Base58 key set as channel `authorized_signer`; signs settlement vouchers. |
+| `receiverAuthorizer` | string | yes | Server-defined Base58 key, or the facilitator's `/supported` `receiverAuthorizer` when the server delegates. Set as channel `authorized_signer`; signs settlement vouchers. |
 | `withdrawDelay` | number | yes | Server-defined `grace_period` in seconds. The client MUST encode this exact value in `open`; the facilitator MUST reject any other value. MUST be an integer greater than zero. SHOULD be `>= maxTimeoutSeconds`. |
 | `tokenProgram` | string | yes | `Tokenkeg...` or `TokenzQ...` (Token-2022); the client SHOULD verify it against the onchain mint owner. |
 | `memo` | string | no | Seller-defined UTF-8 string for the transaction's Memo instruction. When present, the client MUST use this value as the Memo instruction data instead of a random nonce. Maximum 256 bytes. Enables payment references (e.g. invoice IDs) without unique deposit addresses. |
@@ -241,6 +247,7 @@ Example: server uses an external facilitator for fee/rent sponsorship:
 | `deposit` | string | Onchain escrow amount. MUST equal `maxAmount`. |
 | `authorizedSigner` | string | MUST equal `extra.receiverAuthorizer`; included for explicit payload validation. Maps to the onchain `authorized_signer` account. |
 | `openTransaction` | string | Base64 partially signed `open` transaction. The client signature is present; the `feePayer`/`rent_payer` signature is still required before broadcast. |
+| `type` | string | Settle-only. `"deposit"` or `"claim"`. Set by the resource server on each `/settle`; not part of the client authorization, which is reused for both settles. REQUIRED when delegating. |
 
 `channelId` is the program-derived address:
 
@@ -279,7 +286,10 @@ The `open` instruction MUST encode:
 The voucher is not carried in the client's `PAYMENT-SIGNATURE` payload — the
 client signs only `open`. After metering, the server signs an Ed25519 voucher
 with `receiverAuthorizer` and transmits it to the facilitator in the settlement
-request (`payload.voucherSignature`; see Phase 4). The signed message is:
+request (`payload.voucherSignature`; see Phase 4). `voucherSignature` is
+included when the server owns the receiver-authorizer key; omitted when the
+channel delegates receiver authorization to the facilitator, which signs
+before submitting. The signed message is:
 
 ```text
 0x56 0x01 || channelId || u64(cumulativeAmount).le || i64(expiresAt).le
@@ -312,8 +322,9 @@ settled funds, refunds the client, and closes the escrow token account.
 
 ### Phase 1 - Setup
 
-The facilitator's `/supported` `extra` advertises `feePayer`. The server
-returns that `feePayer` together with its own `receiverAuthorizer` and
+The facilitator's `/supported` `extra` advertises `feePayer` and MAY advertise
+`receiverAuthorizer`. The server returns that `feePayer` together with its own
+`receiverAuthorizer` (or the facilitator's advertised key when delegating) and
 `withdrawDelay` in the 402 response. The client builds an `open` transaction
 against the canonical payment-channels program, deposits `maxAmount`, sets
 `payee` and `rent_payer` to `extra.feePayer`, sets `authorized_signer` to
@@ -342,7 +353,10 @@ unauthenticated, every claim settle (Phase 4) — including a zero-amount refund
 settlement amount, and `expiresAt`. That voucher is the facilitator's only proof
 that the claim came from the server and not an arbitrary caller, so the
 facilitator MUST reject any claim settle whose voucher is missing or not signed
-by `receiverAuthorizer`. The facilitator then constructs the `settle_and_seal`
+by `receiverAuthorizer`. When the channel delegates receiver authorization to
+the facilitator, the server omits `voucherSignature` and the facilitator
+authenticates the claim settle out of band (see Phase 4) before signing the
+voucher itself. The facilitator then constructs the `settle_and_seal`
 transaction itself and signs it as channel `payee` and transaction fee payer.
 Onchain, a nonzero amount applies the voucher (`has_voucher = 1`); a zero amount
 uses `has_voucher = 0` — the program requires `settled < cumulative_amount`, so
@@ -364,11 +378,15 @@ SVM `upto` uses the core `escrow` flow
 is not part of this ordering; it MAY be offered as a read-only preflight of the
 same static checks below without co-signing or broadcasting `open`.
 
-The facilitator distinguishes deposit vs claim settles from payload and channel
-state ([x402 v2 §7.2](../../x402-specification-v2.md)): no
+The facilitator distinguishes deposit vs claim settles from `payload.type` when
+present (`"deposit"` or `"claim"`). When `type` is absent, it falls back to
+payload and channel state
+([x402 v2 §7.2](../../x402-specification-v2.md)): no
 `payload.voucherSignature` and `paymentRequirements.amount == payload.maxAmount`
 → deposit (broadcast a fresh `open`; reject if the channel already exists);
-voucher present → claim (Phase 4); otherwise reject.
+voucher present → claim (Phase 4); otherwise reject. `type` is REQUIRED when
+delegating. The resource server stamps it per settle; it is not part of the
+client authorization.
 
 #### Client-supplied `openTransaction` acceptance policy
 
@@ -481,16 +499,19 @@ distribution, and rederived channel PDA.
 
 The server/facilitator MUST, in order:
 
-0. Reject any client-supplied `payload.voucherSignature`. The field is
-   claim-only and server-owned; presence on deposit settle
-   (including an empty string or `undefined` value) MUST fail with
-   `invalid_upto_svm_payload_unexpected_voucher`.
+0. Reject any client-supplied `payload.voucherSignature` or `payload.type`.
+   `voucherSignature` is claim-only and server-owned; presence on the client
+   payload (including an empty string or `undefined` value) MUST fail with
+   `invalid_upto_svm_payload_unexpected_voucher`. `type` is per-settle and
+   not part of the client authorization; presence on the client payload MUST
+   fail with `invalid_upto_svm_payload_type`.
 1. Confirm `payload.maxAmount` equals deposit-phase `requirements.amount`.
 2. Confirm `network`, `asset` (mint), `tokenProgram`, and `payTo` match the
    selected requirements.
 3. Confirm `extra.feePayer` is the sponsor key that will co-sign the
    transaction, `extra.receiverAuthorizer` is the server's configured receiver
-   authorizer, and `extra.withdrawDelay` is an integer greater than zero.
+   authorizer or the facilitator's advertised authorizer, and
+   `extra.withdrawDelay` is an integer greater than zero.
 4. Confirm the channel account does not already exist. If it does, reject with
    `invalid_upto_svm_channel_already_open`. Deposit settle MUST open the
    channel itself for this authorization; out-of-band opens, prior deposits,
@@ -546,14 +567,15 @@ The resource server initiates the claim settle by sending the facilitator a
 `settle` request. It reuses the same x402 settle envelope. Relative to the
 deposit settle: `paymentRequirements.amount` carries the actual metered charge,
 and the resource server attaches a `receiverAuthorizer` voucher signature to
-`paymentPayload.payload`. Because `settle` is unauthenticated, that voucher is
-REQUIRED on every claim settle — including a zero-amount settlement or refund —
-and is what proves the request came from the server.
+`paymentPayload.payload` when it owns the key. Because `settle` is
+unauthenticated, that voucher is REQUIRED on every self-managed claim settle —
+including a zero-amount settlement or refund — and is what proves the request
+came from the server.
 
 | Field | Value |
 |---|---|
 | `x402Version` | `2`. |
-| `paymentPayload` | The client authorization from `PAYMENT-SIGNATURE` (see section 4.2), carrying the signed ceiling (`maxAmount`, `deposit`), `channelId`, `expiresAt`, and the `open` transaction, plus the settle-time `payload.voucherSignature` the resource server adds (see below). `voucherSignature` is REQUIRED on every settle request, including `actual == 0`. |
+| `paymentPayload` | The client authorization from `PAYMENT-SIGNATURE` (see section 4.2), carrying the signed ceiling (`maxAmount`, `deposit`), `channelId`, `expiresAt`, and the `open` transaction, plus the settle-time `payload.type` and, when the server owns the key, `payload.voucherSignature` (see below). `voucherSignature` is included when the server owns the receiver-authorizer key; omitted when the channel delegates receiver authorization to the facilitator, which signs before submitting. |
 | `paymentRequirements` | The selected requirements with `amount` set to the **actual** metered charge for this request (`actual <= maxAmount`). Every other requirement field (`network`, `asset`, `payTo`, `extra`) is unchanged. |
 
 The actual charge travels on `paymentRequirements.amount`; the signed ceiling
@@ -567,11 +589,14 @@ metering, and the resource server attaches it to the settle-time
   over the voucher message defined in section 4.2
   (`0x56 0x01 || channelId || u64(cumulativeAmount).le || i64(expiresAt).le`),
   with `cumulativeAmount == paymentRequirements.amount` (which MAY be `0`).
-- It is REQUIRED on every settle request. The facilitator holds only `feePayer`
-  / `payee` and cannot produce it; because `settle` is unauthenticated, the
-  voucher is the facilitator's only proof that the request came from the server,
-  and it authorizes both nonzero settlement and zero-amount refunds (see
+- It is REQUIRED on every settle request when the server owns the key. The
+  facilitator holds only `feePayer` / `payee` and cannot produce it; because
+  `settle` is unauthenticated, the voucher is the facilitator's only proof that
+  the request came from the server, and it authorizes both nonzero settlement
+  and zero-amount refunds (see
   [Security Properties](#8-security-properties)).
+  If the channel delegates receiver authorization to the facilitator, the
+  server omits it and the facilitator signs before submitting.
 
 The application result determines the settled amount:
 
@@ -638,15 +663,18 @@ On a `settle` request the facilitator MUST:
    `invalid_upto_svm_payload_settlement_exceeds_amount`.
 3. Authenticate the request. Confirm
    `payload.authorizedSigner == extra.receiverAuthorizer` and that both equal
-   the channel's onchain `authorized_signer` (committed at `open`). Verify
-   `payload.voucherSignature` as a valid Ed25519 signature by that key over the
-   section 4.2 voucher message, reconstructed from `channelId`,
-   `cumulativeAmount == paymentRequirements.amount` (which MAY be `0`), and the
-   payload `expiresAt`. Reject the settle when the authorizer binding fails or
-   when `voucherSignature` is missing or invalid — because `settle` is
-   unauthenticated, this voucher is the only proof the request came from the
-   server, and it is REQUIRED even for a zero-amount refund (where
-   `has_voucher = 0` so the program will not re-check the signer). Then apply
+   the channel's onchain `authorized_signer` (committed at `open`). When
+   `voucherSignature` is present, verify it as a valid Ed25519 signature by
+   that key over the section 4.2 voucher message, reconstructed from
+   `channelId`, `cumulativeAmount == paymentRequirements.amount` (which MAY be
+   `0`), and the payload `expiresAt`. Reject the settle when the authorizer
+   binding fails or when the voucher is invalid. When `voucherSignature` is
+   absent, the channel MUST be delegated to this facilitator; authenticate
+   that the caller matches the identity bound to this `channelId` at deposit
+   and sign the voucher, or reject with
+   `invalid_upto_svm_authorizer_not_configured`,
+   `invalid_upto_svm_authorizer_address_mismatch`, or
+   `invalid_upto_svm_delegated_settle_unauthenticated`. Then apply
    it onchain:
    - For `actual > 0`, carry the verified voucher in the Ed25519 precompile that
      precedes `settle_and_seal` (`has_voucher = 1`).
@@ -655,7 +683,10 @@ On a `settle` request the facilitator MUST:
      because the program requires `settled < cumulative_amount`.
    In both cases, the `settle_and_seal` transaction MUST be signed by
    `extra.feePayer` as channel `payee`; the server's only signature is the
-   voucher, never a transaction.
+   voucher, never a transaction. In delegated mode the facilitator MUST bind
+   the authenticated caller identity to the `channelId` at the deposit settle,
+   before broadcasting `open`, and MUST reject a claim settle whose
+   authenticated caller does not match that binding.
 4. Sign as transaction `feePayer` and channel `payee`, broadcast the final
    transaction, and confirm a successful `distribute`. The usual bundle is
    Ed25519 precompile (for nonzero actual), `settle_and_seal`, then
@@ -785,7 +816,9 @@ restart, MUST perform the following flow:
 3. For an `Open` channel, the server may resume settlement only when it has
    recovered the application metering result and can produce the required
    `receiverAuthorizer` voucher. Otherwise it MUST NOT invent a nonzero
-   charge. The facilitator, as payee, may perform the no-voucher, zero-charge
+   charge. A facilitator that has lost the deposit-time binding MUST NOT
+   sign a delegated voucher and takes the zero-charge close path instead.
+   The facilitator, as payee, may perform the no-voucher, zero-charge
    close path (`settle_and_seal` with `has_voucher = 0`, then `distribute`,
    then `reclaim`) on its own; before doing so it SHOULD wait until
    `expiresAt` (plus optional grace). Abandon MUST NOT run before the
@@ -836,6 +869,16 @@ Standard x402 codes apply. Scheme-specific:
 - `duplicate_settlement` - the settlement cache already holds this settle phase
   for the channel; a concurrent or replayed deposit or claim settle MUST NOT
   broadcast.
+- `invalid_upto_svm_payload_type` - client supplied `type` on the
+  `PAYMENT-SIGNATURE` payload, or a delegated settle is missing `type`.
+- `invalid_upto_svm_authorizer_not_configured` - claim settle omitted
+  `voucherSignature` but this facilitator has no advertised `receiverAuthorizer`.
+- `invalid_upto_svm_authorizer_address_mismatch` - delegated claim settle
+  `authorizedSigner` / `extra.receiverAuthorizer` does not equal the
+  facilitator's advertised authorizer.
+- `invalid_upto_svm_delegated_settle_unauthenticated` - delegated deposit or
+  claim settle could not resolve a caller identity, or the claim identity does
+  not match the identity bound at deposit.
 - `CHANNEL_REQUIRED` (with `412`) - no open channel and no valid
   `openTransaction` that can be co-signed, broadcast, and confirmed before
   serving the resource.
@@ -850,12 +893,17 @@ Standard x402 codes apply. Scheme-specific:
   `rent_payer` / zero-share `payee`. It cannot sign vouchers, so it cannot
   settle any nonzero amount; that requires the server-controlled
   `receiverAuthorizer`. Because the `settle` endpoint is unauthenticated, every
-  server-initiated settle — including a zero-amount refund — MUST carry a
-  `receiverAuthorizer` voucher over its `channelId`, amount, and `expiresAt`;
-  the facilitator rejects a settle with a missing or invalid voucher, so an
-  arbitrary caller cannot force a premature seal or refund on a channel. The
-  facilitator's `settle_and_seal` authority only freezes the watermark and
-  triggers the program-fixed payout to `payTo` and refund to the client.
+  self-managed server-initiated settle — including a zero-amount refund — MUST
+  carry a `receiverAuthorizer` voucher over its `channelId`, amount, and
+  `expiresAt`; the facilitator rejects a settle with a missing or invalid
+  voucher, so an arbitrary caller cannot force a premature seal or refund on a
+  channel. The facilitator's `settle_and_seal` authority only freezes the
+  watermark and triggers the program-fixed payout to `payTo` and refund to the
+  client. When the server owns the key the voucher is the consent; when it
+  delegates, the facilitator MUST authenticate that each claim settle
+  originates from the service whose deposit settle opened the channel (SIWX,
+  JWT, or an API credential correlated across the two settles) and MUST NOT
+  advertise a `receiverAuthorizer` otherwise.
 - **Facilitator rent recovery.** Because the facilitator is the channel
   `payee`, it can always run `settle_and_seal` (`has_voucher = 0`), then
   `distribute`, then `reclaim` on its own. A colluding client/server pair

--- a/typescript/.changeset/fatal-startup-capability-errors.md
+++ b/typescript/.changeset/fatal-startup-capability-errors.md
@@ -1,0 +1,9 @@
+---
+"@x402/core": patch
+"@x402/express": patch
+"@x402/hono": patch
+"@x402/fastify": patch
+"@x402/next": patch
+---
+
+Exit the process when eager facilitator sync fails with a permanent capability or route-configuration error, instead of staying up until the first paid request. Transient facilitator timeouts remain retryable.

--- a/typescript/.changeset/svm-upto-delegated-authorizer.md
+++ b/typescript/.changeset/svm-upto-delegated-authorizer.md
@@ -1,0 +1,5 @@
+---
+"@x402/svm": minor
+---
+
+Add an optional facilitator-delegated receiver-authorizer mode to SVM `upto`. The facilitator may advertise `receiverAuthorizer` in `/supported`; a server that omits `receiverAuthorizerSigner` delegates voucher signing, and the facilitator signs after correlating the claim settle to the same authenticated caller that opened the channel.

--- a/typescript/packages/core/src/http/backgroundInit.ts
+++ b/typescript/packages/core/src/http/backgroundInit.ts
@@ -1,0 +1,33 @@
+import { FacilitatorCapabilityError } from "../types/facilitator";
+import { RouteConfigurationError } from "./x402HTTPResourceServer";
+
+/**
+ * Whether a resource-server initialize() failure is a permanent misconfiguration.
+ *
+ * Transient facilitator timeouts stay retryable on the next protected request.
+ * Capability and route mismatches will not become valid later and must not
+ * leave the process listening.
+ *
+ * @param error - The initialize() rejection reason
+ * @returns True when the process should exit rather than retry
+ */
+export function isFatalStartupInitError(error: unknown): boolean {
+  return error instanceof FacilitatorCapabilityError || error instanceof RouteConfigurationError;
+}
+
+/**
+ * Attaches a handler to the eager initialize() promise started by HTTP adapters.
+ *
+ * Retryable failures are swallowed so they are not unhandled rejections; the
+ * original promise is still awaited on the first protected request. Fatal
+ * configuration errors exit the process immediately.
+ *
+ * @param initPromise - The in-flight initialize() promise, or null when unused
+ */
+export function attachBackgroundInitHandler(initPromise: Promise<void> | null): void {
+  void initPromise?.catch(error => {
+    if (!isFatalStartupInitError(error)) return;
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/typescript/packages/core/src/http/index.ts
+++ b/typescript/packages/core/src/http/index.ts
@@ -118,8 +118,10 @@ export {
 export {
   FacilitatorResponseError,
   FacilitatorTimeoutError,
+  FacilitatorCapabilityError,
   getFacilitatorResponseError,
 } from "../types";
+export { attachBackgroundInitHandler, isFatalStartupInitError } from "./backgroundInit";
 export {
   x402HTTPClient,
   PaymentRequiredContext,

--- a/typescript/packages/core/src/server/index.ts
+++ b/typescript/packages/core/src/server/index.ts
@@ -61,8 +61,10 @@ export type { FacilitatorClient, FacilitatorConfig } from "../http/httpFacilitat
 export {
   FacilitatorResponseError,
   FacilitatorTimeoutError,
+  FacilitatorCapabilityError,
   getFacilitatorResponseError,
 } from "../types";
+export { attachBackgroundInitHandler, isFatalStartupInitError } from "../http/backgroundInit";
 
 export {
   x402HTTPResourceServer,

--- a/typescript/packages/core/src/server/x402ResourceServer.ts
+++ b/typescript/packages/core/src/server/x402ResourceServer.ts
@@ -4,6 +4,7 @@ import {
   VerifyResponse,
   SupportedResponse,
   SupportedKind,
+  FacilitatorCapabilityError,
 } from "../types/facilitator";
 import {
   PaymentPayload,
@@ -1626,9 +1627,7 @@ export class x402ResourceServer {
     }
 
     if (configErrors.length > 0) {
-      throw new Error(
-        `x402 facilitator capability errors:\n${configErrors.map(e => `  - ${e}`).join("\n")}`,
-      );
+      throw new FacilitatorCapabilityError(configErrors);
     }
   }
 

--- a/typescript/packages/core/src/types/facilitator.ts
+++ b/typescript/packages/core/src/types/facilitator.ts
@@ -155,6 +155,26 @@ export class FacilitatorTimeoutError extends FacilitatorResponseError {
 }
 
 /**
+ * Error thrown when a registered scheme's configuration is incompatible with
+ * the capabilities the facilitator advertised for that scheme and network.
+ */
+export class FacilitatorCapabilityError extends Error {
+  /** Human-readable problem lines, one per scheme/network mismatch. */
+  readonly problems: string[];
+
+  /**
+   * Creates a FacilitatorCapabilityError listing every capability problem.
+   *
+   * @param problems - Scheme/network problem lines to include in the message
+   */
+  constructor(problems: string[]) {
+    super(`x402 facilitator capability errors:\n${problems.map(e => `  - ${e}`).join("\n")}`);
+    this.name = "FacilitatorCapabilityError";
+    this.problems = problems;
+  }
+}
+
+/**
  * Walks an error cause chain to find the first facilitator response error.
  *
  * @param error - The thrown value to inspect

--- a/typescript/packages/core/src/types/index.ts
+++ b/typescript/packages/core/src/types/index.ts
@@ -11,6 +11,7 @@ export {
   SettleError,
   FacilitatorResponseError,
   FacilitatorTimeoutError,
+  FacilitatorCapabilityError,
   getFacilitatorResponseError,
 } from "./facilitator";
 export type {

--- a/typescript/packages/core/test/unit/http/backgroundInit.test.ts
+++ b/typescript/packages/core/test/unit/http/backgroundInit.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  attachBackgroundInitHandler,
+  isFatalStartupInitError,
+} from "../../../src/http/backgroundInit";
+import { RouteConfigurationError } from "../../../src/http/x402HTTPResourceServer";
+import { FacilitatorCapabilityError } from "../../../src/types/facilitator";
+
+describe("backgroundInit", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("isFatalStartupInitError", () => {
+    it("treats capability and route configuration errors as fatal", () => {
+      expect(
+        isFatalStartupInitError(new FacilitatorCapabilityError(["upto on solana:devnet: missing"])),
+      ).toBe(true);
+      expect(
+        isFatalStartupInitError(
+          new RouteConfigurationError([
+            {
+              routePattern: "GET /api/generate",
+              scheme: "upto",
+              network: "solana:devnet",
+              reason: "missing_facilitator",
+              message: "missing facilitator",
+            },
+          ]),
+        ),
+      ).toBe(true);
+    });
+
+    it("treats facilitator timeouts as retryable", () => {
+      expect(isFatalStartupInitError(new Error("facilitator request timed out"))).toBe(false);
+    });
+  });
+
+  describe("attachBackgroundInitHandler", () => {
+    it("exits the process on a capability mismatch", async () => {
+      const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+      vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+      attachBackgroundInitHandler(
+        Promise.reject(new FacilitatorCapabilityError(["upto on solana:devnet: missing"])),
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(exit).toHaveBeenCalledWith(1);
+    });
+
+    it("does not exit on a retryable facilitator timeout", async () => {
+      const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+
+      attachBackgroundInitHandler(Promise.reject(new Error("facilitator request timed out")));
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(exit).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/typescript/packages/core/test/unit/server/x402ResourceServer.test.ts
+++ b/typescript/packages/core/test/unit/server/x402ResourceServer.test.ts
@@ -15,7 +15,7 @@ import {
   buildSettleResponse,
 } from "../../mocks";
 import { Network } from "../../../src/types";
-import type { SettleResponse } from "../../../src/types/facilitator";
+import { FacilitatorCapabilityError, type SettleResponse } from "../../../src/types/facilitator";
 
 describe("x402ResourceServer", () => {
   describe("Construction", () => {
@@ -351,6 +351,7 @@ describe("x402ResourceServer", () => {
       server.register("eip155:8453" as Network, new ValidatingScheme("exact", "needs a signer"));
 
       await expect(server.initialize()).rejects.toThrow(/exact on eip155:8453: needs a signer/);
+      await expect(server.initialize()).rejects.toBeInstanceOf(FacilitatorCapabilityError);
     });
 
     it("resolves when the hook returns void", async () => {

--- a/typescript/packages/http/express/src/index.ts
+++ b/typescript/packages/http/express/src/index.ts
@@ -8,6 +8,7 @@ import {
   FacilitatorClient,
   FacilitatorResponseError,
   getFacilitatorResponseError,
+  attachBackgroundInitHandler,
   SETTLEMENT_OVERRIDES_HEADER,
   SettlementOverrides,
   checkIfBazaarNeeded,
@@ -102,11 +103,11 @@ export function paymentMiddlewareFromHTTPServer(
   // Store initialization promise (not the result)
   // httpServer.initialize() fetches facilitator support and validates routes
   let initPromise: Promise<void> | null = syncFacilitatorOnStart ? httpServer.initialize() : null;
-  // Attach a no-op rejection handler so an early failure (e.g. a facilitator
-  // request timeout) cannot become an unhandled rejection before the first
-  // protected request awaits initPromise. The original promise is kept, so that
-  // request still observes the failure and triggers the retry path.
-  void initPromise?.catch(() => {});
+  // Retryable failures (e.g. a facilitator timeout) must not become unhandled
+  // rejections; the original promise is still awaited on the first protected
+  // request. Fatal capability / route mismatches exit the process so a
+  // misconfigured server does not stay up until that request.
+  attachBackgroundInitHandler(initPromise);
   let isInitialized = false;
 
   /**

--- a/typescript/packages/http/fastify/src/index.ts
+++ b/typescript/packages/http/fastify/src/index.ts
@@ -9,6 +9,7 @@ import {
   FacilitatorClient,
   FacilitatorResponseError,
   getFacilitatorResponseError,
+  attachBackgroundInitHandler,
   SETTLEMENT_OVERRIDES_HEADER,
   SettlementOverrides,
   checkIfBazaarNeeded,
@@ -282,11 +283,11 @@ export function paymentMiddlewareFromHTTPServer(
   app.decorateRequest("x402RawGuard", undefined);
 
   let initPromise: Promise<void> | null = syncFacilitatorOnStart ? httpServer.initialize() : null;
-  // Attach a no-op rejection handler so an early failure (e.g. a facilitator
-  // request timeout) cannot become an unhandled rejection before the first
-  // protected request awaits initPromise. The original promise is kept, so that
-  // request still observes the failure and triggers the retry path.
-  void initPromise?.catch(() => {});
+  // Retryable failures (e.g. a facilitator timeout) must not become unhandled
+  // rejections; the original promise is still awaited on the first protected
+  // request. Fatal capability / route mismatches exit the process so a
+  // misconfigured server does not stay up until that request.
+  attachBackgroundInitHandler(initPromise);
   let isInitialized = false;
 
   /**

--- a/typescript/packages/http/hono/src/index.ts
+++ b/typescript/packages/http/hono/src/index.ts
@@ -8,6 +8,7 @@ import {
   FacilitatorClient,
   FacilitatorResponseError,
   getFacilitatorResponseError,
+  attachBackgroundInitHandler,
   SETTLEMENT_OVERRIDES_HEADER,
   SettlementOverrides,
   checkIfBazaarNeeded,
@@ -104,11 +105,11 @@ export function paymentMiddlewareFromHTTPServer(
   // Store initialization promise (not the result)
   // httpServer.initialize() fetches facilitator support and validates routes
   let initPromise: Promise<void> | null = syncFacilitatorOnStart ? httpServer.initialize() : null;
-  // Attach a no-op rejection handler so an early failure (e.g. a facilitator
-  // request timeout) cannot become an unhandled rejection before the first
-  // protected request awaits initPromise. The original promise is kept, so that
-  // request still observes the failure and triggers the retry path.
-  void initPromise?.catch(() => {});
+  // Retryable failures (e.g. a facilitator timeout) must not become unhandled
+  // rejections; the original promise is still awaited on the first protected
+  // request. Fatal capability / route mismatches exit the process so a
+  // misconfigured server does not stay up until that request.
+  attachBackgroundInitHandler(initPromise);
   let isInitialized = false;
 
   /**

--- a/typescript/packages/http/next/src/utils.ts
+++ b/typescript/packages/http/next/src/utils.ts
@@ -8,6 +8,7 @@ import {
   RoutesConfig,
   FacilitatorResponseError,
   getFacilitatorResponseError as getCoreFacilitatorResponseError,
+  attachBackgroundInitHandler,
   PaymentCancellationDispatcher,
   CompletedSettlement,
   SETTLEMENT_OVERRIDES_HEADER,
@@ -74,11 +75,11 @@ export function prepareHttpServer(
   // Store initialization promise (not the result)
   // httpServer.initialize() fetches facilitator support and validates routes
   let initPromise: Promise<void> | null = syncFacilitatorOnStart ? httpServer.initialize() : null;
-  // Attach a no-op rejection handler so an early failure (e.g. a facilitator
-  // request timeout) cannot become an unhandled rejection before the first
-  // protected request awaits initPromise. The original promise is kept, so that
-  // request still observes the failure and triggers the retry path.
-  void initPromise?.catch(() => {});
+  // Retryable failures (e.g. a facilitator timeout) must not become unhandled
+  // rejections; the original promise is still awaited on the first protected
+  // request. Fatal capability / route mismatches exit the process so a
+  // misconfigured server does not stay up until that request.
+  attachBackgroundInitHandler(initPromise);
   let isInitialized = false;
 
   return {

--- a/typescript/packages/mechanisms/svm/README.md
+++ b/typescript/packages/mechanisms/svm/README.md
@@ -51,7 +51,7 @@ Usage-based payments: authorize a ceiling, settle actual usage. See [Upto SVM Sc
 | Role | Import |
 |------|--------|
 | Client | `@x402/svm/upto/client` → `UptoSvmScheme` |
-| Server | `@x402/svm/upto/server` → `UptoSvmScheme` (requires `receiverAuthorizerSigner`) |
+| Server | `@x402/svm/upto/server` → `UptoSvmScheme` (requires `receiverAuthorizerSigner` unless the facilitator's `receiverAuthorizer` is delegated to) |
 | Facilitator | `@x402/svm/upto/facilitator` → `UptoSvmScheme` (requires `getSigner` on the facilitator signer) |
 
 ### V1 Package (`@x402/svm/v1`)

--- a/typescript/packages/mechanisms/svm/src/types.ts
+++ b/typescript/packages/mechanisms/svm/src/types.ts
@@ -50,8 +50,16 @@ export type UptoSvmPayloadV2 = {
   /**
    * Base58 Ed25519 voucher signature by `authorizedSigner`. Settle-only;
    * verify rejects any client-supplied value (including empty string).
+   * Omitted when the channel delegates receiver authorization to the facilitator.
    */
   voucherSignature?: string;
+  /**
+   * Per-settle phase stamped by the resource server. Not part of the client
+   * authorization (that payload is reused for deposit and claim). Verify
+   * rejects it if present. Required when the channel delegates receiver
+   * authorization.
+   */
+  type?: "deposit" | "claim";
 };
 
 /**
@@ -72,6 +80,7 @@ export function isUptoSvmPayload(payload: Record<string, unknown>): payload is U
     Number.isSafeInteger(payload.expiresAt) &&
     Number.isSafeInteger(payload.validAfter) &&
     typeof payload.nonce === "string" &&
-    (payload.voucherSignature === undefined || typeof payload.voucherSignature === "string")
+    (payload.voucherSignature === undefined || typeof payload.voucherSignature === "string") &&
+    (payload.type === undefined || payload.type === "deposit" || payload.type === "claim")
   );
 }

--- a/typescript/packages/mechanisms/svm/src/upto/README.md
+++ b/typescript/packages/mechanisms/svm/src/upto/README.md
@@ -34,11 +34,18 @@ client.register("solana:*", new UptoSvmScheme(signer));  // usage-based services
 
 ### Key Difference from Exact
 
-The upto client requires `paymentRequirements.extra.feePayer` and `extra.receiverAuthorizer` (provided via facilitator `getExtra()` and server enhancement). The client signs only the channel `open`; the facilitator co-signs as fee/rent payer and later submits settlement carrying the server's voucher.
+The upto client requires `paymentRequirements.extra.feePayer` and `extra.receiverAuthorizer` (provided via facilitator `getExtra()` and server enhancement). The client signs only the channel `open`; the facilitator co-signs as fee/rent payer and later submits settlement carrying a `receiverAuthorizer` voucher (server-signed, or facilitator-signed when delegated).
 
 ## Server Usage
 
-Register `UptoSvmScheme` with an `x402ResourceServer` and use `setSettlementOverrides` in your handler to specify the actual charge. The server must supply a hot `receiverAuthorizerSigner` that signs settlement vouchers (it does not need SOL or tokens).
+Register `UptoSvmScheme` with an `x402ResourceServer` and use `setSettlementOverrides` in your handler to specify the actual charge.
+
+### Receiver Authorizer
+
+The `receiverAuthorizer` signs settlement vouchers and is committed as the channel `authorized_signer` at deposit:
+
+- **Self-managed** (recommended): pass a `receiverAuthorizerSigner` (a hot Ed25519 key; it does not need SOL or tokens). Channels survive facilitator changes — any facilitator can relay your signed vouchers.
+- **Facilitator-delegated**: omit `receiverAuthorizerSigner`. The scheme picks up `extra.receiverAuthorizer` advertised by the facilitator's `/supported`. The server needs no voucher-signing key; the facilitator signs after authenticating that the claim settle comes from the same service that opened the channel.
 
 ```typescript
 import { paymentMiddleware, setSettlementOverrides, x402ResourceServer } from "@x402/express";
@@ -103,6 +110,11 @@ const svmSigner = toFacilitatorSvmSigner(keypair);
 const scheme = new UptoSvmScheme(svmSigner, {
   rpcUrl: process.env.SVM_RPC_URL,
   maxChannelLifetimeSecs: 3600,
+  // Optional: advertise a receiverAuthorizer so servers can delegate.
+  // Requires resolveCallerIdentity — construction throws without it.
+  authorizerSigner,
+  resolveCallerIdentity: ctx => currentRequestAuth(ctx).subject,
+  // Optional: shared store for multi-replica facilitators. Default is in-memory.
 });
 
 // Optional: reclaim PDA rent from sealed/distributed channels
@@ -121,7 +133,11 @@ the cleanup interval. Omit it to leave discovery off.
 pass, so await it during shutdown rather than exiting underneath a broadcast
 settle.
 
-The upto facilitator's `getExtra()` returns a `feePayer` address. That key is set as channel `payee` (zero distribution share) and `rent_payer`: it co-signs `open`, sponsors fees/rent, and signs `settle_and_seal`. Nonzero settlement still requires the server's `receiverAuthorizer` voucher.
+The upto facilitator's `getExtra()` returns a `feePayer` address and, when `authorizerSigner` is set, a `receiverAuthorizer`. `feePayer` is set as channel `payee` (zero distribution share) and `rent_payer`: it co-signs `open`, sponsors fees/rent, and signs `settle_and_seal`.
+
+A facilitator that advertises a `receiverAuthorizer` (so servers can delegate to it) must authenticate that each claim settle originates from the service whose deposit settle opened the channel (e.g. SIWX, JWT, or an API credential correlated across the two settles). The scheme records that identity at deposit and requires an exact match at claim. If the facilitator has no such authentication mechanism, omit `authorizerSigner` so no `receiverAuthorizer` is advertised; servers then supply their own voucher signatures.
+
+The default identity store is in-memory. A multi-replica facilitator must inject a shared `delegatedAuthStore`; a lost binding fails closed and the server cannot settle (the client still has `request_close`).
 
 ## Supported Networks
 
@@ -140,7 +156,7 @@ Canonical program id: `CHNLxYvVA28MJP9PrFuDXccuoGXAx7jBacfLEkahyGsX`
 2. Facilitator advertises `extra.feePayer`
 3. Client signs a payment-channel `open` that escrows the max amount
 4. Facilitator deposits by broadcasting `open` (escrow settle, before handler)
-5. Server performs work, calculates actual cost, and attaches a voucher via `setSettlementOverrides`
+5. Server performs work, calculates actual cost, and attaches `type` plus a voucher when it owns the key
 6. Facilitator claims with `settle_and_seal` + `distribute` for the actual amount (≤ max)
 7. If actual amount is `0`, the channel closes with a full refund to the client
 

--- a/typescript/packages/mechanisms/svm/src/upto/README.md
+++ b/typescript/packages/mechanisms/svm/src/upto/README.md
@@ -45,10 +45,11 @@ Register `UptoSvmScheme` with an `x402ResourceServer` and use `setSettlementOver
 The `receiverAuthorizer` signs settlement vouchers and is committed as the channel `authorized_signer` at deposit:
 
 - **Self-managed** (recommended): pass a `receiverAuthorizerSigner` (a hot Ed25519 key; it does not need SOL or tokens). Channels survive facilitator changes — any facilitator can relay your signed vouchers.
-- **Facilitator-delegated**: omit `receiverAuthorizerSigner`. The scheme picks up `extra.receiverAuthorizer` advertised by the facilitator's `/supported`. The server needs no voucher-signing key; the facilitator signs after authenticating that the claim settle comes from the same service that opened the channel.
+- **Facilitator-delegated**: omit `receiverAuthorizerSigner`. The scheme picks up `extra.receiverAuthorizer` advertised by the facilitator's `/supported`. The server needs no voucher-signing key; the facilitator signs after authenticating that the claim settle comes from the same service that opened the channel. Delegation requires an out-of-band agreement with the facilitator plus authenticated server→facilitator settle calls — it is not part of the client payment flow.
+
+Self-managed:
 
 ```typescript
-import { paymentMiddleware, setSettlementOverrides, x402ResourceServer } from "@x402/express";
 import { UptoSvmScheme } from "@x402/svm/upto/server";
 import { createKeyPairSignerFromBytes } from "@solana/kit";
 import { base58 } from "@scure/base";
@@ -57,15 +58,33 @@ const receiverAuthorizerSigner = await createKeyPairSignerFromBytes(
   base58.decode(process.env.SVM_RECEIVER_AUTHORIZER_PRIVATE_KEY!),
 );
 
+new UptoSvmScheme({
+  receiverAuthorizerSigner,
+  rpcUrl: process.env.SVM_RPC_URL, // optional: embeds recentBlockhash/recentSlot in 402
+});
+```
+
+Facilitator-delegated (omit `receiverAuthorizerSigner` only; `rpcUrl` unchanged):
+
+```typescript
+new UptoSvmScheme({
+  rpcUrl: process.env.SVM_RPC_URL, // optional: same as self-managed
+});
+```
+
+Full server wiring:
+
+```typescript
+import { paymentMiddleware, setSettlementOverrides, x402ResourceServer } from "@x402/express";
+import { UptoSvmScheme } from "@x402/svm/upto/server";
+
 const server = new x402ResourceServer(facilitatorClient).register(
   "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",
   new UptoSvmScheme({
-    receiverAuthorizerSigner,
-    rpcUrl: process.env.SVM_RPC_URL, // optional: embeds recentBlockhash/recentSlot in 402
+    receiverAuthorizerSigner, // omit for facilitator-delegated mode
+    rpcUrl: process.env.SVM_RPC_URL,
   }),
 );
-
-// In your route config, `price` is the maximum authorized amount:
 const routes = {
   "GET /api/generate": {
     accepts: {
@@ -106,9 +125,12 @@ For custom facilitator implementations:
 import { toFacilitatorSvmSigner } from "@x402/svm";
 import { UptoSvmScheme } from "@x402/svm/upto/facilitator";
 
-const svmSigner = toFacilitatorSvmSigner(keypair);
+// Pass the RPC URL to the signer, not to UptoSvmScheme
+const svmSigner = toFacilitatorSvmSigner(
+  keypair,
+  process.env.SVM_RPC_URL ? { defaultRpcUrl: process.env.SVM_RPC_URL } : undefined,
+);
 const scheme = new UptoSvmScheme(svmSigner, {
-  rpcUrl: process.env.SVM_RPC_URL,
   maxChannelLifetimeSecs: 3600,
   // Optional: advertise a receiverAuthorizer so servers can delegate.
   // Requires resolveCallerIdentity — construction throws without it.

--- a/typescript/packages/mechanisms/svm/src/upto/facilitator/delegatedAuthStore.ts
+++ b/typescript/packages/mechanisms/svm/src/upto/facilitator/delegatedAuthStore.ts
@@ -17,7 +17,28 @@ export interface UptoDelegatedAuthBinding {
   expiresAt: number;
 }
 
-/** Pluggable store of delegated deposit/claim caller-identity bindings. */
+/** Returned by {@link UptoDelegatedAuthStore.bind} when a different identity owns the key. */
+export class UptoDelegatedAuthIdentityConflictError extends Error {
+  /** Create an error when a channel already has a different delegated identity. */
+  constructor() {
+    super("delegated auth binding already exists for a different identity");
+    this.name = "UptoDelegatedAuthIdentityConflictError";
+  }
+}
+
+/**
+ * Pluggable store of delegated deposit/claim caller-identity bindings.
+ *
+ * `bind` is keyed by `(channelId, network)` and is first-writer-wins:
+ *
+ * - no existing row (or expired) → insert
+ * - existing row, same `callerIdentity` → success (idempotent retry after
+ *   bind-then-broadcast-fail)
+ * - existing row, different `callerIdentity` → {@link UptoDelegatedAuthIdentityConflictError}
+ *
+ * `get` returns `undefined` for not-found / expired and propagates store
+ * errors so a host can map infra failures separately from unauthenticated.
+ */
 export interface UptoDelegatedAuthStore {
   bind(binding: UptoDelegatedAuthBinding): Promise<void>;
   get(channelId: string, network: Network): Promise<UptoDelegatedAuthBinding | undefined>;
@@ -32,12 +53,21 @@ export class InMemoryUptoDelegatedAuthStore implements UptoDelegatedAuthStore {
   private readonly bindings = new Map<string, UptoDelegatedAuthBinding>();
 
   /**
-   * Record the caller identity for a channel.
+   * Record the caller identity for a channel. First writer wins: a later
+   * `bind` with the same identity is a no-op; a different identity is an error.
    *
    * @param binding - Channel, network, identity, and expiry
    */
   async bind(binding: UptoDelegatedAuthBinding): Promise<void> {
-    this.bindings.set(bindingKey(binding.channelId, binding.network), binding);
+    const key = bindingKey(binding.channelId, binding.network);
+    const existing = this.bindings.get(key);
+    if (existing && !delegatedAuthExpired(existing.expiresAt)) {
+      if (existing.callerIdentity === binding.callerIdentity) {
+        return;
+      }
+      throw new UptoDelegatedAuthIdentityConflictError();
+    }
+    this.bindings.set(key, binding);
   }
 
   /**
@@ -51,11 +81,11 @@ export class InMemoryUptoDelegatedAuthStore implements UptoDelegatedAuthStore {
     const key = bindingKey(channelId, network);
     const binding = this.bindings.get(key);
     if (!binding) return undefined;
-    if (binding.expiresAt <= Math.floor(Date.now() / 1000)) {
+    if (delegatedAuthExpired(binding.expiresAt)) {
       this.bindings.delete(key);
       return undefined;
     }
-    return binding;
+    return { ...binding };
   }
 
   /**
@@ -78,4 +108,14 @@ export class InMemoryUptoDelegatedAuthStore implements UptoDelegatedAuthStore {
  */
 function bindingKey(channelId: string, network: Network): string {
   return `${network}:${channelId}`;
+}
+
+/**
+ * Whether a delegated auth binding is past its payload `expiresAt`.
+ *
+ * @param expiresAt - Payload expiry (Unix seconds)
+ * @returns True when expired or at the expiry instant
+ */
+function delegatedAuthExpired(expiresAt: number): boolean {
+  return expiresAt <= Math.floor(Date.now() / 1000);
 }

--- a/typescript/packages/mechanisms/svm/src/upto/facilitator/delegatedAuthStore.ts
+++ b/typescript/packages/mechanisms/svm/src/upto/facilitator/delegatedAuthStore.ts
@@ -1,0 +1,81 @@
+import type { Network } from "@x402/core/types";
+
+/**
+ * Deposit-time caller identity bound to a channel so a later claim settle
+ * can be correlated to the same service.
+ *
+ * Kept off the rent-cleanup channel record: that record is re-upserted at
+ * claim time and is repopulated from chain by `discover()` with no identity
+ * available.
+ */
+export interface UptoDelegatedAuthBinding {
+  channelId: string;
+  network: Network;
+  /** Identity `resolveCallerIdentity` returned on the deposit settle. */
+  callerIdentity: string;
+  /** Payload `expiresAt` (Unix seconds); entries past it are unusable. */
+  expiresAt: number;
+}
+
+/** Pluggable store of delegated deposit/claim caller-identity bindings. */
+export interface UptoDelegatedAuthStore {
+  bind(binding: UptoDelegatedAuthBinding): Promise<void>;
+  get(channelId: string, network: Network): Promise<UptoDelegatedAuthBinding | undefined>;
+  delete(channelId: string, network: Network): Promise<void>;
+}
+
+/**
+ * In-memory {@link UptoDelegatedAuthStore}. A multi-replica facilitator must
+ * inject a shared implementation; a lost binding fails closed.
+ */
+export class InMemoryUptoDelegatedAuthStore implements UptoDelegatedAuthStore {
+  private readonly bindings = new Map<string, UptoDelegatedAuthBinding>();
+
+  /**
+   * Record the caller identity for a channel.
+   *
+   * @param binding - Channel, network, identity, and expiry
+   */
+  async bind(binding: UptoDelegatedAuthBinding): Promise<void> {
+    this.bindings.set(bindingKey(binding.channelId, binding.network), binding);
+  }
+
+  /**
+   * Look up a binding. Entries at or past `expiresAt` are treated as absent.
+   *
+   * @param channelId - Channel PDA
+   * @param network - CAIP-2 network the channel was opened on
+   * @returns Stored binding, or undefined when absent or expired
+   */
+  async get(channelId: string, network: Network): Promise<UptoDelegatedAuthBinding | undefined> {
+    const key = bindingKey(channelId, network);
+    const binding = this.bindings.get(key);
+    if (!binding) return undefined;
+    if (binding.expiresAt <= Math.floor(Date.now() / 1000)) {
+      this.bindings.delete(key);
+      return undefined;
+    }
+    return binding;
+  }
+
+  /**
+   * Remove a binding.
+   *
+   * @param channelId - Channel PDA
+   * @param network - CAIP-2 network the channel was opened on
+   */
+  async delete(channelId: string, network: Network): Promise<void> {
+    this.bindings.delete(bindingKey(channelId, network));
+  }
+}
+
+/**
+ * Composite key so the same PDA on two networks cannot collide.
+ *
+ * @param channelId - Channel PDA
+ * @param network - CAIP-2 network
+ * @returns Store key
+ */
+function bindingKey(channelId: string, network: Network): string {
+  return `${network}:${channelId}`;
+}

--- a/typescript/packages/mechanisms/svm/src/upto/facilitator/index.ts
+++ b/typescript/packages/mechanisms/svm/src/upto/facilitator/index.ts
@@ -25,7 +25,10 @@ export {
 export type { UptoSvmSigner } from "./channel";
 export { InMemoryUptoChannelStorage } from "./channelStorage";
 export type { UptoChannelRecord, UptoChannelStorage } from "./channelStorage";
-export { InMemoryUptoDelegatedAuthStore } from "./delegatedAuthStore";
+export {
+  InMemoryUptoDelegatedAuthStore,
+  UptoDelegatedAuthIdentityConflictError,
+} from "./delegatedAuthStore";
 export type { UptoDelegatedAuthBinding, UptoDelegatedAuthStore } from "./delegatedAuthStore";
 export {
   DEFAULT_ABANDON_GRACE_SECS,

--- a/typescript/packages/mechanisms/svm/src/upto/facilitator/index.ts
+++ b/typescript/packages/mechanisms/svm/src/upto/facilitator/index.ts
@@ -1,13 +1,21 @@
 export {
   DEFAULT_MAX_CHANNEL_LIFETIME_SECS,
+  ERR_AUTHORIZER_ADDRESS_MISMATCH,
+  ERR_AUTHORIZER_NOT_CONFIGURED,
   ERR_CHANNEL_ALREADY_OPEN,
   ERR_CHANNEL_LIFETIME_EXCEEDED,
+  ERR_DELEGATED_SETTLE_UNAUTHENTICATED,
   ERR_EXPIRES_AT_MISMATCH,
+  ERR_PAYLOAD_TYPE,
   ERR_SETTLEMENT_EXCEEDS_AMOUNT,
   ERR_UNEXPECTED_VOUCHER,
   UptoSvmScheme,
 } from "./scheme";
-export type { UptoChannelStorageErrorContext, UptoSvmFacilitatorConfig } from "./scheme";
+export type {
+  UptoChannelStorageErrorContext,
+  UptoDelegatedSettleContext,
+  UptoSvmFacilitatorConfig,
+} from "./scheme";
 export { ErrSettlementPending } from "../../exact/facilitator/errors";
 export {
   ChannelOpenConfirmationError,
@@ -17,6 +25,8 @@ export {
 export type { UptoSvmSigner } from "./channel";
 export { InMemoryUptoChannelStorage } from "./channelStorage";
 export type { UptoChannelRecord, UptoChannelStorage } from "./channelStorage";
+export { InMemoryUptoDelegatedAuthStore } from "./delegatedAuthStore";
+export type { UptoDelegatedAuthBinding, UptoDelegatedAuthStore } from "./delegatedAuthStore";
 export {
   DEFAULT_ABANDON_GRACE_SECS,
   DEFAULT_MAX_CLOSES_PER_RUN,

--- a/typescript/packages/mechanisms/svm/src/upto/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/svm/src/upto/facilitator/scheme.ts
@@ -111,6 +111,7 @@ export type UptoChannelStorageErrorContext = {
 
 /** Context passed to {@link UptoSvmFacilitatorConfig.resolveCallerIdentity}. */
 export type UptoDelegatedSettleContext = {
+  abortSignal?: AbortSignal;
   step: "deposit" | "claim";
   channelId: string;
   network: Network;
@@ -1491,7 +1492,12 @@ export class UptoSvmScheme implements SchemeNetworkFacilitator {
     if (!identity) {
       return this.settleFailure(payload, ERR_DELEGATED_SETTLE_UNAUTHENTICATED, p.from);
     }
-    const binding = await this.delegatedAuthStore.get(p.channelId, requirements.network);
+    let binding: Awaited<ReturnType<UptoDelegatedAuthStore["get"]>>;
+    try {
+      binding = await this.delegatedAuthStore.get(p.channelId, requirements.network);
+    } catch {
+      return this.settleFailure(payload, ERR_DELEGATED_SETTLE_UNAUTHENTICATED, p.from);
+    }
     if (!binding || binding.callerIdentity !== identity) {
       return this.settleFailure(payload, ERR_DELEGATED_SETTLE_UNAUTHENTICATED, p.from);
     }

--- a/typescript/packages/mechanisms/svm/src/upto/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/svm/src/upto/facilitator/scheme.ts
@@ -1,5 +1,6 @@
-import type { Address } from "@solana/kit";
+import type { Address, MessagePartialSigner } from "@solana/kit";
 import type {
+  FacilitatorContext,
   Network,
   PaymentPayload,
   PaymentRequirements,
@@ -18,7 +19,11 @@ import {
   type ServerInstruction,
 } from "../../payment-channels/onchain";
 import { parseU64, verifyOpenTransaction } from "../../payment-channels/open";
-import { encodeVoucherMessageBytes, verifyVoucherSignature } from "../../payment-channels/voucher";
+import {
+  encodeVoucherMessageBytes,
+  signVoucher,
+  verifyVoucherSignature,
+} from "../../payment-channels/voucher";
 import { SettlementCache } from "../../settlement-cache";
 import type { FacilitatorSigningCapabilities, FacilitatorSvmSigner } from "../../signer";
 import { isUptoSvmPayload, type UptoSvmPayloadV2 } from "../../types";
@@ -53,6 +58,7 @@ import {
   type UptoChannelRecord,
   type UptoChannelStorage,
 } from "./channelStorage";
+import { InMemoryUptoDelegatedAuthStore, type UptoDelegatedAuthStore } from "./delegatedAuthStore";
 import { assertUptoFacilitatorSigner, type UptoFacilitatorSigner } from "./signer";
 import { UptoSvmRentCleanupManager } from "./rentCleanupManager";
 
@@ -78,6 +84,19 @@ export const ERR_CHANNEL_LIFETIME_EXCEEDED = "invalid_upto_svm_payload_channel_l
 /** Payload `expiresAt` later than `now + maxTimeoutSeconds` (+ skew). */
 export const ERR_EXPIRES_AT_MISMATCH = "invalid_upto_svm_payload_expires_at_mismatch";
 
+/** Claim settle omitted `voucherSignature` and this facilitator has no authorizer. */
+export const ERR_AUTHORIZER_NOT_CONFIGURED = "invalid_upto_svm_authorizer_not_configured";
+
+/** Delegated claim `authorizedSigner` / `extra.receiverAuthorizer` is not this facilitator. */
+export const ERR_AUTHORIZER_ADDRESS_MISMATCH = "invalid_upto_svm_authorizer_address_mismatch";
+
+/** Delegated settle identity missing, unresolved, or not the deposit-time binding. */
+export const ERR_DELEGATED_SETTLE_UNAUTHENTICATED =
+  "invalid_upto_svm_delegated_settle_unauthenticated";
+
+/** Client supplied `type`, or a delegated settle is missing `type`. */
+export const ERR_PAYLOAD_TYPE = "invalid_upto_svm_payload_type";
+
 /** Default facilitator `maxChannelLifetimeSecs` (1 hour). */
 export const DEFAULT_MAX_CHANNEL_LIFETIME_SECS = 3_600;
 
@@ -88,6 +107,19 @@ const EXPIRES_AT_CLOCK_SKEW_SECS = 60;
 export type UptoChannelStorageErrorContext = {
   channelId: string;
   phase: "verify" | "settle";
+};
+
+/** Context passed to {@link UptoSvmFacilitatorConfig.resolveCallerIdentity}. */
+export type UptoDelegatedSettleContext = {
+  step: "deposit" | "claim";
+  channelId: string;
+  network: Network;
+  payer: string;
+  amount: string;
+  expiresAt: number;
+  payload: PaymentPayload;
+  requirements: PaymentRequirements;
+  facilitatorContext?: FacilitatorContext;
 };
 
 /**
@@ -178,6 +210,27 @@ export interface UptoSvmFacilitatorConfig {
    * on a different replica still reconciles correctly.
    */
   pendingSettlementStore?: PendingSettlementStore;
+  /**
+   * Enables facilitator-delegated receiver authorization. Advertised as
+   * `/supported` `extra.receiverAuthorizer` and used to sign claim vouchers
+   * when the server omits `voucherSignature`. Requires
+   * {@link resolveCallerIdentity}.
+   */
+  authorizerSigner?: MessagePartialSigner;
+  /**
+   * Resolves a stable caller identity for a delegated settle. Returning
+   * `undefined` (or throwing) rejects the settle. Required when
+   * {@link authorizerSigner} is set.
+   */
+  resolveCallerIdentity?: (
+    ctx: UptoDelegatedSettleContext,
+  ) => Promise<string | undefined> | string | undefined;
+  /**
+   * Stores `channelId → caller identity` bindings written at deposit and
+   * checked at claim. Defaults to {@link InMemoryUptoDelegatedAuthStore}.
+   * Inject a shared implementation for a multi-replica facilitator.
+   */
+  delegatedAuthStore?: UptoDelegatedAuthStore;
 }
 
 type OpenAuthFailure = {
@@ -197,17 +250,18 @@ type OpenAuthContext = {
 /**
  * SVM facilitator for the `upto` payment scheme.
  *
- * Escrow flow: `/settle` without `voucherSignature` and with
- * `requirements.amount === payload.maxAmount` deposits (broadcasts `open`);
- * `/settle` with a server voucher claims (`settle_and_seal` + `distribute`).
- * `/verify` is an optional read-only preflight of the same static checks —
- * it never broadcasts.
+ * Escrow flow: `/settle` with `payload.type === "deposit"` (or, when `type` is
+ * absent, no `voucherSignature` and `requirements.amount === payload.maxAmount`)
+ * deposits (broadcasts `open`); `/settle` with `type === "claim"` or a server
+ * voucher claims (`settle_and_seal` + `distribute`). `/verify` is an optional
+ * read-only preflight of the same static checks — it never broadcasts.
  *
  * The fee payer holds the channel `payee` seat with a zero distribution share:
  * it signs `settle_and_seal` (lifecycle authority) and can always seal an
- * abandoned channel with `has_voucher = 0` to recover its rent, while any
- * nonzero settlement still requires the server's receiver-authorizer voucher
- * (payment authority).
+ * abandoned channel with `has_voucher = 0` to recover its rent. Nonzero
+ * settlement requires a receiver-authorizer voucher — signed by the server, or
+ * by this facilitator when the server delegates and the caller identity
+ * matches the deposit-time binding.
  *
  * Fee-payer selection matches the exact SVM facilitator: `getExtra` randomly
  * picks one of the configured signers so load is distributed across keys.
@@ -220,6 +274,9 @@ export class UptoSvmScheme implements SchemeNetworkFacilitator {
   private readonly channelStorage: UptoChannelStorage;
   private readonly settlementCache = new SettlementCache();
   private readonly pendingStore: PendingSettlementStore;
+  private readonly authorizerSigner: MessagePartialSigner | undefined;
+  private readonly resolveCallerIdentity: UptoSvmFacilitatorConfig["resolveCallerIdentity"];
+  private readonly delegatedAuthStore: UptoDelegatedAuthStore;
   private readonly signer: UptoFacilitatorSigner;
 
   private readonly getKitSigner: (feePayer: Address) => FacilitatorSigningCapabilities;
@@ -247,9 +304,15 @@ export class UptoSvmScheme implements SchemeNetworkFacilitator {
     if (this.signer.getAddresses().length === 0) {
       throw new Error("UptoSvmScheme requires at least one fee payer signer");
     }
+    if (config.authorizerSigner && !config.resolveCallerIdentity) {
+      throw new Error("authorizerSigner requires resolveCallerIdentity");
+    }
     this.config = config;
     this.channelStorage = config.channelStorage ?? new InMemoryUptoChannelStorage();
     this.pendingStore = config.pendingSettlementStore ?? new InMemoryPendingSettlementStore();
+    this.authorizerSigner = config.authorizerSigner;
+    this.resolveCallerIdentity = config.resolveCallerIdentity;
+    this.delegatedAuthStore = config.delegatedAuthStore ?? new InMemoryUptoDelegatedAuthStore();
   }
 
   /**
@@ -299,7 +362,11 @@ export class UptoSvmScheme implements SchemeNetworkFacilitator {
   getExtra(_: Network): Record<string, unknown> | undefined {
     const addresses = this.signer.getAddresses();
     const randomIndex = Math.floor(Math.random() * addresses.length);
-    return { feePayer: addresses[randomIndex] };
+    const extra: Record<string, unknown> = { feePayer: addresses[randomIndex] };
+    if (this.authorizerSigner) {
+      extra.receiverAuthorizer = this.authorizerSigner.address;
+    }
+    return extra;
   }
 
   /**
@@ -325,6 +392,7 @@ export class UptoSvmScheme implements SchemeNetworkFacilitator {
   ): Promise<VerifyResponse> {
     const auth = await this.validateOpenAuthorization(payload, requirements, {
       rejectVoucher: true,
+      rejectType: true,
     });
     if (!auth.ok) {
       return {
@@ -340,17 +408,20 @@ export class UptoSvmScheme implements SchemeNetworkFacilitator {
   /**
    * Deposit (open channel) or claim (settle_and_seal + distribute).
    *
-   * Discrimination (no settle phase on the wire):
+   * Prefers `payload.type` when present. When absent (older servers):
    * - no `voucherSignature` and `requirements.amount === payload.maxAmount` → deposit
    * - `voucherSignature` present → claim against the open channel
+   * `type` is required when the settle is delegated to this facilitator.
    *
    * @param payload - The payment payload
    * @param requirements - Deposit: amount = ceiling; claim: amount = actual charge
+   * @param context - Facilitator extensions (used by `resolveCallerIdentity`)
    * @returns The settlement response
    */
   async settle(
     payload: PaymentPayload,
     requirements: PaymentRequirements,
+    context?: FacilitatorContext,
   ): Promise<SettleResponse> {
     const raw = payload.payload as Record<string, unknown>;
     if (!isUptoSvmPayload(raw)) {
@@ -380,12 +451,23 @@ export class UptoSvmScheme implements SchemeNetworkFacilitator {
       return this.settleFailure(payload, ERR_SETTLEMENT_EXCEEDS_AMOUNT, p.from);
     }
 
+    const delegated = this.isDelegatedSettle(requirements);
+    if (p.type === "deposit") {
+      return this.settleDeposit(payload, requirements, p, context);
+    }
+    if (p.type === "claim") {
+      return this.settleClaim(payload, requirements, p, actual, payloadMaxAmount, context);
+    }
+    if (delegated) {
+      return this.settleFailure(payload, ERR_PAYLOAD_TYPE, p.from);
+    }
+
     const hasVoucher = Object.prototype.hasOwnProperty.call(raw, "voucherSignature");
     if (hasVoucher) {
-      return this.settleClaim(payload, requirements, p, actual, payloadMaxAmount);
+      return this.settleClaim(payload, requirements, p, actual, payloadMaxAmount, context);
     }
     if (actual === payloadMaxAmount) {
-      return this.settleDeposit(payload, requirements, p);
+      return this.settleDeposit(payload, requirements, p, context);
     }
     return this.settleFailure(payload, "invalid_upto_svm_payload_missing_voucher", p.from);
   }
@@ -467,13 +549,34 @@ export class UptoSvmScheme implements SchemeNetworkFacilitator {
    * @param payload - The payment payload
    * @param requirements - Requirements with amount = authorized ceiling
    * @param p - Typed upto payload (channelId is needed before open validation)
+   * @param context - Facilitator extensions (used by `resolveCallerIdentity`)
    * @returns Deposit settlement response
    */
   private async settleDeposit(
     payload: PaymentPayload,
     requirements: PaymentRequirements,
     p: UptoSvmPayloadV2,
+    context?: FacilitatorContext,
   ): Promise<SettleResponse> {
+    const delegated = this.isDelegatedSettle(requirements);
+    let depositIdentity: string | undefined;
+    if (delegated) {
+      depositIdentity = await this.resolveDelegatedCallerIdentity({
+        step: "deposit",
+        channelId: p.channelId,
+        network: requirements.network,
+        payer: p.from,
+        amount: requirements.amount,
+        expiresAt: p.expiresAt,
+        payload,
+        requirements,
+        facilitatorContext: context,
+      });
+      if (!depositIdentity) {
+        return this.settleFailure(payload, ERR_DELEGATED_SETTLE_UNAUTHENTICATED, p.from);
+      }
+    }
+
     // settlementCache dedup key: channel-scoped (not tied to exact transaction
     // bytes) so concurrent settles for the same channel with differently-signed
     // opens are still caught (see the race comment below).
@@ -601,6 +704,14 @@ export class UptoSvmScheme implements SchemeNetworkFacilitator {
         tokenProgram,
         expiresAt: p.expiresAt,
       });
+      if (delegated && depositIdentity) {
+        await this.delegatedAuthStore.bind({
+          channelId: p.channelId,
+          network: requirements.network,
+          callerIdentity: depositIdentity,
+          expiresAt: p.expiresAt,
+        });
+      }
     } catch (error) {
       this.settlementCache.delete(depositChannelKey);
       return {
@@ -608,7 +719,7 @@ export class UptoSvmScheme implements SchemeNetworkFacilitator {
         network: payload.accepted.network,
         transaction: "",
         errorReason: ERR_CHANNEL_BROADCAST,
-        errorMessage: `failed to durably index the channel before broadcast: ${
+        errorMessage: `failed to durably record the channel before broadcast: ${
           error instanceof Error ? error.message : String(error)
         }`,
         payer: p.from,
@@ -691,7 +802,7 @@ export class UptoSvmScheme implements SchemeNetworkFacilitator {
   }
 
   /**
-   * Claim path: re-bind the open channel, verify the voucher, then
+   * Claim path: re-bind the open channel, verify or produce the voucher, then
    * settle_and_seal + distribute.
    *
    * @param payload - The payment payload
@@ -699,6 +810,7 @@ export class UptoSvmScheme implements SchemeNetworkFacilitator {
    * @param p - Typed upto payload
    * @param actual - Actual charge in atomic units
    * @param payloadMaxAmount - Signed ceiling from the payload
+   * @param context - Facilitator extensions (used by `resolveCallerIdentity`)
    * @returns Claim settlement response
    */
   private async settleClaim(
@@ -707,7 +819,19 @@ export class UptoSvmScheme implements SchemeNetworkFacilitator {
     p: UptoSvmPayloadV2,
     actual: bigint,
     payloadMaxAmount: bigint,
+    context?: FacilitatorContext,
   ): Promise<SettleResponse> {
+    const hasVoucher = typeof p.voucherSignature === "string" && p.voucherSignature.length > 0;
+    if (!hasVoucher) {
+      const unauthenticated = await this.authenticateDelegatedClaim(
+        payload,
+        requirements,
+        p,
+        context,
+      );
+      if (unauthenticated) return unauthenticated;
+    }
+
     // Pending-settlement fast path: a prior claim settle for this exact
     // channel broadcast settle_and_seal + distribute successfully but
     // couldn't confirm it in time. Reconcile against that signature instead
@@ -733,6 +857,11 @@ export class UptoSvmScheme implements SchemeNetworkFacilitator {
       if (!pending.ok) {
         return pending.response;
       }
+      try {
+        await this.delegatedAuthStore.delete(p.channelId, requirements.network);
+      } catch {
+        // Best-effort; settlement is already confirmed.
+      }
       return {
         success: true,
         transaction: cachedClaimSignature,
@@ -740,10 +869,6 @@ export class UptoSvmScheme implements SchemeNetworkFacilitator {
         amount: actual.toString(),
         payer: p.from,
       };
-    }
-
-    if (typeof p.voucherSignature !== "string" || p.voucherSignature.length === 0) {
-      return this.settleFailure(payload, "invalid_upto_svm_payload_missing_voucher", p.from);
     }
 
     let channelConfig: UptoSvmPaymentChannelConfig;
@@ -778,23 +903,26 @@ export class UptoSvmScheme implements SchemeNetworkFacilitator {
     }
 
     const expiresAt = BigInt(p.expiresAt);
-    const voucherMessage = encodeVoucherMessageBytes({
-      channelId: p.channelId,
-      cumulativeAmount: actual,
-      expiresAt,
-    });
-    let voucherOk: boolean;
-    try {
-      voucherOk = await verifyVoucherSignature({
-        message: voucherMessage,
-        signatureBase58: p.voucherSignature,
-        signerBase58: p.authorizedSigner,
+    let voucherSignature = p.voucherSignature;
+    if (hasVoucher) {
+      const voucherMessage = encodeVoucherMessageBytes({
+        channelId: p.channelId,
+        cumulativeAmount: actual,
+        expiresAt,
       });
-    } catch {
-      return this.settleFailure(payload, "invalid_upto_svm_payload_voucher_signature", p.from);
-    }
-    if (!voucherOk) {
-      return this.settleFailure(payload, "invalid_upto_svm_payload_voucher_signature", p.from);
+      let voucherOk: boolean;
+      try {
+        voucherOk = await verifyVoucherSignature({
+          message: voucherMessage,
+          signatureBase58: p.voucherSignature as string,
+          signerBase58: p.authorizedSigner,
+        });
+      } catch {
+        return this.settleFailure(payload, "invalid_upto_svm_payload_voucher_signature", p.from);
+      }
+      if (!voucherOk) {
+        return this.settleFailure(payload, "invalid_upto_svm_payload_voucher_signature", p.from);
+      }
     }
 
     let tokenProgram: string;
@@ -832,6 +960,18 @@ export class UptoSvmScheme implements SchemeNetworkFacilitator {
       };
     }
 
+    if (!hasVoucher) {
+      const authorizerSigner = this.authorizerSigner;
+      if (!authorizerSigner || channel.authorizedSigner !== authorizerSigner.address) {
+        return this.settleFailure(payload, ERR_AUTHORIZER_ADDRESS_MISMATCH, p.from);
+      }
+      voucherSignature = await signVoucher(authorizerSigner, {
+        channelId: p.channelId,
+        cumulativeAmount: actual,
+        expiresAt,
+      });
+    }
+
     // Claim only after the open channel is rebound. Concurrent or replayed
     // settles for the same channel — including different valid amounts /
     // vouchers — must fail after the first claim so only one settle_and_seal +
@@ -853,7 +993,7 @@ export class UptoSvmScheme implements SchemeNetworkFacilitator {
                 authorizedSigner: channel.authorizedSigner,
                 cumulativeAmount: actual,
                 expiresAt,
-                signatureBase58: p.voucherSignature,
+                signatureBase58: voucherSignature as string,
               }
             : undefined,
       });
@@ -891,6 +1031,11 @@ export class UptoSvmScheme implements SchemeNetworkFacilitator {
       } catch {
         // Best-effort cleanup, per the comment above: settlement is already
         // confirmed onchain and must not be masked by a storage hiccup.
+      }
+      try {
+        await this.delegatedAuthStore.delete(channel.channelId, network);
+      } catch {
+        // Best-effort; settlement is already confirmed.
       }
       return {
         success: true,
@@ -949,12 +1094,13 @@ export class UptoSvmScheme implements SchemeNetworkFacilitator {
    * @param requirements - Payment requirements (amount must equal ceiling)
    * @param options - Validation options
    * @param options.rejectVoucher - Reject payloads that include `voucherSignature`
+   * @param options.rejectType - Reject payloads that include `type` (client-owned verify)
    * @returns Open auth context or a structured failure
    */
   private async validateOpenAuthorization(
     payload: PaymentPayload,
     requirements: PaymentRequirements,
-    options: { rejectVoucher: boolean },
+    options: { rejectVoucher: boolean; rejectType?: boolean },
   ): Promise<{ ok: true; ctx: OpenAuthContext } | { ok: false; failure: OpenAuthFailure }> {
     const raw = payload.payload as Record<string, unknown>;
     if (!isUptoSvmPayload(raw)) {
@@ -977,6 +1123,9 @@ export class UptoSvmScheme implements SchemeNetworkFacilitator {
     // client-set key (even "" or undefined) blocks the real voucher at claim.
     if (options.rejectVoucher && Object.prototype.hasOwnProperty.call(raw, "voucherSignature")) {
       return { ok: false, failure: { reason: ERR_UNEXPECTED_VOUCHER, payer: p.from } };
+    }
+    if (options.rejectType && Object.prototype.hasOwnProperty.call(raw, "type")) {
+      return { ok: false, failure: { reason: ERR_PAYLOAD_TYPE, payer: p.from } };
     }
 
     let channelConfig: UptoSvmPaymentChannelConfig;
@@ -1261,6 +1410,91 @@ export class UptoSvmScheme implements SchemeNetworkFacilitator {
       errorReason,
       payer,
     };
+  }
+
+  /**
+   * Whether this settle's `extra.receiverAuthorizer` is this facilitator's
+   * advertised authorizer.
+   *
+   * @param requirements - Payment requirements for the settle
+   * @returns True when this facilitator is the delegated receiver authorizer
+   */
+  private isDelegatedSettle(requirements: PaymentRequirements): boolean {
+    const advertised = requirements.extra?.receiverAuthorizer;
+    return (
+      this.authorizerSigner !== undefined &&
+      typeof advertised === "string" &&
+      advertised === this.authorizerSigner.address
+    );
+  }
+
+  /**
+   * Resolve a delegated settle's caller identity. Throws and empty/missing
+   * results are treated as unauthenticated.
+   *
+   * @param ctx - Settle context passed to the operator resolver
+   * @returns Stable identity, or undefined when the caller is unauthenticated
+   */
+  private async resolveDelegatedCallerIdentity(
+    ctx: UptoDelegatedSettleContext,
+  ): Promise<string | undefined> {
+    if (!this.resolveCallerIdentity) return undefined;
+    try {
+      const identity = await this.resolveCallerIdentity(ctx);
+      if (typeof identity !== "string" || identity.length === 0) return undefined;
+      return identity;
+    } catch {
+      return undefined;
+    }
+  }
+
+  /**
+   * Authenticate a delegated claim that omitted `voucherSignature`.
+   * Runs before the pending-settlement fast path and any RPC.
+   *
+   * @param payload - The payment payload
+   * @param requirements - Claim requirements
+   * @param p - Typed upto payload
+   * @param context - Facilitator extensions
+   * @returns A failure response, or undefined when the caller matches the binding
+   */
+  private async authenticateDelegatedClaim(
+    payload: PaymentPayload,
+    requirements: PaymentRequirements,
+    p: UptoSvmPayloadV2,
+    context?: FacilitatorContext,
+  ): Promise<SettleResponse | undefined> {
+    const authorizerSigner = this.authorizerSigner;
+    if (!authorizerSigner) {
+      return this.settleFailure(payload, ERR_AUTHORIZER_NOT_CONFIGURED, p.from);
+    }
+    const extraAuthorizer = requirements.extra?.receiverAuthorizer;
+    if (
+      typeof extraAuthorizer !== "string" ||
+      p.authorizedSigner !== extraAuthorizer ||
+      extraAuthorizer !== authorizerSigner.address
+    ) {
+      return this.settleFailure(payload, ERR_AUTHORIZER_ADDRESS_MISMATCH, p.from);
+    }
+
+    const identity = await this.resolveDelegatedCallerIdentity({
+      step: "claim",
+      channelId: p.channelId,
+      network: requirements.network,
+      payer: p.from,
+      amount: requirements.amount,
+      expiresAt: p.expiresAt,
+      payload,
+      requirements,
+      facilitatorContext: context,
+    });
+    if (!identity) {
+      return this.settleFailure(payload, ERR_DELEGATED_SETTLE_UNAUTHENTICATED, p.from);
+    }
+    const binding = await this.delegatedAuthStore.get(p.channelId, requirements.network);
+    if (!binding || binding.callerIdentity !== identity) {
+      return this.settleFailure(payload, ERR_DELEGATED_SETTLE_UNAUTHENTICATED, p.from);
+    }
   }
 
   /**

--- a/typescript/packages/mechanisms/svm/src/upto/server/scheme.ts
+++ b/typescript/packages/mechanisms/svm/src/upto/server/scheme.ts
@@ -19,8 +19,12 @@ import { createRpcClient, getStablecoinTokenProgram, validateSvmAddress } from "
 
 /** Options for the server-side {@link UptoSvmScheme}. */
 export interface UptoSvmServerOptions {
-  /** Server hot key set as the channel `authorized_signer`; signs settlement vouchers. */
-  receiverAuthorizerSigner: MessagePartialSigner;
+  /**
+   * Server hot key set as the channel `authorized_signer`; signs settlement
+   * vouchers. Omit to delegate to the facilitator's advertised
+   * `receiverAuthorizer`.
+   */
+  receiverAuthorizerSigner?: MessagePartialSigner;
   /**
    * Channel `grace_period`; defaults to
    * `max(DEFAULT_GRACE_PERIOD_SECONDS, maxTimeoutSeconds)`.
@@ -40,11 +44,11 @@ export interface UptoSvmServerOptions {
  * Declares the `escrow` payment flow: deposit settle before the handler, claim
  * (or zero-amount cancel) settle after. Price parsing matches the exact scheme
  * (stablecoin → 6-decimal atomic units); `enhancePaymentRequirements` folds the
- * facilitator's `feePayer`, declares the server-owned `receiverAuthorizer` /
- * `withdrawDelay`, and — when an `rpcUrl` is configured — embeds a fresh
- * `recentBlockhash`/`recentSlot` pair. `enrichSettlementPayload` attaches the
- * receiver-authorizer voucher only on claim/cancel settle (`after-handler` /
- * `cancel`); deposit settle (`before-handler`) leaves the payload unchanged.
+ * facilitator's `feePayer`, declares `receiverAuthorizer` (server-owned or
+ * facilitator-delegated) / `withdrawDelay`, and — when an `rpcUrl` is
+ * configured — embeds a fresh `recentBlockhash`/`recentSlot` pair.
+ * `enrichSettlementPayload` stamps `type` on every settle and attaches the
+ * receiver-authorizer voucher on claim/cancel only when the server owns the key.
  */
 export class UptoSvmScheme implements SchemeNetworkServer {
   readonly scheme = "upto";
@@ -55,16 +59,17 @@ export class UptoSvmScheme implements SchemeNetworkServer {
   /** Blockhash/slot hints regenerated per PaymentRequired; omitted from accepted-echo matching. */
   readonly dynamicExtraFields = ["recentBlockhash", "lastValidBlockHeight", "recentSlot"];
   private moneyParsers: MoneyParser[] = [];
-  private readonly receiverAuthorizerSigner: MessagePartialSigner;
+  private readonly receiverAuthorizerSigner: MessagePartialSigner | undefined;
   private readonly withdrawDelay: number | undefined;
   private readonly rpcUrl: string | undefined;
 
   /**
    * Construct the server-side upto scheme.
    *
-   * @param options - Server configuration including the voucher-signing key
+   * @param options - Server configuration; omit `receiverAuthorizerSigner` to
+   *   delegate voucher signing to the facilitator
    */
-  constructor(options: UptoSvmServerOptions) {
+  constructor(options: UptoSvmServerOptions = {}) {
     this.receiverAuthorizerSigner = options.receiverAuthorizerSigner;
     this.withdrawDelay = options.withdrawDelay;
     this.rpcUrl = options.rpcUrl;
@@ -120,7 +125,9 @@ export class UptoSvmScheme implements SchemeNetworkServer {
   }
 
   /**
-   * Fail server startup when the facilitator does not advertise a usable `feePayer`.
+   * Fail server startup when the facilitator does not advertise a usable `feePayer`,
+   * or when this server delegates and the facilitator does not advertise a
+   * `receiverAuthorizer`.
    *
    * @param network - The network identifier being validated
    * @param supportedKind - The facilitator's advertised kind for this scheme/network
@@ -137,6 +144,16 @@ export class UptoSvmScheme implements SchemeNetworkServer {
       return (
         `facilitator does not advertise a valid feePayer for upto on ${network}; ` +
         `a base58 Solana address is required`
+      );
+    }
+    if (this.receiverAuthorizerSigner) return;
+
+    const advertised = supportedKind.extra?.receiverAuthorizer;
+    if (typeof advertised !== "string" || !validateSvmAddress(advertised)) {
+      return (
+        `no receiverAuthorizerSigner is configured and the facilitator does not advertise a ` +
+        `receiverAuthorizer on ${network}. Configure a receiverAuthorizerSigner or use a ` +
+        `facilitator that advertises one.`
       );
     }
   }
@@ -175,16 +192,17 @@ export class UptoSvmScheme implements SchemeNetworkServer {
   }
 
   /**
-   * Fold the facilitator's `feePayer` into the requirement, declare the
-   * server-owned `receiverAuthorizer` / `withdrawDelay`, and optionally embed
-   * a fresh blockhash/slot pair for the client open.
+   * Fold the facilitator's `feePayer` into the requirement, declare
+   * `receiverAuthorizer` (local signer, else the facilitator's advertised key)
+   * / `withdrawDelay`, and optionally embed a fresh blockhash/slot pair for
+   * the client open.
    *
    * @param paymentRequirements - The base payment requirements
    * @param supportedKind - The supported kind from the facilitator's /supported endpoint
    * @param supportedKind.x402Version - The x402 version
    * @param supportedKind.scheme - The payment scheme
    * @param supportedKind.network - The network identifier
-   * @param supportedKind.extra - Facilitator extra (`feePayer` only)
+   * @param supportedKind.extra - Facilitator extra (`feePayer`, optional `receiverAuthorizer`)
    * @param extensionKeys - Extension keys supported by the facilitator (unused)
    * @returns Enhanced payment requirements
    */
@@ -202,10 +220,18 @@ export class UptoSvmScheme implements SchemeNetworkServer {
     const withdrawDelay =
       this.withdrawDelay ??
       Math.max(DEFAULT_GRACE_PERIOD_SECONDS, paymentRequirements.maxTimeoutSeconds);
+    const advertised = supportedKind.extra?.receiverAuthorizer;
+    const receiverAuthorizer =
+      this.receiverAuthorizerSigner?.address ??
+      (typeof advertised === "string" ? advertised : undefined);
+    if (!receiverAuthorizer || !validateSvmAddress(receiverAuthorizer)) {
+      throw new Error("Payment requirements must include a valid extra.receiverAuthorizer");
+    }
+
     const extra: Record<string, unknown> = {
       ...paymentRequirements.extra,
       ...supportedKind.extra,
-      receiverAuthorizer: this.receiverAuthorizerSigner.address,
+      receiverAuthorizer,
       withdrawDelay,
     };
     extra.tokenProgram ??= getStablecoinTokenProgram(
@@ -233,17 +259,19 @@ export class UptoSvmScheme implements SchemeNetworkServer {
   }
 
   /**
-   * Attach the receiver-authorizer voucher signature on claim/cancel settle.
-   * Deposit settle (`before-handler`) must not add `voucherSignature`.
+   * Stamp `type` on every settle. Attach the receiver-authorizer voucher on
+   * claim/cancel only when this server owns the key.
    *
    * @param ctx - Settlement context (`requirements.amount` is the charge or `0`)
-   * @returns Additive `voucherSignature` field, or void for deposit settle
+   * @returns Additive settle fields
    */
   enrichSettlementPayload = async (ctx: SettleContext): Promise<Record<string, unknown> | void> => {
-    if (ctx.phase === "before-handler") return;
+    if (ctx.phase === "before-handler") return { type: "deposit" };
 
     const raw = ctx.paymentPayload.payload as Record<string, unknown>;
-    if (!isUptoSvmPayload(raw)) return;
+    if (!isUptoSvmPayload(raw)) return { type: "claim" };
+
+    if (!this.receiverAuthorizerSigner) return { type: "claim" };
 
     if (raw.authorizedSigner !== this.receiverAuthorizerSigner.address) {
       throw new Error(
@@ -257,7 +285,7 @@ export class UptoSvmScheme implements SchemeNetworkServer {
       cumulativeAmount: BigInt(ctx.requirements.amount),
       expiresAt: BigInt(raw.expiresAt),
     });
-    return { voucherSignature };
+    return { type: "claim", voucherSignature };
   };
 
   /**

--- a/typescript/packages/mechanisms/svm/test/unit/upto.facilitator.test.ts
+++ b/typescript/packages/mechanisms/svm/test/unit/upto.facilitator.test.ts
@@ -64,7 +64,10 @@ import {
   ERR_UNEXPECTED_VOUCHER,
   UptoSvmScheme,
 } from "../../src/upto/facilitator/scheme";
-import { InMemoryUptoDelegatedAuthStore } from "../../src/upto/facilitator/delegatedAuthStore";
+import {
+  InMemoryUptoDelegatedAuthStore,
+  UptoDelegatedAuthIdentityConflictError,
+} from "../../src/upto/facilitator/delegatedAuthStore";
 import { ErrSettlementPending } from "../../src/exact/facilitator/errors";
 import {
   SettlementConfirmationTimeoutError,
@@ -1207,6 +1210,51 @@ describe("UptoSvmScheme facilitator channel lifecycle", () => {
       expect(
         () => new UptoSvmScheme(toFacilitatorSvmSigner(feePayer), { authorizerSigner }),
       ).toThrow(/resolveCallerIdentity/);
+    });
+
+    it("InMemoryUptoDelegatedAuthStore bind is first-writer-wins", async () => {
+      const store = new InMemoryUptoDelegatedAuthStore();
+      const expiresAt = Math.floor(Date.now() / 1000) + 3_600;
+      const binding = {
+        channelId: "ch-1",
+        network: SOLANA_DEVNET_CAIP2,
+        callerIdentity: "svc-1",
+        expiresAt,
+      };
+
+      await store.bind(binding);
+      await store.bind(binding);
+
+      await expect(store.bind({ ...binding, callerIdentity: "svc-2" })).rejects.toBeInstanceOf(
+        UptoDelegatedAuthIdentityConflictError,
+      );
+
+      expect(await store.get("ch-1", SOLANA_DEVNET_CAIP2)).toMatchObject({
+        callerIdentity: "svc-1",
+      });
+    });
+
+    it("InMemoryUptoDelegatedAuthStore bind replaces expired bindings", async () => {
+      const store = new InMemoryUptoDelegatedAuthStore();
+      const expiredAt = Math.floor(Date.now() / 1000) - 1;
+      const expiresAt = Math.floor(Date.now() / 1000) + 3_600;
+
+      await store.bind({
+        channelId: "ch-1",
+        network: SOLANA_DEVNET_CAIP2,
+        callerIdentity: "svc-1",
+        expiresAt: expiredAt,
+      });
+      await store.bind({
+        channelId: "ch-1",
+        network: SOLANA_DEVNET_CAIP2,
+        callerIdentity: "svc-2",
+        expiresAt,
+      });
+
+      expect(await store.get("ch-1", SOLANA_DEVNET_CAIP2)).toMatchObject({
+        callerIdentity: "svc-2",
+      });
     });
 
     it("routes a full-charge type=claim as a claim, not a deposit", async () => {

--- a/typescript/packages/mechanisms/svm/test/unit/upto.facilitator.test.ts
+++ b/typescript/packages/mechanisms/svm/test/unit/upto.facilitator.test.ts
@@ -53,13 +53,18 @@ import { signVoucher } from "../../src/payment-channels/voucher";
 import { toFacilitatorSvmSigner } from "../../src/signer";
 import type { FacilitatorSvmSigner } from "../../src/signer";
 import {
+  ERR_AUTHORIZER_ADDRESS_MISMATCH,
+  ERR_AUTHORIZER_NOT_CONFIGURED,
   ERR_CHANNEL_ALREADY_OPEN,
   ERR_CHANNEL_BROADCAST,
+  ERR_DELEGATED_SETTLE_UNAUTHENTICATED,
   ERR_EXPIRES_AT_MISMATCH,
   ERR_CHANNEL_LIFETIME_EXCEEDED,
+  ERR_PAYLOAD_TYPE,
   ERR_UNEXPECTED_VOUCHER,
   UptoSvmScheme,
 } from "../../src/upto/facilitator/scheme";
+import { InMemoryUptoDelegatedAuthStore } from "../../src/upto/facilitator/delegatedAuthStore";
 import { ErrSettlementPending } from "../../src/exact/facilitator/errors";
 import {
   SettlementConfirmationTimeoutError,
@@ -82,10 +87,13 @@ describe("UptoSvmScheme facilitator channel lifecycle", () => {
     channelMocks.submitSettle.mockResolvedValue(USDC_MAINNET_ADDRESS);
   });
 
-  async function buildFixture(config: ConstructorParameters<typeof UptoSvmScheme>[1] = {}) {
+  async function buildFixture(
+    config: ConstructorParameters<typeof UptoSvmScheme>[1] = {},
+    keys?: { receiverAuthorizer?: Awaited<ReturnType<typeof generateKeyPairSigner>> },
+  ) {
     const payer = await generateKeyPairSigner();
     const feePayer = await generateKeyPairSigner();
-    const receiverAuthorizer = await generateKeyPairSigner();
+    const receiverAuthorizer = keys?.receiverAuthorizer ?? (await generateKeyPairSigner());
     const open = await buildOpenPaymentChannelTransaction({
       authorizedSigner: receiverAuthorizer.address,
       blockhash: { blockhash: USDC_MAINNET_ADDRESS, lastValidBlockHeight: 0n },
@@ -1147,6 +1155,275 @@ describe("UptoSvmScheme facilitator channel lifecycle", () => {
       ).resolves.toMatchObject({
         success: false,
         errorReason: "invalid_upto_svm_settlement_simulation",
+      });
+    });
+  });
+
+  describe("delegated receiver authorizer", () => {
+    async function buildDelegatedFixture(
+      resolveCallerIdentity: (ctx: {
+        step: string;
+      }) => Promise<string | undefined> | string | undefined = async (): Promise<string> => "svc-1",
+    ): Promise<
+      Awaited<ReturnType<typeof buildFixture>> & {
+        authorizerSigner: Awaited<ReturnType<typeof generateKeyPairSigner>>;
+        store: InMemoryUptoDelegatedAuthStore;
+      }
+    > {
+      const store = new InMemoryUptoDelegatedAuthStore();
+      const authorizerSigner = await generateKeyPairSigner();
+      const fixture = await buildFixture(
+        {
+          authorizerSigner,
+          resolveCallerIdentity,
+          delegatedAuthStore: store,
+        },
+        { receiverAuthorizer: authorizerSigner },
+      );
+      return { ...fixture, authorizerSigner, store };
+    }
+
+    it("getExtra includes receiverAuthorizer only when authorizerSigner is set", async () => {
+      const { facilitator } = await buildFixture();
+      expect(facilitator.getExtra(SOLANA_DEVNET_CAIP2)).toEqual({
+        feePayer: expect.any(String),
+      });
+      expect(facilitator.getExtra(SOLANA_DEVNET_CAIP2)).not.toHaveProperty("receiverAuthorizer");
+
+      const authorizerSigner = await generateKeyPairSigner();
+      const delegated = new UptoSvmScheme(toFacilitatorSvmSigner(await generateKeyPairSigner()), {
+        authorizerSigner,
+        resolveCallerIdentity: () => "svc-1",
+      });
+      expect(delegated.getExtra(SOLANA_DEVNET_CAIP2)).toEqual({
+        feePayer: expect.any(String),
+        receiverAuthorizer: authorizerSigner.address,
+      });
+    });
+
+    it("constructor throws without resolveCallerIdentity", async () => {
+      const feePayer = await generateKeyPairSigner();
+      const authorizerSigner = await generateKeyPairSigner();
+      expect(
+        () => new UptoSvmScheme(toFacilitatorSvmSigner(feePayer), { authorizerSigner }),
+      ).toThrow(/resolveCallerIdentity/);
+    });
+
+    it("routes a full-charge type=claim as a claim, not a deposit", async () => {
+      const resolveCallerIdentity = vi.fn().mockResolvedValue("svc-1");
+      const { facilitator, payload, requirements, uptoPayload, store, authorizerSigner } =
+        await buildDelegatedFixture(resolveCallerIdentity);
+
+      // Deposit first so the binding exists.
+      await expect(
+        facilitator.settle(
+          { ...payload, payload: { ...uptoPayload, type: "deposit" } },
+          requirements,
+        ),
+      ).resolves.toMatchObject({ success: true });
+      expect(channelMocks.broadcastOpen).toHaveBeenCalledTimes(1);
+
+      channelMocks.broadcastOpen.mockClear();
+      channelMocks.fetchAndVerifyOpenChannel.mockResolvedValue({
+        authorizedSigner: authorizerSigner.address,
+        channelId: uptoPayload.channelId,
+        deposit: 1_000_000n,
+        mint: requirements.asset,
+        openSlot: OPEN_SLOT,
+        payee: requirements.extra!.feePayer,
+        payer: uptoPayload.from,
+        rentPayer: requirements.extra!.feePayer,
+        splits: [{ bps: 10_000, recipient: authorizerSigner.address }],
+      });
+
+      await expect(
+        facilitator.settle(
+          { ...payload, payload: { ...uptoPayload, type: "claim" } },
+          requirements, // amount === maxAmount; old inference would treat this as a deposit
+        ),
+      ).resolves.toMatchObject({ success: true, amount: "1000000" });
+      expect(channelMocks.broadcastOpen).not.toHaveBeenCalled();
+      expect(channelMocks.submitSettle).toHaveBeenCalledTimes(1);
+      expect(await store.get(uptoPayload.channelId, requirements.network)).toBeUndefined();
+    });
+
+    it("rejects a delegated settle missing type", async () => {
+      const { facilitator, payload, requirements } = await buildDelegatedFixture();
+      await expect(facilitator.settle(payload, requirements)).resolves.toMatchObject({
+        success: false,
+        errorReason: ERR_PAYLOAD_TYPE,
+      });
+      expect(channelMocks.broadcastOpen).not.toHaveBeenCalled();
+    });
+
+    it("rejects client-supplied type at verify", async () => {
+      const { facilitator, payload, requirements, uptoPayload } = await buildDelegatedFixture();
+      await expect(
+        facilitator.verify(
+          { ...payload, payload: { ...uptoPayload, type: "deposit" } },
+          requirements,
+        ),
+      ).resolves.toMatchObject({
+        isValid: false,
+        invalidReason: ERR_PAYLOAD_TYPE,
+      });
+    });
+
+    it("signs and settles a delegated claim after a matching deposit identity", async () => {
+      const resolveCallerIdentity = vi.fn().mockResolvedValue("svc-1");
+      const { facilitator, payload, requirements, uptoPayload, store, authorizerSigner } =
+        await buildDelegatedFixture(resolveCallerIdentity);
+
+      await expect(
+        facilitator.settle(
+          { ...payload, payload: { ...uptoPayload, type: "deposit" } },
+          requirements,
+        ),
+      ).resolves.toMatchObject({ success: true });
+      expect(await store.get(uptoPayload.channelId, requirements.network)).toMatchObject({
+        callerIdentity: "svc-1",
+      });
+
+      channelMocks.fetchAndVerifyOpenChannel.mockResolvedValue({
+        authorizedSigner: authorizerSigner.address,
+        channelId: uptoPayload.channelId,
+        deposit: 1_000_000n,
+        mint: requirements.asset,
+        openSlot: OPEN_SLOT,
+        payee: requirements.extra!.feePayer,
+        payer: uptoPayload.from,
+        rentPayer: requirements.extra!.feePayer,
+        splits: [{ bps: 10_000, recipient: authorizerSigner.address }],
+      });
+
+      await expect(
+        facilitator.settle(
+          { ...payload, payload: { ...uptoPayload, type: "claim" } },
+          { ...requirements, amount: "1858" },
+        ),
+      ).resolves.toMatchObject({ success: true, amount: "1858" });
+      expect(channelMocks.submitSettle).toHaveBeenCalledTimes(1);
+      expect(resolveCallerIdentity).toHaveBeenCalledWith(
+        expect.objectContaining({ step: "deposit", channelId: uptoPayload.channelId }),
+      );
+      expect(resolveCallerIdentity).toHaveBeenCalledWith(
+        expect.objectContaining({ step: "claim", channelId: uptoPayload.channelId }),
+      );
+      expect(await store.get(uptoPayload.channelId, requirements.network)).toBeUndefined();
+    });
+
+    it("rejects a claim from a different identity without broadcasting", async () => {
+      const resolveCallerIdentity = vi
+        .fn()
+        .mockResolvedValueOnce("svc-1")
+        .mockResolvedValueOnce("svc-2");
+      const { facilitator, payload, requirements, uptoPayload } =
+        await buildDelegatedFixture(resolveCallerIdentity);
+
+      await expect(
+        facilitator.settle(
+          { ...payload, payload: { ...uptoPayload, type: "deposit" } },
+          requirements,
+        ),
+      ).resolves.toMatchObject({ success: true });
+      channelMocks.fetchAndVerifyOpenChannel.mockClear();
+      channelMocks.submitSettle.mockClear();
+
+      await expect(
+        facilitator.settle(
+          { ...payload, payload: { ...uptoPayload, type: "claim" } },
+          { ...requirements, amount: "1858" },
+        ),
+      ).resolves.toMatchObject({
+        success: false,
+        errorReason: ERR_DELEGATED_SETTLE_UNAUTHENTICATED,
+      });
+      expect(channelMocks.submitSettle).not.toHaveBeenCalled();
+      expect(channelMocks.fetchAndVerifyOpenChannel).not.toHaveBeenCalled();
+    });
+
+    it("rejects a claim with no stored binding", async () => {
+      const { facilitator, payload, requirements, uptoPayload } = await buildDelegatedFixture();
+      await expect(
+        facilitator.settle(
+          { ...payload, payload: { ...uptoPayload, type: "claim" } },
+          { ...requirements, amount: "1858" },
+        ),
+      ).resolves.toMatchObject({
+        success: false,
+        errorReason: ERR_DELEGATED_SETTLE_UNAUTHENTICATED,
+      });
+      expect(channelMocks.submitSettle).not.toHaveBeenCalled();
+      expect(channelMocks.fetchAndVerifyOpenChannel).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      ["undefined", async (): Promise<undefined> => undefined],
+      [
+        "throwing",
+        async (): Promise<undefined> => {
+          throw new Error("no creds");
+        },
+      ],
+    ] as const)(
+      "rejects when resolveCallerIdentity is %s at deposit and claim",
+      async (_label, resolver) => {
+        const { facilitator, payload, requirements, uptoPayload } =
+          await buildDelegatedFixture(resolver);
+
+        await expect(
+          facilitator.settle(
+            { ...payload, payload: { ...uptoPayload, type: "deposit" } },
+            requirements,
+          ),
+        ).resolves.toMatchObject({
+          success: false,
+          errorReason: ERR_DELEGATED_SETTLE_UNAUTHENTICATED,
+        });
+        expect(channelMocks.broadcastOpen).not.toHaveBeenCalled();
+        expect(channelMocks.simulateOpenSettleDistribute).not.toHaveBeenCalled();
+
+        await expect(
+          facilitator.settle(
+            { ...payload, payload: { ...uptoPayload, type: "claim" } },
+            { ...requirements, amount: "1858" },
+          ),
+        ).resolves.toMatchObject({
+          success: false,
+          errorReason: ERR_DELEGATED_SETTLE_UNAUTHENTICATED,
+        });
+        expect(channelMocks.submitSettle).not.toHaveBeenCalled();
+      },
+    );
+
+    it("rejects a delegated claim when authorizerSigner is not configured", async () => {
+      const { facilitator, payload, requirements, uptoPayload } = await buildFixture();
+      await expect(
+        facilitator.settle(
+          { ...payload, payload: { ...uptoPayload, type: "claim" } },
+          { ...requirements, amount: "1858" },
+        ),
+      ).resolves.toMatchObject({
+        success: false,
+        errorReason: ERR_AUTHORIZER_NOT_CONFIGURED,
+      });
+    });
+
+    it("rejects a delegated claim whose authorizer is not this facilitator", async () => {
+      const authorizerSigner = await generateKeyPairSigner();
+      const { facilitator, payload, requirements, uptoPayload } = await buildFixture({
+        authorizerSigner,
+        resolveCallerIdentity: () => "svc-1",
+      });
+      // extra.receiverAuthorizer is still the fixture's server key, not authorizerSigner
+      await expect(
+        facilitator.settle(
+          { ...payload, payload: { ...uptoPayload, type: "claim" } },
+          { ...requirements, amount: "1858" },
+        ),
+      ).resolves.toMatchObject({
+        success: false,
+        errorReason: ERR_AUTHORIZER_ADDRESS_MISMATCH,
       });
     });
   });

--- a/typescript/packages/mechanisms/svm/test/unit/upto.test.ts
+++ b/typescript/packages/mechanisms/svm/test/unit/upto.test.ts
@@ -11,7 +11,7 @@ import {
   partiallySignTransaction,
   type KeyPairSigner,
 } from "@solana/kit";
-import type { PaymentPayload, PaymentRequirements } from "@x402/core/types";
+import type { PaymentPayload, PaymentRequirements, SupportedKind } from "@x402/core/types";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 
 import {
@@ -333,7 +333,7 @@ describe("upto SVM scheme", () => {
       maxTimeoutSeconds: 300,
     };
 
-    it("skips voucher signing on before-handler deposit settle", async () => {
+    it("stamps type=deposit on before-handler settle without a voucher", async () => {
       const enrichment = await server.enrichSettlementPayload!({
         paymentPayload: {
           x402Version: 2,
@@ -344,7 +344,7 @@ describe("upto SVM scheme", () => {
         declaredExtensions: {},
         phase: "before-handler",
       });
-      expect(enrichment).toBeUndefined();
+      expect(enrichment).toEqual({ type: "deposit" });
     });
 
     it("signs a voucher the facilitator accepts", async () => {
@@ -362,7 +362,7 @@ describe("upto SVM scheme", () => {
         declaredExtensions: {},
         phase: "after-handler",
       });
-      expect(enrichment).toMatchObject({ voucherSignature: expect.any(String) });
+      expect(enrichment).toMatchObject({ type: "claim", voucherSignature: expect.any(String) });
 
       const { verifyVoucherSignature } = await import("../../src/payment-channels/voucher");
       await expect(
@@ -393,7 +393,7 @@ describe("upto SVM scheme", () => {
         declaredExtensions: {},
         phase: "cancel",
       });
-      expect(enrichment).toMatchObject({ voucherSignature: expect.any(String) });
+      expect(enrichment).toMatchObject({ type: "claim", voucherSignature: expect.any(String) });
 
       const { verifyVoucherSignature } = await import("../../src/payment-channels/voucher");
       await expect(
@@ -407,6 +407,110 @@ describe("upto SVM scheme", () => {
           signerBase58: serverAuthorizer.address,
         }),
       ).resolves.toBe(true);
+    });
+  });
+
+  describe("server delegated receiver authorizer", () => {
+    const advertisedAuthorizer = USDC_MAINNET_ADDRESS;
+    const supportedKind: SupportedKind = {
+      x402Version: 2,
+      scheme: "upto",
+      network: SOLANA_DEVNET_CAIP2,
+      extra: {
+        feePayer: advertisedAuthorizer,
+        receiverAuthorizer: advertisedAuthorizer,
+      },
+    };
+    const requirements: PaymentRequirements = {
+      scheme: "upto",
+      network: SOLANA_DEVNET_CAIP2,
+      asset: MINT,
+      amount: "1000000",
+      payTo: PAY_TO,
+      maxTimeoutSeconds: 300,
+      extra: {},
+    };
+
+    it("falls back to facilitator extra.receiverAuthorizer when no local signer", async () => {
+      const delegated = new UptoServerScheme({ withdrawDelay: WITHDRAW_DELAY });
+      const result = await delegated.enhancePaymentRequirements(requirements, supportedKind, []);
+      expect(result.extra?.receiverAuthorizer).toBe(advertisedAuthorizer);
+    });
+
+    it("throws when neither side supplies a receiverAuthorizer", async () => {
+      const delegated = new UptoServerScheme({ withdrawDelay: WITHDRAW_DELAY });
+      await expect(
+        delegated.enhancePaymentRequirements(
+          requirements,
+          {
+            ...supportedKind,
+            extra: { feePayer: advertisedAuthorizer },
+          },
+          [],
+        ),
+      ).rejects.toThrow(/valid extra.receiverAuthorizer/);
+    });
+
+    it("validateFacilitatorSupport fails without a local signer or advertisement", () => {
+      const delegated = new UptoServerScheme({ withdrawDelay: WITHDRAW_DELAY });
+      const problem = delegated.validateFacilitatorSupport?.(
+        SOLANA_DEVNET_CAIP2,
+        {
+          x402Version: 2,
+          scheme: "upto",
+          network: SOLANA_DEVNET_CAIP2,
+          extra: { feePayer: advertisedAuthorizer },
+        },
+        [],
+      );
+      expect(problem).toMatch(/receiverAuthorizer/);
+    });
+
+    it("validateFacilitatorSupport accepts a facilitator-advertised authorizer", () => {
+      const delegated = new UptoServerScheme({ withdrawDelay: WITHDRAW_DELAY });
+      expect(
+        delegated.validateFacilitatorSupport?.(SOLANA_DEVNET_CAIP2, supportedKind, []),
+      ).toBeUndefined();
+    });
+
+    it("stamps type and omits voucherSignature when delegating", async () => {
+      const delegated = new UptoServerScheme({ withdrawDelay: WITHDRAW_DELAY });
+      const payload = {
+        from: PAY_TO,
+        maxAmount: "1000000",
+        deposit: "1000000",
+        channelId: USDC_MAINNET_ADDRESS,
+        authorizedSigner: advertisedAuthorizer,
+        openTransaction: "unused",
+        openSlot: OPEN_SLOT.toString(),
+        expiresAt: FAR_FUTURE,
+        validAfter: 0,
+        nonce: "1",
+      };
+      await expect(
+        delegated.enrichSettlementPayload!({
+          paymentPayload: {
+            x402Version: 2,
+            accepted: requirements,
+            payload,
+          },
+          requirements,
+          declaredExtensions: {},
+          phase: "before-handler",
+        }),
+      ).resolves.toEqual({ type: "deposit" });
+      await expect(
+        delegated.enrichSettlementPayload!({
+          paymentPayload: {
+            x402Version: 2,
+            accepted: requirements,
+            payload,
+          },
+          requirements: { ...requirements, amount: "1858" },
+          declaredExtensions: {},
+          phase: "after-handler",
+        }),
+      ).resolves.toEqual({ type: "claim" });
     });
   });
 


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

SVM upto can now optionally delegate the `receiverAuthorizer` role to the facilitator, similar to EVM batch-settlement: /supported may advertise `receiverAuthorizer`, and a server that omits receiverAuthorizerSigner no longer needs a voucher-signing key. The facilitator signs the claim voucher only after binding the deposit to a caller identity and matching that same identity on claim; a lost binding fails closed. Self-managed server vouchers stay the default. Settle routing prefers server-stamped payload.type (deposit | claim) and falls back to the existing voucher/amount inference when type is absent, so older non-delegating servers keep working. type is required only for delegated settles and is not part of the reused client authorization.

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [ ] I have formatted and linted my code
- [ ] All new and existing tests pass
- [ ] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [ ] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 