### PR TITLE
feat(go): add delegated receiver authorizer for SVM upto

### DIFF
--- a/examples/go/facilitator/upto/README.md
+++ b/examples/go/facilitator/upto/README.md
@@ -58,6 +58,68 @@ scheme := uptosvm.NewUptoSvmScheme(signer, &uptosvm.Config{
 })
 ```
 
+## SVM receiver authorizer (optional delegation)
+
+This example registers `UptoSvmScheme` with a **fee payer only** — no
+`AuthorizerSigner` is configured, so `/supported` advertises `extra.feePayer`
+but not `extra.receiverAuthorizer`. Servers must sign their own claim vouchers
+(self-managed mode).
+
+To let resource servers delegate voucher signing to your facilitator, extend
+the SVM registration with a separate Ed25519 key and a `ResolveCallerIdentity`
+hook. Delegation is not negotiated in x402 — it requires an out-of-band
+agreement with each resource server, and authenticated settle requests so
+claim vouchers are signed only for that server.
+
+| Signer | Role | Onchain effect |
+| ------ | ---- | -------------- |
+| `SVM_PRIVATE_KEY` | **Fee payer** — co-signs channel `open`, submits claim/cleanup txs | Pays SOL for opens, settlement, and rent cleanup |
+| `AuthorizerSigner` (optional) | **Receiver authorizer** — signs claim vouchers when servers delegate | Committed as the channel `authorized_signer` for delegating servers |
+
+When `AuthorizerSigner` is set, `GET /supported` includes both `feePayer` and
+`receiverAuthorizer`:
+
+```json
+{
+  "kinds": [
+    {
+      "x402Version": 2,
+      "scheme": "upto",
+      "network": "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",
+      "extra": {
+        "feePayer": "...",
+        "receiverAuthorizer": "..."
+      }
+    }
+  ]
+}
+```
+
+Wire it in your facilitator:
+
+```go
+authorizer, err := svmsigners.NewReceiverAuthorizerSignerFromPrivateKey(
+    os.Getenv("SVM_RECEIVER_AUTHORIZER_PRIVATE_KEY"),
+)
+
+scheme := uptosvm.NewUptoSvmScheme(signer, &uptosvm.Config{
+    ChannelStorage:            channelStorage,
+    MaxChannelLifetimeSecs:    &maxChannelLifetimeSecs,
+    AuthorizerSigner:          authorizer,
+    ResolveCallerIdentity:     resolveCallerIdentity, // JWT / SIWX / mTLS subject
+    // Optional for multi-replica facilitators; default is in-memory.
+    // DelegatedAuthStore: sharedRedisDelegatedAuthStore,
+})
+```
+
+> ⚠️ A facilitator that advertises `receiverAuthorizer` **must** authenticate
+> that each claim settle comes from the same service whose deposit settle
+> opened the channel (SIWX, JWT, mTLS, or an API credential correlated across
+> both settles). The scheme records that identity at deposit and requires an
+> exact match at claim. **Do not advertise `receiverAuthorizer` without real
+> authentication.** The default identity binding store is in-memory; inject a
+> shared `DelegatedAuthStore` for multi-replica facilitators.
+
 ## API endpoints
 
 The standard x402 facilitator surface: `POST /verify`, `POST /settle`,

--- a/go/.changes/unreleased/added-20260902-svm-upto-delegated-authorizer.yaml
+++ b/go/.changes/unreleased/added-20260902-svm-upto-delegated-authorizer.yaml
@@ -1,0 +1,3 @@
+kind: added
+body: Add an optional facilitator-delegated receiver-authorizer mode to SVM `upto`. The facilitator may advertise `receiverAuthorizer` in `/supported`; a server that omits `ReceiverAuthorizerSigner` delegates voucher signing, and the facilitator signs after correlating the claim settle to the same authenticated caller that opened the channel.
+time: 2026-09-02T11:00:00Z

--- a/go/.changes/unreleased/changed-20260902-fatal-startup-capability-errors.yaml
+++ b/go/.changes/unreleased/changed-20260902-fatal-startup-capability-errors.yaml
@@ -1,0 +1,3 @@
+kind: changed
+body: Exit the process when eager facilitator sync fails with a permanent capability or route-configuration error, instead of staying up until the first paid request. Transient facilitator timeouts remain retryable.
+time: 2026-09-02T10:45:00Z

--- a/go/errors.go
+++ b/go/errors.go
@@ -1,6 +1,9 @@
 package x402
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // PaymentError represents a payment-specific error
 type PaymentError struct {
@@ -138,4 +141,27 @@ func NewSettleError(reason string, payer string, network Network, transaction st
 		Transaction:  transaction,
 		ErrorMessage: message,
 	}
+}
+
+// FacilitatorCapabilityError is thrown when a registered scheme's configuration
+// is incompatible with the capabilities the facilitator advertised for that
+// scheme and network.
+type FacilitatorCapabilityError struct {
+	// Problems are human-readable lines, one per scheme/network mismatch.
+	Problems []string
+}
+
+// Error implements the error interface.
+func (e *FacilitatorCapabilityError) Error() string {
+	lines := make([]string, 0, len(e.Problems)+1)
+	lines = append(lines, "x402 facilitator capability errors:")
+	for _, problem := range e.Problems {
+		lines = append(lines, "  - "+problem)
+	}
+	return strings.Join(lines, "\n")
+}
+
+// NewFacilitatorCapabilityError lists every capability problem.
+func NewFacilitatorCapabilityError(problems []string) *FacilitatorCapabilityError {
+	return &FacilitatorCapabilityError{Problems: problems}
 }

--- a/go/http/background_init.go
+++ b/go/http/background_init.go
@@ -1,0 +1,48 @@
+package http
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	x402 "github.com/x402-foundation/x402/go/v2"
+)
+
+// processExit is os.Exit, overridable in tests so fatal-init coverage does not
+// kill the test process.
+var processExit = os.Exit
+
+// IsFatalStartupInitError reports whether a resource-server Initialize failure
+// is a permanent misconfiguration.
+//
+// Transient facilitator timeouts stay retryable on the next protected request.
+// Capability and route mismatches will not become valid later and must not
+// leave the process listening.
+func IsFatalStartupInitError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var capErr *x402.FacilitatorCapabilityError
+	if errors.As(err, &capErr) {
+		return true
+	}
+	var routeErr *RouteConfigurationError
+	return errors.As(err, &routeErr)
+}
+
+// HandleBackgroundInitError handles an Initialize() failure from HTTP adapters.
+//
+// Retryable failures are logged so they are not silent; the original error is
+// still available to the caller. Fatal configuration errors exit the process
+// so a misconfigured server does not stay up until the first paid request.
+func HandleBackgroundInitError(err error) {
+	if err == nil {
+		return
+	}
+	if !IsFatalStartupInitError(err) {
+		fmt.Printf("Warning: failed to initialize x402 server: %v\n", err)
+		return
+	}
+	fmt.Fprintln(os.Stderr, err)
+	processExit(1)
+}

--- a/go/http/background_init_test.go
+++ b/go/http/background_init_test.go
@@ -1,0 +1,66 @@
+package http
+
+import (
+	"errors"
+	"testing"
+
+	x402 "github.com/x402-foundation/x402/go/v2"
+)
+
+func TestIsFatalStartupInitErrorTreatsCapabilityAndRouteErrorsAsFatal(t *testing.T) {
+	if !IsFatalStartupInitError(x402.NewFacilitatorCapabilityError([]string{"upto on solana:devnet: missing"})) {
+		t.Fatal("expected FacilitatorCapabilityError to be fatal")
+	}
+	if !IsFatalStartupInitError(&RouteConfigurationError{
+		Errors: []RouteValidationError{
+			{
+				RoutePattern: "GET /api/generate",
+				Scheme:       "upto",
+				Network:      "solana:devnet",
+				Reason:       "missing_facilitator",
+				Message:      "missing facilitator",
+			},
+		},
+	}) {
+		t.Fatal("expected RouteConfigurationError to be fatal")
+	}
+}
+
+func TestIsFatalStartupInitErrorTreatsTimeoutsAsRetryable(t *testing.T) {
+	if IsFatalStartupInitError(errors.New("facilitator request timed out")) {
+		t.Fatal("expected facilitator timeouts to be retryable")
+	}
+}
+
+func TestHandleBackgroundInitErrorExitsOnCapabilityMismatch(t *testing.T) {
+	var exitCode int
+	called := false
+	orig := processExit
+	processExit = func(code int) {
+		called = true
+		exitCode = code
+	}
+	t.Cleanup(func() { processExit = orig })
+
+	HandleBackgroundInitError(x402.NewFacilitatorCapabilityError([]string{"upto on solana:devnet: missing"}))
+
+	if !called {
+		t.Fatal("expected process exit on capability mismatch")
+	}
+	if exitCode != 1 {
+		t.Fatalf("expected exit code 1, got %d", exitCode)
+	}
+}
+
+func TestHandleBackgroundInitErrorDoesNotExitOnRetryableTimeout(t *testing.T) {
+	called := false
+	orig := processExit
+	processExit = func(int) { called = true }
+	t.Cleanup(func() { processExit = orig })
+
+	HandleBackgroundInitError(errors.New("facilitator request timed out"))
+
+	if called {
+		t.Fatal("expected no process exit on retryable facilitator timeout")
+	}
+}

--- a/go/http/echo/middleware.go
+++ b/go/http/echo/middleware.go
@@ -194,7 +194,7 @@ func PaymentMiddleware(routes x402http.RoutesConfig, server *x402.X402ResourceSe
 		ctx, cancel := context.WithTimeout(context.Background(), config.Timeout)
 		defer cancel()
 		if err := httpServer.Initialize(ctx); err != nil {
-			fmt.Printf("Warning: failed to initialize x402 server: %v\n", err)
+			x402http.HandleBackgroundInitError(err)
 		}
 	}
 
@@ -234,7 +234,7 @@ func PaymentMiddlewareFromHTTPServer(httpServer *x402http.HTTPServer, opts ...Mi
 		ctx, cancel := context.WithTimeout(context.Background(), config.Timeout)
 		defer cancel()
 		if err := httpServer.Initialize(ctx); err != nil {
-			fmt.Printf("Warning: failed to initialize x402 server: %v\n", err)
+			x402http.HandleBackgroundInitError(err)
 		}
 	}
 
@@ -278,7 +278,7 @@ func PaymentMiddlewareFromConfig(routes x402http.RoutesConfig, opts ...Middlewar
 		ctx, cancel := context.WithTimeout(context.Background(), config.Timeout)
 		defer cancel()
 		if err := httpServer.Initialize(ctx); err != nil {
-			fmt.Printf("Warning: failed to initialize x402 server: %v\n", err)
+			x402http.HandleBackgroundInitError(err)
 		}
 	}
 

--- a/go/http/gin/middleware.go
+++ b/go/http/gin/middleware.go
@@ -192,7 +192,7 @@ func PaymentMiddleware(routes x402http.RoutesConfig, server *x402.X402ResourceSe
 		ctx, cancel := context.WithTimeout(context.Background(), config.Timeout)
 		defer cancel()
 		if err := httpServer.Initialize(ctx); err != nil {
-			fmt.Printf("Warning: failed to initialize x402 server: %v\n", err)
+			x402http.HandleBackgroundInitError(err)
 		}
 	}
 
@@ -233,7 +233,7 @@ func PaymentMiddlewareFromHTTPServer(httpServer *x402http.HTTPServer, opts ...Mi
 		ctx, cancel := context.WithTimeout(context.Background(), config.Timeout)
 		defer cancel()
 		if err := httpServer.Initialize(ctx); err != nil {
-			fmt.Printf("Warning: failed to initialize x402 server: %v\n", err)
+			x402http.HandleBackgroundInitError(err)
 		}
 	}
 
@@ -278,7 +278,7 @@ func PaymentMiddlewareFromConfig(routes x402http.RoutesConfig, opts ...Middlewar
 		ctx, cancel := context.WithTimeout(context.Background(), config.Timeout)
 		defer cancel()
 		if err := httpServer.Initialize(ctx); err != nil {
-			fmt.Printf("Warning: failed to initialize x402 server: %v\n", err)
+			x402http.HandleBackgroundInitError(err)
 		}
 	}
 

--- a/go/http/nethttp/middleware.go
+++ b/go/http/nethttp/middleware.go
@@ -137,7 +137,7 @@ func PaymentMiddleware(routes x402http.RoutesConfig, server *x402.X402ResourceSe
 		ctx, cancel := context.WithTimeout(context.Background(), config.Timeout)
 		defer cancel()
 		if err := httpServer.Initialize(ctx); err != nil {
-			fmt.Printf("Warning: failed to initialize x402 server: %v\n", err)
+			x402http.HandleBackgroundInitError(err)
 		}
 	}
 
@@ -177,7 +177,7 @@ func PaymentMiddlewareFromConfig(routes x402http.RoutesConfig, opts ...Middlewar
 		ctx, cancel := context.WithTimeout(context.Background(), config.Timeout)
 		defer cancel()
 		if err := httpServer.Initialize(ctx); err != nil {
-			fmt.Printf("Warning: failed to initialize x402 server: %v\n", err)
+			x402http.HandleBackgroundInitError(err)
 		}
 	}
 
@@ -214,7 +214,7 @@ func PaymentMiddlewareFromHTTPServer(httpServer *x402http.HTTPServer, opts ...Mi
 		ctx, cancel := context.WithTimeout(context.Background(), config.Timeout)
 		defer cancel()
 		if err := httpServer.Initialize(ctx); err != nil {
-			fmt.Printf("Warning: failed to initialize x402 server: %v\n", err)
+			x402http.HandleBackgroundInitError(err)
 		}
 	}
 

--- a/go/mechanisms/svm/README.md
+++ b/go/mechanisms/svm/README.md
@@ -71,7 +71,7 @@ github.com/x402-foundation/x402/go/v2/mechanisms/svm/upto/server
 github.com/x402-foundation/x402/go/v2/mechanisms/svm/upto/facilitator
 ```
 
-The server role additionally needs a voucher signer from `github.com/x402-foundation/x402/go/v2/signers/svm`:
+The server role additionally needs a voucher signer from `github.com/x402-foundation/x402/go/v2/signers/svm` unless the facilitator's `receiverAuthorizer` is delegated to:
 
 ```go
 authorizer, err := svmsigners.NewReceiverAuthorizerSignerFromPrivateKey(os.Getenv("SVM_RECEIVER_AUTHORIZER_PRIVATE_KEY"))

--- a/go/mechanisms/svm/types.go
+++ b/go/mechanisms/svm/types.go
@@ -48,11 +48,26 @@ type UptoSvmPayload struct {
 	OpenTransaction string `json:"openTransaction"`
 	// VoucherSignature is the base58 Ed25519 voucher signature by AuthorizedSigner.
 	// Claim-only and server-owned: verify and deposit settle reject any client-supplied value.
+	// Omitted when the channel delegates receiver authorization to the facilitator.
 	VoucherSignature string `json:"voucherSignature,omitempty"`
+	// Type is the per-settle phase stamped by the resource server. Not part of
+	// the client authorization (that payload is reused for deposit and claim).
+	// Verify rejects it if present. Required when the channel delegates
+	// receiver authorization.
+	Type string `json:"type,omitempty"`
 }
 
 // UptoVoucherSignatureField is the payload key carrying the settle-time voucher.
 const UptoVoucherSignatureField = "voucherSignature"
+
+// UptoPayloadTypeField is the payload key carrying the server-stamped settle phase.
+const UptoPayloadTypeField = "type"
+
+// Server-stamped settle phases for SVM `upto`.
+const (
+	UptoPayloadTypeDeposit = "deposit"
+	UptoPayloadTypeClaim   = "claim"
+)
 
 // ToMap converts an UptoSvmPayload to a map for JSON marshaling.
 func (p *UptoSvmPayload) ToMap() map[string]interface{} {
@@ -70,6 +85,9 @@ func (p *UptoSvmPayload) ToMap() map[string]interface{} {
 	}
 	if p.VoucherSignature != "" {
 		out[UptoVoucherSignatureField] = p.VoucherSignature
+	}
+	if p.Type != "" {
+		out[UptoPayloadTypeField] = p.Type
 	}
 	return out
 }
@@ -102,6 +120,9 @@ func UptoPayloadFromMap(data map[string]interface{}) (*UptoSvmPayload, error) {
 			return nil, fmt.Errorf("missing %s field in payload", field)
 		}
 	}
+	if payload.Type != "" && payload.Type != UptoPayloadTypeDeposit && payload.Type != UptoPayloadTypeClaim {
+		return nil, fmt.Errorf("invalid type field in payload")
+	}
 
 	return &payload, nil
 }
@@ -131,6 +152,12 @@ func IsUptoSvmPayload(payload map[string]interface{}) bool {
 			return false
 		}
 	}
+	if payloadType, present := payload[UptoPayloadTypeField]; present {
+		typed, ok := payloadType.(string)
+		if !ok || (typed != UptoPayloadTypeDeposit && typed != UptoPayloadTypeClaim) {
+			return false
+		}
+	}
 	return true
 }
 
@@ -153,6 +180,14 @@ func jsonNumberIsInt64(value interface{}) bool {
 // deposit settle, so an empty client-supplied value is still a rejection.
 func HasUptoVoucherSignature(payload map[string]interface{}) bool {
 	_, present := payload[UptoVoucherSignatureField]
+	return present
+}
+
+// HasUptoPayloadType reports whether the payload carries the server-stamped
+// settle-phase key. Presence is rejected at verify: the client authorization
+// must not include it.
+func HasUptoPayloadType(payload map[string]interface{}) bool {
+	_, present := payload[UptoPayloadTypeField]
 	return present
 }
 

--- a/go/mechanisms/svm/types_test.go
+++ b/go/mechanisms/svm/types_test.go
@@ -54,6 +54,16 @@ func TestIsUptoSvmPayload(t *testing.T) {
 		t.Fatal("expected valid upto payload")
 	}
 
+	valid["type"] = UptoPayloadTypeDeposit
+	if !IsUptoSvmPayload(valid) {
+		t.Fatal("expected deposit type to pass the guard")
+	}
+	valid["type"] = "refund"
+	if IsUptoSvmPayload(valid) {
+		t.Fatal("expected invalid type to fail the guard")
+	}
+	delete(valid, "type")
+
 	missingExpires := map[string]interface{}{}
 	for k, v := range valid {
 		missingExpires[k] = v

--- a/go/mechanisms/svm/upto/README.md
+++ b/go/mechanisms/svm/upto/README.md
@@ -33,13 +33,43 @@ x402Client := x402.Newx402Client().
 
 ### Key Difference from Exact
 
-The upto client requires `PaymentRequirements.Extra["feePayer"]` (from the facilitator's `GetExtra()`) and `Extra["receiverAuthorizer"]` (from the server). The client signs only the channel `open`; the facilitator co-signs as fee and rent payer, then later submits the settlement carrying the server's voucher.
+The upto client requires `PaymentRequirements.Extra["feePayer"]` (from the facilitator's `GetExtra()`) and `Extra["receiverAuthorizer"]` (from the server). The client signs only the channel `open`; the facilitator co-signs as fee and rent payer, then later submits the settlement carrying a `receiverAuthorizer` voucher (server-signed, or facilitator-signed when delegated).
 
 Pass a `*svm.ClientConfig` with `RPCURL` to control which endpoint the client uses when the challenge omits the `recentBlockhash` / `recentSlot` hints.
 
 ## Server Usage
 
-Register `UptoSvmScheme` with middleware and use `SetSettlementOverrides` in your handler to specify the actual charge. The server must supply a hot `ReceiverAuthorizerSigner` that signs settlement vouchers; that key never signs a transaction and needs no SOL or token balance.
+Register `UptoSvmScheme` with middleware and use `SetSettlementOverrides` in your handler to specify the actual charge.
+
+### Receiver Authorizer
+
+The `receiverAuthorizer` signs settlement vouchers and is committed as the channel `authorized_signer` at deposit:
+
+- **Self-managed** (recommended): pass a `ReceiverAuthorizerSigner` (a hot Ed25519 key; it does not need SOL or tokens). Channels survive facilitator changes — any facilitator can relay your signed vouchers.
+- **Facilitator-delegated**: omit `ReceiverAuthorizerSigner`. The scheme picks up `extra.receiverAuthorizer` advertised by the facilitator's `/supported`. The server needs no voucher-signing key; the facilitator signs after authenticating that the claim settle comes from the same service that opened the channel. Delegation requires an out-of-band agreement with the facilitator plus authenticated server→facilitator settle calls — it is not part of the client payment flow.
+
+Self-managed:
+
+```go
+authorizer, err := svmsigners.NewReceiverAuthorizerSignerFromPrivateKey(
+    os.Getenv("SVM_RECEIVER_AUTHORIZER_PRIVATE_KEY"),
+)
+
+uptosvm.NewUptoSvmScheme(&uptosvm.Config{
+    ReceiverAuthorizerSigner: authorizer,
+    RPCURL:                   os.Getenv("SVM_RPC_URL"), // optional: embeds recentBlockhash/recentSlot in the 402
+})
+```
+
+Facilitator-delegated (omit `ReceiverAuthorizerSigner` only; `RPCURL` unchanged):
+
+```go
+uptosvm.NewUptoSvmScheme(&uptosvm.Config{
+    RPCURL: os.Getenv("SVM_RPC_URL"), // optional: same as self-managed
+})
+```
+
+Full server wiring:
 
 ```go
 import (
@@ -73,8 +103,8 @@ r.Use(ginmw.X402Payment(ginmw.Config{
         {
             Network: x402.Network("solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"),
             Server: uptosvm.NewUptoSvmScheme(&uptosvm.Config{
-                ReceiverAuthorizerSigner: authorizer,
-                RPCURL:                   os.Getenv("SVM_RPC_URL"), // optional: embeds recentBlockhash/recentSlot in the 402
+                ReceiverAuthorizerSigner: authorizer, // omit for facilitator-delegated mode
+                RPCURL:                   os.Getenv("SVM_RPC_URL"),
             }),
         },
     },
@@ -124,8 +154,12 @@ import (
 
 maxChannelLifetimeSecs := 3600
 scheme := uptosvm.NewUptoSvmScheme(svmSigner, &uptosvm.Config{
-    RPCURL:                 os.Getenv("SVM_RPC_URL"),
     MaxChannelLifetimeSecs: &maxChannelLifetimeSecs,
+    // Optional: advertise a receiverAuthorizer so servers can delegate.
+    // Requires ResolveCallerIdentity — construction panics without it.
+    AuthorizerSigner:      authorizer,
+    ResolveCallerIdentity: resolveCallerIdentity,
+    // Optional: shared store for multi-replica facilitators. Default is in-memory.
 })
 facilitator.Register([]x402.Network{network}, scheme)
 
@@ -138,7 +172,11 @@ cleanup.Start(ctx, uptosvm.StartConfig{
 defer cleanup.Stop()
 ```
 
-The upto facilitator's `GetExtra()` returns a `feePayer` address. That key is set as the channel `payee` (with a zero distribution share) and `rent_payer`: it co-signs `open`, sponsors fees and rent, and signs `settle_and_seal`. Any nonzero settlement still requires the server's `receiverAuthorizer` voucher.
+The upto facilitator's `GetExtra()` returns a `feePayer` address and, when `AuthorizerSigner` is set, a `receiverAuthorizer`. `feePayer` is set as the channel `payee` (with a zero distribution share) and `rent_payer`: it co-signs `open`, sponsors fees and rent, and signs `settle_and_seal`.
+
+A facilitator that advertises a `receiverAuthorizer` (so servers can delegate to it) must authenticate that each claim settle originates from the service whose deposit settle opened the channel (e.g. SIWX, JWT, or an API credential correlated across the two settles). The scheme records that identity at deposit and requires an exact match at claim. If the facilitator has no such authentication mechanism, omit `AuthorizerSigner` so no `receiverAuthorizer` is advertised; servers then supply their own voucher signatures.
+
+The default identity store is in-memory. A multi-replica facilitator must inject a shared `DelegatedAuthStore`; a lost binding fails closed and the server cannot settle (the client still has `request_close`).
 
 ### Channel Storage and Rent Cleanup
 
@@ -171,7 +209,7 @@ Canonical program id: `CHNLxYvVA28MJP9PrFuDXccuoGXAx7jBacfLEkahyGsX`
 2. Facilitator advertises `extra.feePayer`
 3. Client derives the channel PDA and signs a payment-channel `open` that escrows the max amount
 4. Facilitator deposits by co-signing and broadcasting `open` (escrow settle, before the handler)
-5. Server performs work, calculates the actual cost, and signs a voucher for it
+5. Server performs work, calculates the actual cost, and attaches `type` plus a voucher when it owns the key
 6. Facilitator claims with `settle_and_seal` + `distribute` for the actual amount (≤ max)
 7. If the actual amount is `0`, the channel closes with a full refund to the client
 

--- a/go/mechanisms/svm/upto/facilitator/delegated_auth_store.go
+++ b/go/mechanisms/svm/upto/facilitator/delegated_auth_store.go
@@ -1,0 +1,82 @@
+package facilitator
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	x402 "github.com/x402-foundation/x402/go/v2"
+)
+
+// DelegatedAuthBinding is the deposit-time caller identity bound to a channel
+// so a later claim settle can be correlated to the same service.
+//
+// Kept off the rent-cleanup channel record: that record is re-upserted at
+// claim time and is repopulated from chain by Discover with no identity
+// available.
+type DelegatedAuthBinding struct {
+	ChannelID string
+	Network   x402.Network
+	// CallerIdentity is the identity ResolveCallerIdentity returned on the deposit settle.
+	CallerIdentity string
+	// ExpiresAt is payload expiresAt (Unix seconds); entries past it are unusable.
+	ExpiresAt int64
+}
+
+// DelegatedAuthStore is a pluggable store of delegated deposit/claim
+// caller-identity bindings.
+type DelegatedAuthStore interface {
+	Bind(ctx context.Context, binding DelegatedAuthBinding) error
+	Get(ctx context.Context, channelID string, network x402.Network) (*DelegatedAuthBinding, error)
+	Delete(ctx context.Context, channelID string, network x402.Network) error
+}
+
+// InMemoryDelegatedAuthStore is the default DelegatedAuthStore. A multi-replica
+// facilitator must inject a shared implementation; a lost binding fails closed.
+type InMemoryDelegatedAuthStore struct {
+	mu       sync.Mutex
+	bindings map[string]DelegatedAuthBinding
+}
+
+// NewInMemoryDelegatedAuthStore creates an empty in-memory identity store.
+func NewInMemoryDelegatedAuthStore() *InMemoryDelegatedAuthStore {
+	return &InMemoryDelegatedAuthStore{bindings: make(map[string]DelegatedAuthBinding)}
+}
+
+func delegatedAuthBindingKey(channelID string, network x402.Network) string {
+	return string(network) + ":" + channelID
+}
+
+// Bind records the caller identity for a channel.
+func (s *InMemoryDelegatedAuthStore) Bind(_ context.Context, binding DelegatedAuthBinding) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.bindings[delegatedAuthBindingKey(binding.ChannelID, binding.Network)] = binding
+	return nil
+}
+
+// Get looks up a binding. Entries at or past ExpiresAt are treated as absent.
+func (s *InMemoryDelegatedAuthStore) Get(_ context.Context, channelID string, network x402.Network) (*DelegatedAuthBinding, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	key := delegatedAuthBindingKey(channelID, network)
+	binding, ok := s.bindings[key]
+	if !ok {
+		return nil, nil
+	}
+	if binding.ExpiresAt <= time.Now().Unix() {
+		delete(s.bindings, key)
+		return nil, nil
+	}
+	copied := binding
+	return &copied, nil
+}
+
+// Delete removes a binding.
+func (s *InMemoryDelegatedAuthStore) Delete(_ context.Context, channelID string, network x402.Network) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.bindings, delegatedAuthBindingKey(channelID, network))
+	return nil
+}

--- a/go/mechanisms/svm/upto/facilitator/delegated_auth_store.go
+++ b/go/mechanisms/svm/upto/facilitator/delegated_auth_store.go
@@ -2,6 +2,8 @@ package facilitator
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"sync"
 	"time"
 
@@ -23,8 +25,22 @@ type DelegatedAuthBinding struct {
 	ExpiresAt int64
 }
 
+// ErrDelegatedAuthIdentityConflict is returned by Bind when a different
+// CallerIdentity already owns the (channelID, network) key.
+var ErrDelegatedAuthIdentityConflict = errors.New("delegated auth binding already exists for a different identity")
+
 // DelegatedAuthStore is a pluggable store of delegated deposit/claim
 // caller-identity bindings.
+//
+// Bind is keyed by (channelID, network) and is first-writer-wins:
+//
+//   - no existing row (or expired) → insert
+//   - existing row, same CallerIdentity → success (idempotent retry after
+//     bind-then-broadcast-fail)
+//   - existing row, different CallerIdentity → ErrDelegatedAuthIdentityConflict
+//
+// Get should return (nil, nil) for not-found / expired and propagate store
+// errors so a host can map infra failures separately from unauthenticated.
 type DelegatedAuthStore interface {
 	Bind(ctx context.Context, binding DelegatedAuthBinding) error
 	Get(ctx context.Context, channelID string, network x402.Network) (*DelegatedAuthBinding, error)
@@ -47,11 +63,25 @@ func delegatedAuthBindingKey(channelID string, network x402.Network) string {
 	return string(network) + ":" + channelID
 }
 
-// Bind records the caller identity for a channel.
+func delegatedAuthExpired(expiresAt int64) bool {
+	return expiresAt <= time.Now().Unix()
+}
+
+// Bind records the caller identity for a channel. First writer wins: a later
+// Bind with the same identity is a no-op; a different identity is an error.
 func (s *InMemoryDelegatedAuthStore) Bind(_ context.Context, binding DelegatedAuthBinding) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.bindings[delegatedAuthBindingKey(binding.ChannelID, binding.Network)] = binding
+
+	key := delegatedAuthBindingKey(binding.ChannelID, binding.Network)
+	existing, ok := s.bindings[key]
+	if ok && !delegatedAuthExpired(existing.ExpiresAt) {
+		if existing.CallerIdentity == binding.CallerIdentity {
+			return nil
+		}
+		return fmt.Errorf("%w", ErrDelegatedAuthIdentityConflict)
+	}
+	s.bindings[key] = binding
 	return nil
 }
 
@@ -65,7 +95,7 @@ func (s *InMemoryDelegatedAuthStore) Get(_ context.Context, channelID string, ne
 	if !ok {
 		return nil, nil
 	}
-	if binding.ExpiresAt <= time.Now().Unix() {
+	if delegatedAuthExpired(binding.ExpiresAt) {
 		delete(s.bindings, key)
 		return nil, nil
 	}

--- a/go/mechanisms/svm/upto/facilitator/errors.go
+++ b/go/mechanisms/svm/upto/facilitator/errors.go
@@ -51,6 +51,18 @@ const (
 	ErrReceiverAuthorizer = "invalid_upto_svm_payload_receiver_authorizer"
 	// ErrVoucherSignature is returned when the voucher is not signed by the authorizer.
 	ErrVoucherSignature = "invalid_upto_svm_payload_voucher_signature"
+	// ErrAuthorizerNotConfigured is returned when a claim settle omitted
+	// voucherSignature and this facilitator has no authorizer.
+	ErrAuthorizerNotConfigured = "invalid_upto_svm_authorizer_not_configured"
+	// ErrAuthorizerAddressMismatch is returned when a delegated claim
+	// authorizedSigner / extra.receiverAuthorizer is not this facilitator.
+	ErrAuthorizerAddressMismatch = "invalid_upto_svm_authorizer_address_mismatch"
+	// ErrDelegatedSettleUnauthenticated is returned when a delegated settle
+	// identity is missing, unresolved, or not the deposit-time binding.
+	ErrDelegatedSettleUnauthenticated = "invalid_upto_svm_delegated_settle_unauthenticated"
+	// ErrPayloadType is returned when the client supplied type, or a delegated
+	// settle is missing type.
+	ErrPayloadType = "invalid_upto_svm_payload_type"
 
 	// Channel and settlement codes.
 

--- a/go/mechanisms/svm/upto/facilitator/scheme.go
+++ b/go/mechanisms/svm/upto/facilitator/scheme.go
@@ -111,6 +111,7 @@ const (
 
 // DelegatedSettleContext is passed to Config.ResolveCallerIdentity.
 type DelegatedSettleContext struct {
+	Ctx                context.Context
 	Step               DelegatedSettleStep
 	ChannelID          string
 	Network            x402.Network
@@ -451,6 +452,7 @@ func (f *UptoSvmScheme) settleDeposit(
 	var depositIdentity string
 	if parseErr == nil && delegated {
 		depositIdentity = f.resolveDelegatedCallerIdentity(DelegatedSettleContext{
+			Ctx:                ctx,
 			Step:               DelegatedSettleStepDeposit,
 			ChannelID:          uptoPayload.ChannelId,
 			Network:            x402.Network(requirements.Network),
@@ -1121,6 +1123,7 @@ func (f *UptoSvmScheme) authenticateDelegatedClaim(
 	}
 
 	identity := f.resolveDelegatedCallerIdentity(DelegatedSettleContext{
+		Ctx:                ctx,
 		Step:               DelegatedSettleStepClaim,
 		ChannelID:          uptoPayload.ChannelId,
 		Network:            x402.Network(requirements.Network),

--- a/go/mechanisms/svm/upto/facilitator/scheme.go
+++ b/go/mechanisms/svm/upto/facilitator/scheme.go
@@ -83,27 +83,72 @@ type Config struct {
 	// distributions. Reclaim batches size themselves per channel and are
 	// mint-independent, so they are unaffected by this cap.
 	SettleComputeUnitLimit *uint32
+
+	// AuthorizerSigner enables facilitator-delegated receiver authorization.
+	// Advertised as /supported extra.receiverAuthorizer and used to sign claim
+	// vouchers when the server omits voucherSignature. Requires
+	// ResolveCallerIdentity.
+	AuthorizerSigner svm.ReceiverAuthorizerSigner
+
+	// ResolveCallerIdentity resolves a stable caller identity for a delegated
+	// settle. Returning an empty string or an error rejects the settle.
+	// Required when AuthorizerSigner is set.
+	ResolveCallerIdentity ResolveCallerIdentity
+
+	// DelegatedAuthStore stores channelId → caller identity bindings written
+	// at deposit and checked at claim. Defaults to InMemoryDelegatedAuthStore.
+	// Inject a shared implementation for a multi-replica facilitator.
+	DelegatedAuthStore DelegatedAuthStore
 }
+
+// DelegatedSettleStep is the settle phase passed to ResolveCallerIdentity.
+type DelegatedSettleStep string
+
+const (
+	DelegatedSettleStepDeposit DelegatedSettleStep = "deposit"
+	DelegatedSettleStepClaim   DelegatedSettleStep = "claim"
+)
+
+// DelegatedSettleContext is passed to Config.ResolveCallerIdentity.
+type DelegatedSettleContext struct {
+	Step               DelegatedSettleStep
+	ChannelID          string
+	Network            x402.Network
+	Payer              string
+	Amount             string
+	ExpiresAt          int64
+	Payload            types.PaymentPayload
+	Requirements       types.PaymentRequirements
+	FacilitatorContext *x402.FacilitatorContext
+}
+
+// ResolveCallerIdentity resolves a stable caller identity for a delegated settle.
+type ResolveCallerIdentity func(ctx DelegatedSettleContext) (string, error)
 
 // UptoSvmScheme implements the SchemeNetworkFacilitator interface for SVM
 // `upto` payments.
 //
-// Escrow flow: a settle without `voucherSignature` whose amount equals
-// `payload.maxAmount` deposits (co-signs and broadcasts `open`); a settle
-// carrying a server voucher claims (`settle_and_seal` + `distribute`).
-// Verify is an optional read-only preflight of the same static checks and
-// never broadcasts.
+// Escrow flow: a settle with payload.type == "deposit" (or, when type is
+// absent, no voucherSignature and amount equal to payload.maxAmount) deposits
+// (co-signs and broadcasts open); a settle with type == "claim" or a server
+// voucher claims (settle_and_seal + distribute). Verify is an optional
+// read-only preflight of the same static checks and never broadcasts.
 //
 // The fee payer holds the channel payee seat with a zero distribution share:
-// it signs `settle_and_seal` as the lifecycle authority and can always seal an
-// abandoned channel to recover its rent, while any nonzero settlement still
-// requires the server's receiver-authorizer voucher.
+// it signs settle_and_seal as the lifecycle authority and can always seal an
+// abandoned channel to recover its rent. Nonzero settlement requires a
+// receiver-authorizer voucher — signed by the server, or by this facilitator
+// when the server delegates and the caller identity matches the deposit-time
+// binding.
 type UptoSvmScheme struct {
-	signer          UptoFacilitatorSigner
-	config          Config
-	channelStorage  ChannelStorage
-	settlementCache *svm.SettlementCache
-	pendingStore    x402.PendingSettlementStore
+	signer                UptoFacilitatorSigner
+	config                Config
+	channelStorage        ChannelStorage
+	settlementCache       *svm.SettlementCache
+	pendingStore          x402.PendingSettlementStore
+	authorizerSigner      svm.ReceiverAuthorizerSigner
+	resolveCallerIdentity ResolveCallerIdentity
+	delegatedAuthStore    DelegatedAuthStore
 }
 
 // NewUptoSvmScheme creates a new UptoSvmScheme. The signer supplies the fee
@@ -132,16 +177,26 @@ func NewUptoSvmScheme(signer svm.FacilitatorSvmSigner, config *Config) *UptoSvmS
 	if cfg.SettleComputeUnitLimit != nil {
 		assertPositive("settleComputeUnitLimit", int64(*cfg.SettleComputeUnitLimit))
 	}
+	if cfg.AuthorizerSigner != nil && cfg.ResolveCallerIdentity == nil {
+		panic("upto svm facilitator: authorizerSigner requires resolveCallerIdentity")
+	}
 	storage := cfg.ChannelStorage
 	if storage == nil {
 		storage = NewInMemoryChannelStorage()
 	}
+	delegatedAuthStore := cfg.DelegatedAuthStore
+	if delegatedAuthStore == nil {
+		delegatedAuthStore = NewInMemoryDelegatedAuthStore()
+	}
 	return &UptoSvmScheme{
-		signer:          assertUptoFacilitatorSigner(signer, "UptoSvmScheme"),
-		config:          cfg,
-		channelStorage:  storage,
-		settlementCache: svm.NewSettlementCache(),
-		pendingStore:    x402.NewInMemoryPendingSettlementStore(),
+		signer:                assertUptoFacilitatorSigner(signer, "UptoSvmScheme"),
+		config:                cfg,
+		channelStorage:        storage,
+		settlementCache:       svm.NewSettlementCache(),
+		pendingStore:          x402.NewInMemoryPendingSettlementStore(),
+		authorizerSigner:      cfg.AuthorizerSigner,
+		resolveCallerIdentity: cfg.ResolveCallerIdentity,
+		delegatedAuthStore:    delegatedAuthStore,
 	}
 }
 
@@ -200,9 +255,13 @@ func (f *UptoSvmScheme) GetExtra(network x402.Network) map[string]interface{} {
 	if len(addresses) == 0 {
 		return nil
 	}
-	return map[string]interface{}{
+	extra := map[string]interface{}{
 		upto.ExtraFeePayer: addresses[rand.IntN(len(addresses))].String(),
 	}
+	if f.authorizerSigner != nil {
+		extra[upto.ExtraReceiverAuthorizer] = f.authorizerSigner.Address().String()
+	}
+	return extra
 }
 
 // GetSigners returns the fee-payer addresses managed by this facilitator.
@@ -223,7 +282,7 @@ func (f *UptoSvmScheme) Verify(
 	requirements types.PaymentRequirements,
 	_ *x402.FacilitatorContext,
 ) (*x402.VerifyResponse, error) {
-	auth, err := f.validateOpenAuthorization(ctx, payload, requirements)
+	auth, err := f.validateOpenAuthorization(ctx, payload, requirements, true)
 	if err != nil {
 		return nil, err
 	}
@@ -232,15 +291,15 @@ func (f *UptoSvmScheme) Verify(
 
 // Settle deposits (opens the channel) or claims (settle_and_seal + distribute).
 //
-// The settle phase is not on the wire, so the path is discriminated by the
-// payload: a present `voucherSignature` key claims; otherwise an amount equal
-// to the signed ceiling deposits. Anything else is a partial charge with no
-// authorization and is rejected.
+// Prefers payload.type when present. When absent (older servers):
+// a present voucherSignature key claims; otherwise an amount equal to the
+// signed ceiling deposits. type is required when the settle is delegated to
+// this facilitator.
 func (f *UptoSvmScheme) Settle(
 	ctx context.Context,
 	payload types.PaymentPayload,
 	requirements types.PaymentRequirements,
-	_ *x402.FacilitatorContext,
+	fctx *x402.FacilitatorContext,
 ) (*x402.SettleResponse, error) {
 	network := x402.Network(payload.Accepted.Network)
 
@@ -272,11 +331,23 @@ func (f *UptoSvmScheme) Settle(
 			fmt.Sprintf("settlement amount %d exceeds the authorized ceiling %d", actual, maxAmount))
 	}
 
+	delegated := f.isDelegatedSettle(requirements)
+	if uptoPayload.Type == svm.UptoPayloadTypeDeposit {
+		return f.settleDeposit(ctx, payload, requirements, fctx)
+	}
+	if uptoPayload.Type == svm.UptoPayloadTypeClaim {
+		return f.settleClaim(ctx, payload, requirements, uptoPayload, actual, maxAmount, fctx)
+	}
+	if delegated {
+		return nil, x402.NewSettleError(ErrPayloadType, uptoPayload.From, network, "",
+			"a delegated settle requires payload.type")
+	}
+
 	if svm.HasUptoVoucherSignature(payload.Payload) {
-		return f.settleClaim(ctx, payload, requirements, uptoPayload, actual, maxAmount)
+		return f.settleClaim(ctx, payload, requirements, uptoPayload, actual, maxAmount, fctx)
 	}
 	if actual == maxAmount {
-		return f.settleDeposit(ctx, payload, requirements)
+		return f.settleDeposit(ctx, payload, requirements, fctx)
 	}
 	return nil, x402.NewSettleError(ErrMissingVoucher, uptoPayload.From, network, "",
 		"a partial settlement requires a receiver-authorizer voucher")
@@ -371,22 +442,44 @@ func (f *UptoSvmScheme) settleDeposit(
 	ctx context.Context,
 	payload types.PaymentPayload,
 	requirements types.PaymentRequirements,
+	fctx *x402.FacilitatorContext,
 ) (*x402.SettleResponse, error) {
 	network := x402.Network(payload.Accepted.Network)
+
+	uptoPayload, parseErr := svm.UptoPayloadFromMap(payload.Payload)
+	delegated := f.isDelegatedSettle(requirements)
+	var depositIdentity string
+	if parseErr == nil && delegated {
+		depositIdentity = f.resolveDelegatedCallerIdentity(DelegatedSettleContext{
+			Step:               DelegatedSettleStepDeposit,
+			ChannelID:          uptoPayload.ChannelId,
+			Network:            x402.Network(requirements.Network),
+			Payer:              uptoPayload.From,
+			Amount:             requirements.Amount,
+			ExpiresAt:          uptoPayload.ExpiresAt,
+			Payload:            payload,
+			Requirements:       requirements,
+			FacilitatorContext: fctx,
+		})
+		if depositIdentity == "" {
+			return nil, x402.NewSettleError(ErrDelegatedSettleUnauthenticated, uptoPayload.From, network, "",
+				"delegated deposit settle is unauthenticated")
+		}
+	}
 
 	// Pending-settlement fast path: a prior deposit settle for this exact
 	// channel broadcast the open successfully but couldn't confirm it in
 	// time. Reconcile against that signature instead of re-validating and
 	// re-broadcasting — a second open attempt would hit ErrChannelAlreadyOpen
 	// even though the original payment is (or will be) fine.
-	if uptoPayload, parseErr := svm.UptoPayloadFromMap(payload.Payload); parseErr == nil {
+	if parseErr == nil {
 		depositKey := uptoDepositCacheKey(string(requirements.Network), uptoPayload.ChannelId)
 		if resp, hit, err := f.reconcilePendingUpto(ctx, depositKey, uptoPayload.From, uptoPayload.MaxAmount, network, string(requirements.Network)); hit {
 			return resp, err
 		}
 	}
 
-	auth, err := f.validateOpenAuthorization(ctx, payload, requirements)
+	auth, err := f.validateOpenAuthorization(ctx, payload, requirements, false)
 	if err != nil {
 		verifyErr := &x402.VerifyError{}
 		if !errors.As(err, &verifyErr) {
@@ -395,7 +488,7 @@ func (f *UptoSvmScheme) settleDeposit(
 		return nil, x402.NewSettleError(verifyErr.InvalidReason, verifyErr.Payer, network, "", verifyErr.InvalidMessage)
 	}
 
-	uptoPayload := auth.payload
+	uptoPayload = auth.payload
 	networkStr := string(requirements.Network)
 
 	// One authorization opens one channel. An existing PDA is a replay or a
@@ -450,7 +543,19 @@ func (f *UptoSvmScheme) settleDeposit(
 	}); err != nil {
 		f.settlementCache.Delete(depositKey)
 		return nil, x402.NewSettleError(ErrChannelBroadcast, uptoPayload.From, network, "",
-			fmt.Sprintf("failed to durably index the channel before broadcast: %s", err.Error()))
+			fmt.Sprintf("failed to durably record the channel before broadcast: %s", err.Error()))
+	}
+	if delegated && depositIdentity != "" {
+		if err := f.delegatedAuthStore.Bind(ctx, DelegatedAuthBinding{
+			ChannelID:      uptoPayload.ChannelId,
+			Network:        x402.Network(requirements.Network),
+			CallerIdentity: depositIdentity,
+			ExpiresAt:      uptoPayload.ExpiresAt,
+		}); err != nil {
+			f.settlementCache.Delete(depositKey)
+			return nil, x402.NewSettleError(ErrChannelBroadcast, uptoPayload.From, network, "",
+				fmt.Sprintf("failed to durably record the channel before broadcast: %s", err.Error()))
+		}
 	}
 
 	openSignature, err := broadcastOpen(
@@ -501,8 +606,16 @@ func (f *UptoSvmScheme) settleClaim(
 	uptoPayload *svm.UptoSvmPayload,
 	actual uint64,
 	maxAmount uint64,
+	fctx *x402.FacilitatorContext,
 ) (*x402.SettleResponse, error) {
 	network := x402.Network(payload.Accepted.Network)
+
+	hasVoucher := uptoPayload.VoucherSignature != ""
+	if !hasVoucher {
+		if err := f.authenticateDelegatedClaim(ctx, payload, requirements, uptoPayload, fctx); err != nil {
+			return nil, err
+		}
+	}
 
 	// Pending-settlement fast path: a prior claim settle for this exact
 	// channel broadcast settle_and_seal + distribute successfully but
@@ -513,12 +626,10 @@ func (f *UptoSvmScheme) settleClaim(
 	// original payment succeeded.
 	settlementKey := uptoClaimCacheKey(string(requirements.Network), uptoPayload.ChannelId)
 	if resp, hit, err := f.reconcilePendingUpto(ctx, settlementKey, uptoPayload.From, strconv.FormatUint(actual, 10), network, string(requirements.Network)); hit {
+		if err == nil {
+			_ = f.delegatedAuthStore.Delete(ctx, uptoPayload.ChannelId, x402.Network(requirements.Network))
+		}
 		return resp, err
-	}
-
-	if uptoPayload.VoucherSignature == "" {
-		return nil, x402.NewSettleError(ErrMissingVoucher, uptoPayload.From, network, "",
-			"voucherSignature is present but empty")
 	}
 
 	channelConfig, err := upto.ResolvePaymentChannelConfig(requirements)
@@ -550,11 +661,14 @@ func (f *UptoSvmScheme) settleClaim(
 	if err != nil {
 		return nil, x402.NewSettleError(ErrChannelID, uptoPayload.From, network, "", err.Error())
 	}
-	voucherMessage := paymentchannels.EncodeVoucherMessage(channelID, actual, uptoPayload.ExpiresAt)
-	if err := paymentchannels.VerifyVoucherSignature(
-		uptoPayload.VoucherSignature, uptoPayload.AuthorizedSigner, voucherMessage,
-	); err != nil {
-		return nil, x402.NewSettleError(ErrVoucherSignature, uptoPayload.From, network, "", err.Error())
+	voucherSignature := uptoPayload.VoucherSignature
+	if hasVoucher {
+		voucherMessage := paymentchannels.EncodeVoucherMessage(channelID, actual, uptoPayload.ExpiresAt)
+		if err := paymentchannels.VerifyVoucherSignature(
+			uptoPayload.VoucherSignature, uptoPayload.AuthorizedSigner, voucherMessage,
+		); err != nil {
+			return nil, x402.NewSettleError(ErrVoucherSignature, uptoPayload.From, network, "", err.Error())
+		}
 	}
 
 	tokenProgram, err := upto.ResolveTokenProgram(requirements)
@@ -598,6 +712,23 @@ func (f *UptoSvmScheme) settleClaim(
 		return nil, x402.NewSettleError(ErrPaymentRequirements, uptoPayload.From, network, "", blockhashErr.Error())
 	}
 
+	if !hasVoucher {
+		if f.authorizerSigner == nil || channel.AuthorizedSigner.String() != f.authorizerSigner.Address().String() {
+			return nil, x402.NewSettleError(ErrAuthorizerAddressMismatch, uptoPayload.From, network, "",
+				"delegated claim authorizer is not this facilitator")
+		}
+		message := paymentchannels.EncodeVoucherMessage(channelID, actual, uptoPayload.ExpiresAt)
+		signatureBytes, err := f.authorizerSigner.SignMessage(ctx, message)
+		if err != nil {
+			return nil, x402.NewSettleError(ErrVoucherSignature, uptoPayload.From, network, "", err.Error())
+		}
+		if len(signatureBytes) != 64 {
+			return nil, x402.NewSettleError(ErrVoucherSignature, uptoPayload.From, network, "",
+				fmt.Sprintf("voucher signature must be 64 bytes, got %d", len(signatureBytes)))
+		}
+		voucherSignature = solana.SignatureFromBytes(signatureBytes).String()
+	}
+
 	// Deduplicate only once the channel is rebound, so replays and concurrent
 	// claims — including ones carrying a different valid voucher — collapse to
 	// a single settle_and_seal + distribute. Failures above never insert.
@@ -611,7 +742,7 @@ func (f *UptoSvmScheme) settleClaim(
 		TokenProgram:     tokenProgram,
 		Actual:           actual,
 		ExpiresAt:        uptoPayload.ExpiresAt,
-		VoucherSignature: uptoPayload.VoucherSignature,
+		VoucherSignature: voucherSignature,
 	}, &prefetchedHash)
 	if err != nil {
 		var simErr *SettlementSimulationError
@@ -643,6 +774,7 @@ func (f *UptoSvmScheme) settleClaim(
 		ExpiresAt:    uptoPayload.ExpiresAt,
 		Network:      string(requirements.Network),
 	})
+	_ = f.delegatedAuthStore.Delete(ctx, channel.ChannelID.String(), x402.Network(requirements.Network))
 
 	return &x402.SettleResponse{
 		Success:     true,
@@ -723,6 +855,7 @@ func (f *UptoSvmScheme) validateOpenAuthorization(
 	ctx context.Context,
 	payload types.PaymentPayload,
 	requirements types.PaymentRequirements,
+	rejectType bool,
 ) (*openAuthorization, error) {
 	uptoPayload, err := svm.UptoPayloadFromMap(payload.Payload)
 	if err != nil {
@@ -741,6 +874,10 @@ func (f *UptoSvmScheme) validateOpenAuthorization(
 	if svm.HasUptoVoucherSignature(payload.Payload) {
 		return nil, x402.NewVerifyError(ErrUnexpectedVoucher, payer,
 			"voucherSignature is server-owned and only valid on a claim settlement")
+	}
+	if rejectType && svm.HasUptoPayloadType(payload.Payload) {
+		return nil, x402.NewVerifyError(ErrPayloadType, payer,
+			"type is server-owned and only valid on a settlement")
 	}
 
 	channelConfig, err := upto.ResolvePaymentChannelConfig(requirements)
@@ -936,6 +1073,74 @@ func (f *UptoSvmScheme) resolveRecentSlot(
 		return 0, fmt.Errorf("failed to fetch the current slot: %w", err)
 	}
 	return slot, nil
+}
+
+// isDelegatedSettle reports whether this settle's extra.receiverAuthorizer is
+// this facilitator's advertised authorizer.
+func (f *UptoSvmScheme) isDelegatedSettle(requirements types.PaymentRequirements) bool {
+	if f.authorizerSigner == nil || requirements.Extra == nil {
+		return false
+	}
+	advertised, _ := requirements.Extra[upto.ExtraReceiverAuthorizer].(string)
+	return advertised != "" && advertised == f.authorizerSigner.Address().String()
+}
+
+// resolveDelegatedCallerIdentity resolves a delegated settle's caller identity.
+// Errors and empty/missing results are treated as unauthenticated.
+func (f *UptoSvmScheme) resolveDelegatedCallerIdentity(ctx DelegatedSettleContext) string {
+	if f.resolveCallerIdentity == nil {
+		return ""
+	}
+	identity, err := f.resolveCallerIdentity(ctx)
+	if err != nil || identity == "" {
+		return ""
+	}
+	return identity
+}
+
+// authenticateDelegatedClaim authenticates a delegated claim that omitted
+// voucherSignature. Runs before the pending-settlement fast path and any RPC.
+func (f *UptoSvmScheme) authenticateDelegatedClaim(
+	ctx context.Context,
+	payload types.PaymentPayload,
+	requirements types.PaymentRequirements,
+	uptoPayload *svm.UptoSvmPayload,
+	fctx *x402.FacilitatorContext,
+) error {
+	network := x402.Network(payload.Accepted.Network)
+	if f.authorizerSigner == nil {
+		return x402.NewSettleError(ErrAuthorizerNotConfigured, uptoPayload.From, network, "",
+			"claim omitted voucherSignature and no authorizer is configured")
+	}
+	extraAuthorizer, _ := requirements.Extra[upto.ExtraReceiverAuthorizer].(string)
+	if extraAuthorizer == "" ||
+		uptoPayload.AuthorizedSigner != extraAuthorizer ||
+		extraAuthorizer != f.authorizerSigner.Address().String() {
+		return x402.NewSettleError(ErrAuthorizerAddressMismatch, uptoPayload.From, network, "",
+			"delegated claim authorizer is not this facilitator")
+	}
+
+	identity := f.resolveDelegatedCallerIdentity(DelegatedSettleContext{
+		Step:               DelegatedSettleStepClaim,
+		ChannelID:          uptoPayload.ChannelId,
+		Network:            x402.Network(requirements.Network),
+		Payer:              uptoPayload.From,
+		Amount:             requirements.Amount,
+		ExpiresAt:          uptoPayload.ExpiresAt,
+		Payload:            payload,
+		Requirements:       requirements,
+		FacilitatorContext: fctx,
+	})
+	if identity == "" {
+		return x402.NewSettleError(ErrDelegatedSettleUnauthenticated, uptoPayload.From, network, "",
+			"delegated claim settle is unauthenticated")
+	}
+	binding, err := f.delegatedAuthStore.Get(ctx, uptoPayload.ChannelId, x402.Network(requirements.Network))
+	if err != nil || binding == nil || binding.CallerIdentity != identity {
+		return x402.NewSettleError(ErrDelegatedSettleUnauthenticated, uptoPayload.From, network, "",
+			"delegated claim settle is unauthenticated")
+	}
+	return nil
 }
 
 func (f *UptoSvmScheme) resolveFeePayer(

--- a/go/mechanisms/svm/upto/facilitator/scheme_test.go
+++ b/go/mechanisms/svm/upto/facilitator/scheme_test.go
@@ -138,6 +138,13 @@ func TestVerifyRejections(t *testing.T) {
 			wantReason: ErrUnexpectedVoucher,
 		},
 		{
+			name: "client-supplied type",
+			payload: func(_ *testing.T, f *paymentFixture) types.PaymentPayload {
+				return f.withPayload(map[string]interface{}{svm.UptoPayloadTypeField: svm.UptoPayloadTypeDeposit})
+			},
+			wantReason: ErrPayloadType,
+		},
+		{
 			name: "missing receiver authorizer in the challenge",
 			require: func(_ *testing.T, f *paymentFixture) types.PaymentRequirements {
 				return f.withRequirements(func(requirements *types.PaymentRequirements) {
@@ -518,7 +525,7 @@ func TestSettleRejectsAnEmptyVoucher(t *testing.T) {
 
 	_, err := scheme.Settle(context.Background(), payload, fixture.claimRequirements(500), nil)
 
-	assert.Equal(t, ErrMissingVoucher, settleErrorReason(t, err))
+	assert.Equal(t, ErrAuthorizerNotConfigured, settleErrorReason(t, err))
 }
 
 func TestDepositSettleSimulatesThenBroadcasts(t *testing.T) {
@@ -1305,4 +1312,250 @@ func instructionPrograms(t *testing.T, tx *solana.Transaction) []solana.PublicKe
 		programs = append(programs, program)
 	}
 	return programs
+}
+
+type testAuthorizerSigner struct {
+	key solana.PrivateKey
+}
+
+func (a *testAuthorizerSigner) Address() solana.PublicKey {
+	return a.key.PublicKey()
+}
+
+func (a *testAuthorizerSigner) SignMessage(_ context.Context, message []byte) ([]byte, error) {
+	signature, err := a.key.Sign(message)
+	if err != nil {
+		return nil, err
+	}
+	return signature[:], nil
+}
+
+func identityResolver(identity string) ResolveCallerIdentity {
+	return func(DelegatedSettleContext) (string, error) {
+		return identity, nil
+	}
+}
+
+type delegatedFixture struct {
+	signer     *mockSigner
+	stub       *stubRPC
+	fixture    *paymentFixture
+	scheme     *UptoSvmScheme
+	authorizer *testAuthorizerSigner
+	store      *InMemoryDelegatedAuthStore
+}
+
+func newDelegatedFixture(t *testing.T, resolve ResolveCallerIdentity) *delegatedFixture {
+	t.Helper()
+	signer := newMockSigner(t, 1)
+	stub := newStubRPC(t)
+	authorizerKey, err := solana.NewRandomPrivateKey()
+	require.NoError(t, err)
+	authorizer := &testAuthorizerSigner{key: authorizerKey}
+	store := NewInMemoryDelegatedAuthStore()
+	scheme := newScheme(signer, stub, &Config{
+		AuthorizerSigner:      authorizer,
+		ResolveCallerIdentity: resolve,
+		DelegatedAuthStore:    store,
+	})
+	fixture := newPaymentFixtureWithAuthorizer(t, signer, authorizerKey)
+	return &delegatedFixture{
+		signer:     signer,
+		stub:       stub,
+		fixture:    fixture,
+		scheme:     scheme,
+		authorizer: authorizer,
+		store:      store,
+	}
+}
+
+func (d *delegatedFixture) depositPayload() types.PaymentPayload {
+	return d.fixture.withPayload(map[string]interface{}{svm.UptoPayloadTypeField: svm.UptoPayloadTypeDeposit})
+}
+
+func (d *delegatedFixture) claimPayload() types.PaymentPayload {
+	return d.fixture.withPayload(map[string]interface{}{svm.UptoPayloadTypeField: svm.UptoPayloadTypeClaim})
+}
+
+func (d *delegatedFixture) openOnSend(t *testing.T) {
+	d.signer.onSend = func(*solana.Transaction) {
+		d.stub.setAccount(d.fixture.channelID.String(), d.fixture.openChannel().encode(t))
+	}
+}
+
+func TestGetExtraIncludesReceiverAuthorizerOnlyWhenAuthorizerSignerIsSet(t *testing.T) {
+	signer := newMockSigner(t, 1)
+	scheme := newScheme(signer, newStubRPC(t), nil)
+	extra := scheme.GetExtra(testNetwork)
+	require.NotNil(t, extra)
+	_, hasAuthorizer := extra[upto.ExtraReceiverAuthorizer]
+	assert.False(t, hasAuthorizer)
+
+	authorizerKey, err := solana.NewRandomPrivateKey()
+	require.NoError(t, err)
+	delegated := NewUptoSvmScheme(signer, &Config{
+		AuthorizerSigner:      &testAuthorizerSigner{key: authorizerKey},
+		ResolveCallerIdentity: identityResolver("svc-1"),
+	})
+	delegatedExtra := delegated.GetExtra(testNetwork)
+	assert.Equal(t, authorizerKey.PublicKey().String(), delegatedExtra[upto.ExtraReceiverAuthorizer])
+	assert.Contains(t, delegatedExtra, upto.ExtraFeePayer)
+}
+
+func TestNewUptoSvmSchemeRequiresResolveCallerIdentityWithAuthorizer(t *testing.T) {
+	signer := newMockSigner(t, 1)
+	authorizerKey, err := solana.NewRandomPrivateKey()
+	require.NoError(t, err)
+	assert.Panics(t, func() {
+		NewUptoSvmScheme(signer, &Config{AuthorizerSigner: &testAuthorizerSigner{key: authorizerKey}})
+	})
+}
+
+func TestDelegatedSettleRoutesFullChargeTypeClaimAsClaim(t *testing.T) {
+	d := newDelegatedFixture(t, identityResolver("svc-1"))
+	d.openOnSend(t)
+
+	_, err := d.scheme.Settle(context.Background(), d.depositPayload(), d.fixture.requirements, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(d.signer.sentTransactions()))
+
+	d.stub.setAccount(d.fixture.channelID.String(), d.fixture.openChannel().encode(t))
+	sentBefore := len(d.signer.sentTransactions())
+
+	response, err := d.scheme.Settle(context.Background(), d.claimPayload(), d.fixture.requirements, nil)
+	require.NoError(t, err)
+	assert.True(t, response.Success)
+	assert.Equal(t, "10000", response.Amount)
+	assert.Equal(t, sentBefore+1, len(d.signer.sentTransactions()), "claim must not re-broadcast open")
+	binding, err := d.store.Get(context.Background(), d.fixture.channelID.String(), testNetwork)
+	require.NoError(t, err)
+	assert.Nil(t, binding)
+}
+
+func TestDelegatedSettleRejectsMissingType(t *testing.T) {
+	d := newDelegatedFixture(t, identityResolver("svc-1"))
+
+	_, err := d.scheme.Settle(context.Background(), d.fixture.payload, d.fixture.requirements, nil)
+	assert.Equal(t, ErrPayloadType, settleErrorReason(t, err))
+	assert.Empty(t, d.signer.sentTransactions())
+}
+
+func TestDelegatedSettleRejectsClientSuppliedTypeAtVerify(t *testing.T) {
+	d := newDelegatedFixture(t, identityResolver("svc-1"))
+
+	_, err := d.scheme.Verify(context.Background(), d.depositPayload(), d.fixture.requirements, nil)
+	assert.Equal(t, ErrPayloadType, verifyErrorReason(t, err))
+}
+
+func TestDelegatedSettleSignsAndSettlesMatchingIdentities(t *testing.T) {
+	var steps []DelegatedSettleStep
+	resolve := func(ctx DelegatedSettleContext) (string, error) {
+		steps = append(steps, ctx.Step)
+		return "svc-1", nil
+	}
+	d := newDelegatedFixture(t, resolve)
+	d.openOnSend(t)
+
+	_, err := d.scheme.Settle(context.Background(), d.depositPayload(), d.fixture.requirements, nil)
+	require.NoError(t, err)
+	binding, err := d.store.Get(context.Background(), d.fixture.channelID.String(), testNetwork)
+	require.NoError(t, err)
+	require.NotNil(t, binding)
+	assert.Equal(t, "svc-1", binding.CallerIdentity)
+
+	d.stub.setAccount(d.fixture.channelID.String(), d.fixture.openChannel().encode(t))
+
+	response, err := d.scheme.Settle(context.Background(), d.claimPayload(), d.fixture.claimRequirements(1858), nil)
+	require.NoError(t, err)
+	assert.True(t, response.Success)
+	assert.Equal(t, "1858", response.Amount)
+	assert.Equal(t, []DelegatedSettleStep{DelegatedSettleStepDeposit, DelegatedSettleStepClaim}, steps)
+	binding, err = d.store.Get(context.Background(), d.fixture.channelID.String(), testNetwork)
+	require.NoError(t, err)
+	assert.Nil(t, binding)
+}
+
+func TestDelegatedSettleRejectsDifferentIdentityWithoutBroadcasting(t *testing.T) {
+	calls := 0
+	resolve := func(DelegatedSettleContext) (string, error) {
+		calls++
+		if calls == 1 {
+			return "svc-1", nil
+		}
+		return "svc-2", nil
+	}
+	d := newDelegatedFixture(t, resolve)
+	d.openOnSend(t)
+
+	_, err := d.scheme.Settle(context.Background(), d.depositPayload(), d.fixture.requirements, nil)
+	require.NoError(t, err)
+	sentBefore := len(d.signer.sentTransactions())
+	accountReadsBefore := len(d.stub.commitmentsFor("getAccountInfo"))
+
+	_, err = d.scheme.Settle(context.Background(), d.claimPayload(), d.fixture.claimRequirements(1858), nil)
+	assert.Equal(t, ErrDelegatedSettleUnauthenticated, settleErrorReason(t, err))
+	assert.Equal(t, sentBefore, len(d.signer.sentTransactions()))
+	assert.Equal(t, accountReadsBefore, len(d.stub.commitmentsFor("getAccountInfo")), "claim must not fetch the channel before identity match")
+}
+
+func TestDelegatedSettleRejectsClaimWithNoStoredBinding(t *testing.T) {
+	d := newDelegatedFixture(t, identityResolver("svc-1"))
+
+	_, err := d.scheme.Settle(context.Background(), d.claimPayload(), d.fixture.claimRequirements(1858), nil)
+	assert.Equal(t, ErrDelegatedSettleUnauthenticated, settleErrorReason(t, err))
+	assert.Empty(t, d.signer.sentTransactions())
+	assert.Empty(t, d.stub.commitmentsFor("getAccountInfo"))
+}
+
+func TestDelegatedSettleRejectsWhenResolveCallerIdentityIsUndefinedOrThrowing(t *testing.T) {
+	tests := []struct {
+		name     string
+		resolver ResolveCallerIdentity
+	}{
+		{name: "undefined", resolver: func(DelegatedSettleContext) (string, error) { return "", nil }},
+		{name: "throwing", resolver: func(DelegatedSettleContext) (string, error) { return "", errors.New("no creds") }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			d := newDelegatedFixture(t, test.resolver)
+
+			_, err := d.scheme.Settle(context.Background(), d.depositPayload(), d.fixture.requirements, nil)
+			assert.Equal(t, ErrDelegatedSettleUnauthenticated, settleErrorReason(t, err))
+			assert.Empty(t, d.signer.sentTransactions())
+			assert.Zero(t, d.stub.simulations())
+
+			_, err = d.scheme.Settle(context.Background(), d.claimPayload(), d.fixture.claimRequirements(1858), nil)
+			assert.Equal(t, ErrDelegatedSettleUnauthenticated, settleErrorReason(t, err))
+			assert.Empty(t, d.signer.sentTransactions())
+		})
+	}
+}
+
+func TestDelegatedSettleRejectsClaimWhenAuthorizerSignerIsNotConfigured(t *testing.T) {
+	signer := newMockSigner(t, 1)
+	stub := newStubRPC(t)
+	fixture := newPaymentFixture(t, signer)
+	scheme := newScheme(signer, stub, nil)
+
+	_, err := scheme.Settle(context.Background(), fixture.withPayload(map[string]interface{}{
+		svm.UptoPayloadTypeField: svm.UptoPayloadTypeClaim,
+	}), fixture.claimRequirements(1858), nil)
+	assert.Equal(t, ErrAuthorizerNotConfigured, settleErrorReason(t, err))
+}
+
+func TestDelegatedSettleRejectsClaimWhoseAuthorizerIsNotThisFacilitator(t *testing.T) {
+	signer := newMockSigner(t, 1)
+	stub := newStubRPC(t)
+	authorizerKey, err := solana.NewRandomPrivateKey()
+	require.NoError(t, err)
+	fixture := newPaymentFixture(t, signer)
+	scheme := newScheme(signer, stub, &Config{
+		AuthorizerSigner:      &testAuthorizerSigner{key: authorizerKey},
+		ResolveCallerIdentity: identityResolver("svc-1"),
+	})
+
+	_, err = scheme.Settle(context.Background(), fixture.withPayload(map[string]interface{}{
+		svm.UptoPayloadTypeField: svm.UptoPayloadTypeClaim,
+	}), fixture.claimRequirements(1858), nil)
+	assert.Equal(t, ErrAuthorizerAddressMismatch, settleErrorReason(t, err))
 }

--- a/go/mechanisms/svm/upto/facilitator/scheme_test.go
+++ b/go/mechanisms/svm/upto/facilitator/scheme_test.go
@@ -1411,6 +1411,46 @@ func TestNewUptoSvmSchemeRequiresResolveCallerIdentityWithAuthorizer(t *testing.
 	})
 }
 
+func TestInMemoryDelegatedAuthStore_Bind_FirstWriterWins(t *testing.T) {
+	store := NewInMemoryDelegatedAuthStore()
+	ctx := t.Context()
+	expiresAt := time.Now().Add(time.Hour).Unix()
+
+	require.NoError(t, store.Bind(ctx, DelegatedAuthBinding{
+		ChannelID: "ch-1", Network: testNetwork, CallerIdentity: "svc-1", ExpiresAt: expiresAt,
+	}))
+	require.NoError(t, store.Bind(ctx, DelegatedAuthBinding{
+		ChannelID: "ch-1", Network: testNetwork, CallerIdentity: "svc-1", ExpiresAt: expiresAt,
+	}))
+
+	err := store.Bind(ctx, DelegatedAuthBinding{
+		ChannelID: "ch-1", Network: testNetwork, CallerIdentity: "svc-2", ExpiresAt: expiresAt,
+	})
+	require.ErrorIs(t, err, ErrDelegatedAuthIdentityConflict)
+
+	got, err := store.Get(ctx, "ch-1", testNetwork)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "svc-1", got.CallerIdentity)
+}
+
+func TestInMemoryDelegatedAuthStore_Bind_ExpiredIsAbsent(t *testing.T) {
+	store := NewInMemoryDelegatedAuthStore()
+	ctx := t.Context()
+
+	require.NoError(t, store.Bind(ctx, DelegatedAuthBinding{
+		ChannelID: "ch-1", Network: testNetwork, CallerIdentity: "svc-1", ExpiresAt: time.Now().Add(-time.Second).Unix(),
+	}))
+	require.NoError(t, store.Bind(ctx, DelegatedAuthBinding{
+		ChannelID: "ch-1", Network: testNetwork, CallerIdentity: "svc-2", ExpiresAt: time.Now().Add(time.Hour).Unix(),
+	}))
+
+	got, err := store.Get(ctx, "ch-1", testNetwork)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "svc-2", got.CallerIdentity)
+}
+
 func TestDelegatedSettleRoutesFullChargeTypeClaimAsClaim(t *testing.T) {
 	d := newDelegatedFixture(t, identityResolver("svc-1"))
 	d.openOnSend(t)

--- a/go/mechanisms/svm/upto/facilitator/utils_test.go
+++ b/go/mechanisms/svm/upto/facilitator/utils_test.go
@@ -545,10 +545,15 @@ type paymentFixture struct {
 
 func newPaymentFixture(t *testing.T, signer *mockSigner) *paymentFixture {
 	t.Helper()
+	authorizer, err := solana.NewRandomPrivateKey()
+	require.NoError(t, err)
+	return newPaymentFixtureWithAuthorizer(t, signer, authorizer)
+}
+
+func newPaymentFixtureWithAuthorizer(t *testing.T, signer *mockSigner, authorizer solana.PrivateKey) *paymentFixture {
+	t.Helper()
 
 	payerKey, err := solana.NewRandomPrivateKey()
-	require.NoError(t, err)
-	authorizer, err := solana.NewRandomPrivateKey()
 	require.NoError(t, err)
 	payTo, err := solana.NewRandomPrivateKey()
 	require.NoError(t, err)

--- a/go/mechanisms/svm/upto/server/scheme.go
+++ b/go/mechanisms/svm/upto/server/scheme.go
@@ -27,7 +27,8 @@ const AssetTransferMethodChannel = "channel"
 // Config configures the server-side SVM `upto` scheme.
 type Config struct {
 	// ReceiverAuthorizerSigner is the server hot key set as the channel
-	// authorized_signer. It signs settlement vouchers and is required.
+	// authorized_signer. It signs settlement vouchers. Omit to delegate to
+	// the facilitator's advertised receiverAuthorizer.
 	ReceiverAuthorizerSigner svm.ReceiverAuthorizerSigner
 
 	// WithdrawDelay is the channel grace period in seconds. Defaults to
@@ -43,19 +44,19 @@ type Config struct {
 // payments.
 //
 // It declares the escrow payment flow: a deposit settle before the handler and
-// a claim (or zero-amount cancel) settle after. The voucher for the metered
-// amount is attached only on the claim/cancel settle; the deposit settle must
-// not carry one.
+// a claim (or zero-amount cancel) settle after. enrichSettlementPayload stamps
+// type on every settle and attaches the receiver-authorizer voucher on
+// claim/cancel only when the server owns the key.
 type UptoSvmScheme struct {
 	moneyParsers []x402.MoneyParser
 	config       *Config
 }
 
-// NewUptoSvmScheme creates a new UptoSvmScheme. The receiver authorizer signer
-// is required: without it the server cannot authorize any settlement.
+// NewUptoSvmScheme creates a new UptoSvmScheme. Omit ReceiverAuthorizerSigner
+// to delegate voucher signing to the facilitator.
 func NewUptoSvmScheme(config *Config) *UptoSvmScheme {
-	if config == nil || config.ReceiverAuthorizerSigner == nil {
-		panic("upto svm server: ReceiverAuthorizerSigner is required")
+	if config == nil {
+		config = &Config{}
 	}
 	return &UptoSvmScheme{
 		moneyParsers: []x402.MoneyParser{},
@@ -100,7 +101,8 @@ func (s *UptoSvmScheme) GetAssetDecimals(_ string, _ x402.Network) int {
 }
 
 // ValidateFacilitatorSupport fails server startup when the facilitator does not
-// advertise a usable feePayer: without one, no client can build an open.
+// advertise a usable feePayer: without one, no client can build an open. When
+// this server delegates, the facilitator must also advertise a receiverAuthorizer.
 func (s *UptoSvmScheme) ValidateFacilitatorSupport(
 	network x402.Network,
 	supportedKind types.SupportedKind,
@@ -113,7 +115,20 @@ func (s *UptoSvmScheme) ValidateFacilitatorSupport(
 			network,
 		)
 	}
-	return nil
+	if s.config.ReceiverAuthorizerSigner != nil {
+		return nil
+	}
+
+	advertised, _ := supportedKind.Extra[upto.ExtraReceiverAuthorizer].(string)
+	if svm.ValidateSolanaAddress(advertised) {
+		return nil
+	}
+	return fmt.Errorf(
+		"no receiverAuthorizerSigner is configured and the facilitator does not advertise a "+
+			"receiverAuthorizer on %s. Configure a receiverAuthorizerSigner or use a "+
+			"facilitator that advertises one",
+		network,
+	)
 }
 
 // SettleOnCancel settles canceled verified payments as a zero-amount refund so
@@ -133,17 +148,19 @@ func (s *UptoSvmScheme) SettleOnCancel(ctx x402.VerifiedPaymentCanceledContext) 
 	return &requirements, nil
 }
 
-// EnrichSettlementPayload attaches the receiver-authorizer voucher on the
-// claim and cancel settles. The deposit settle (before-handler) must not carry
-// a voucher: the facilitator rejects one there because no usage has occurred.
+// EnrichSettlementPayload stamps type on every settle. It attaches the
+// receiver-authorizer voucher on claim/cancel only when this server owns the key.
 func (s *UptoSvmScheme) EnrichSettlementPayload(ctx x402.SettleContext) (map[string]interface{}, error) {
 	if ctx.Phase == x402.SettlePhaseBeforeHandler {
-		return nil, nil
+		return map[string]interface{}{svm.UptoPayloadTypeField: svm.UptoPayloadTypeDeposit}, nil
 	}
 
-	// A payload from another mechanism has no voucher to sign.
+	claimFields := map[string]interface{}{svm.UptoPayloadTypeField: svm.UptoPayloadTypeClaim}
 	if !svm.IsUptoSvmPayload(ctx.Payload.GetPayload()) {
-		return nil, nil
+		return claimFields, nil
+	}
+	if s.config.ReceiverAuthorizerSigner == nil {
+		return claimFields, nil
 	}
 	payload, err := svm.UptoPayloadFromMap(ctx.Payload.GetPayload())
 	if err != nil {
@@ -177,6 +194,7 @@ func (s *UptoSvmScheme) EnrichSettlementPayload(ctx x402.SettleContext) (map[str
 	}
 
 	return map[string]interface{}{
+		svm.UptoPayloadTypeField:      svm.UptoPayloadTypeClaim,
 		svm.UptoVoucherSignatureField: solana.SignatureFromBytes(signature).String(),
 	}, nil
 }
@@ -242,8 +260,9 @@ func (s *UptoSvmScheme) ParsePrice(price x402.Price, network x402.Network) (x402
 }
 
 // EnhancePaymentRequirements folds the facilitator's feePayer into the
-// requirement, declares the server-owned receiverAuthorizer and withdrawDelay,
-// and embeds a fresh blockhash/slot pair for the client open when configured.
+// requirement, declares receiverAuthorizer (local signer, else the
+// facilitator's advertised key) and withdrawDelay, and embeds a fresh
+// blockhash/slot pair for the client open when configured.
 func (s *UptoSvmScheme) EnhancePaymentRequirements(
 	ctx context.Context,
 	requirements types.PaymentRequirements,
@@ -293,7 +312,15 @@ func (s *UptoSvmScheme) EnhancePaymentRequirements(
 			withdrawDelay = uint32(requirements.MaxTimeoutSeconds)
 		}
 	}
-	extra[upto.ExtraReceiverAuthorizer] = s.config.ReceiverAuthorizerSigner.Address().String()
+	advertised, _ := supportedKind.Extra[upto.ExtraReceiverAuthorizer].(string)
+	receiverAuthorizer := advertised
+	if s.config.ReceiverAuthorizerSigner != nil {
+		receiverAuthorizer = s.config.ReceiverAuthorizerSigner.Address().String()
+	}
+	if !svm.ValidateSolanaAddress(receiverAuthorizer) {
+		return requirements, errors.New("payment requirements must include a valid extra.receiverAuthorizer")
+	}
+	extra[upto.ExtraReceiverAuthorizer] = receiverAuthorizer
 	extra[upto.ExtraWithdrawDelay] = withdrawDelay
 
 	// Token-2022 mints (USDG, PYUSD, CASH) need their own program on the open, and

--- a/go/mechanisms/svm/upto/server/scheme_test.go
+++ b/go/mechanisms/svm/upto/server/scheme_test.go
@@ -107,9 +107,9 @@ func TestDynamicExtraFieldsExcludeRegeneratedHints(t *testing.T) {
 	)
 }
 
-func TestNewUptoSvmSchemeRequiresAnAuthorizer(t *testing.T) {
-	assert.Panics(t, func() { NewUptoSvmScheme(nil) })
-	assert.Panics(t, func() { NewUptoSvmScheme(&Config{}) })
+func TestNewUptoSvmSchemeAllowsOmittingAnAuthorizer(t *testing.T) {
+	assert.NotPanics(t, func() { NewUptoSvmScheme(nil) })
+	assert.NotPanics(t, func() { NewUptoSvmScheme(&Config{}) })
 }
 
 func TestParsePrice(t *testing.T) {
@@ -427,7 +427,7 @@ func TestSettleOnCancelRefundsOnlyFailedHandlers(t *testing.T) {
 	}
 }
 
-func TestEnrichSettlementPayloadSkipsTheDepositSettle(t *testing.T) {
+func TestEnrichSettlementPayloadStampsDepositTypeWithoutAVoucher(t *testing.T) {
 	scheme, authorizer := newTestScheme(t)
 
 	fields, err := scheme.EnrichSettlementPayload(x402.SettleContext{
@@ -438,7 +438,7 @@ func TestEnrichSettlementPayloadSkipsTheDepositSettle(t *testing.T) {
 	})
 
 	require.NoError(t, err)
-	assert.Nil(t, fields, "the deposit settle carries no voucher because no usage has occurred")
+	assert.Equal(t, map[string]interface{}{svm.UptoPayloadTypeField: svm.UptoPayloadTypeDeposit}, fields)
 }
 
 func TestEnrichSettlementPayloadSignsTheMeteredVoucher(t *testing.T) {
@@ -467,6 +467,7 @@ func TestEnrichSettlementPayloadSignsTheMeteredVoucher(t *testing.T) {
 
 			signatureBase58, ok := fields[svm.UptoVoucherSignatureField].(string)
 			require.True(t, ok, "the voucher signature is returned as base58")
+			assert.Equal(t, svm.UptoPayloadTypeClaim, fields[svm.UptoPayloadTypeField])
 
 			decoded, err := svm.UptoPayloadFromMap(payload.Payload)
 			require.NoError(t, err)
@@ -516,7 +517,7 @@ func TestEnrichSettlementPayloadIgnoresForeignPayloads(t *testing.T) {
 	})
 
 	require.NoError(t, err)
-	assert.Nil(t, fields)
+	assert.Equal(t, map[string]interface{}{svm.UptoPayloadTypeField: svm.UptoPayloadTypeClaim}, fields)
 }
 
 func TestEnrichSettlementPayloadRejectsANonIntegerAmount(t *testing.T) {
@@ -530,4 +531,141 @@ func TestEnrichSettlementPayloadRejectsANonIntegerAmount(t *testing.T) {
 	})
 
 	require.ErrorContains(t, err, ErrInvalidPayload)
+}
+
+func TestServerDelegatedReceiverAuthorizerFallsBackToFacilitatorExtra(t *testing.T) {
+	advertised := svm.USDCMainnetAddress
+	delegated := NewUptoSvmScheme(&Config{WithdrawDelay: 3600})
+	supportedKind := types.SupportedKind{
+		X402Version: 2,
+		Scheme:      svm.SchemeUpto,
+		Network:     testNetwork,
+		Extra: map[string]interface{}{
+			upto.ExtraFeePayer:           advertised,
+			upto.ExtraReceiverAuthorizer: advertised,
+		},
+	}
+	requirements := types.PaymentRequirements{
+		Scheme:            svm.SchemeUpto,
+		Network:           testNetwork,
+		Asset:             svm.USDCDevnetAddress,
+		Amount:            "1000000",
+		PayTo:             solana.SysVarRentPubkey.String(),
+		MaxTimeoutSeconds: 300,
+		Extra:             map[string]interface{}{},
+	}
+
+	result, err := delegated.EnhancePaymentRequirements(context.Background(), requirements, supportedKind, nil)
+	require.NoError(t, err)
+	assert.Equal(t, advertised, result.Extra[upto.ExtraReceiverAuthorizer])
+}
+
+func TestServerDelegatedReceiverAuthorizerThrowsWhenNeitherSideSuppliesOne(t *testing.T) {
+	advertised := svm.USDCMainnetAddress
+	delegated := NewUptoSvmScheme(&Config{WithdrawDelay: 3600})
+	requirements := types.PaymentRequirements{
+		Scheme:            svm.SchemeUpto,
+		Network:           testNetwork,
+		Asset:             svm.USDCDevnetAddress,
+		Amount:            "1000000",
+		PayTo:             solana.SysVarRentPubkey.String(),
+		MaxTimeoutSeconds: 300,
+		Extra:             map[string]interface{}{},
+	}
+
+	_, err := delegated.EnhancePaymentRequirements(
+		context.Background(),
+		requirements,
+		types.SupportedKind{
+			X402Version: 2,
+			Scheme:      svm.SchemeUpto,
+			Network:     testNetwork,
+			Extra:       map[string]interface{}{upto.ExtraFeePayer: advertised},
+		},
+		nil,
+	)
+	require.ErrorContains(t, err, "valid extra.receiverAuthorizer")
+}
+
+func TestValidateFacilitatorSupportFailsWithoutLocalSignerOrAdvertisement(t *testing.T) {
+	advertised := svm.USDCMainnetAddress
+	delegated := NewUptoSvmScheme(&Config{WithdrawDelay: 3600})
+
+	err := delegated.ValidateFacilitatorSupport(testNetwork, types.SupportedKind{
+		X402Version: 2,
+		Scheme:      svm.SchemeUpto,
+		Network:     testNetwork,
+		Extra:       map[string]interface{}{upto.ExtraFeePayer: advertised},
+	}, nil)
+	require.ErrorContains(t, err, "receiverAuthorizer")
+}
+
+func TestValidateFacilitatorSupportAcceptsFacilitatorAdvertisedAuthorizer(t *testing.T) {
+	advertised := svm.USDCMainnetAddress
+	delegated := NewUptoSvmScheme(&Config{WithdrawDelay: 3600})
+
+	err := delegated.ValidateFacilitatorSupport(testNetwork, types.SupportedKind{
+		X402Version: 2,
+		Scheme:      svm.SchemeUpto,
+		Network:     testNetwork,
+		Extra: map[string]interface{}{
+			upto.ExtraFeePayer:           advertised,
+			upto.ExtraReceiverAuthorizer: advertised,
+		},
+	}, nil)
+	require.NoError(t, err)
+}
+
+func TestEnrichSettlementPayloadStampsTypeAndOmitsVoucherWhenDelegating(t *testing.T) {
+	advertised := svm.USDCMainnetAddress
+	delegated := NewUptoSvmScheme(&Config{WithdrawDelay: 3600})
+	requirements := types.PaymentRequirements{
+		Scheme:            svm.SchemeUpto,
+		Network:           testNetwork,
+		Asset:             svm.USDCDevnetAddress,
+		Amount:            "1000000",
+		PayTo:             solana.SysVarRentPubkey.String(),
+		MaxTimeoutSeconds: 300,
+		Extra:             map[string]interface{}{},
+	}
+	payload := types.PaymentPayload{
+		X402Version: 2,
+		Accepted:    requirements,
+		Payload: (&svm.UptoSvmPayload{
+			From:             solana.SysVarRentPubkey.String(),
+			MaxAmount:        "1000000",
+			Deposit:          "1000000",
+			ChannelId:        svm.USDCMainnetAddress,
+			AuthorizedSigner: advertised,
+			OpenTransaction:  "unused",
+			OpenSlot:         "341000000",
+			ExpiresAt:        1893456000,
+			ValidAfter:       0,
+			Nonce:            "1",
+		}).ToMap(),
+	}
+
+	deposit, err := delegated.EnrichSettlementPayload(x402.SettleContext{
+		Payload:      payload,
+		Requirements: requirements,
+		Phase:        x402.SettlePhaseBeforeHandler,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{svm.UptoPayloadTypeField: svm.UptoPayloadTypeDeposit}, deposit)
+
+	claim, err := delegated.EnrichSettlementPayload(x402.SettleContext{
+		Payload: payload,
+		Requirements: types.PaymentRequirements{
+			Scheme:            requirements.Scheme,
+			Network:           requirements.Network,
+			Asset:             requirements.Asset,
+			Amount:            "1858",
+			PayTo:             requirements.PayTo,
+			MaxTimeoutSeconds: requirements.MaxTimeoutSeconds,
+			Extra:             requirements.Extra,
+		},
+		Phase: x402.SettlePhaseAfterHandler,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{svm.UptoPayloadTypeField: svm.UptoPayloadTypeClaim}, claim)
 }

--- a/go/server.go
+++ b/go/server.go
@@ -247,7 +247,7 @@ func (s *x402ResourceServer) Initialize(ctx context.Context) error {
 // it supports. Only schemes the facilitator actually supports are validated, and
 // only schemes implementing FacilitatorSupportValidator participate.
 func (s *x402ResourceServer) validateFacilitatorCapabilities(_ context.Context) error {
-	var problems []error
+	var problems []string
 
 	for network, schemeMap := range s.schemes {
 		for scheme, server := range schemeMap {
@@ -262,7 +262,7 @@ func (s *x402ResourceServer) validateFacilitatorCapabilities(_ context.Context) 
 			}
 
 			if err := validator.ValidateFacilitatorSupport(network, supportedKind, extensions); err != nil {
-				problems = append(problems, fmt.Errorf("%s on %s: %w", scheme, network, err))
+				problems = append(problems, fmt.Sprintf("%s on %s: %s", scheme, network, err.Error()))
 			}
 		}
 	}
@@ -270,7 +270,7 @@ func (s *x402ResourceServer) validateFacilitatorCapabilities(_ context.Context) 
 	if len(problems) == 0 {
 		return nil
 	}
-	return fmt.Errorf("x402 facilitator capability errors: %w", errors.Join(problems...))
+	return NewFacilitatorCapabilityError(problems)
 }
 
 // findSupportedKind scans the cached facilitator responses for the V2 kind matching

--- a/go/server_test.go
+++ b/go/server_test.go
@@ -164,6 +164,97 @@ func TestServerInitialize(t *testing.T) {
 	}
 }
 
+// mockValidatingScheme implements FacilitatorSupportValidator so Initialize
+// capability checks can be unit-tested.
+type mockValidatingScheme struct {
+	mockSchemeNetworkServer
+	problem       string
+	validateCalls int
+}
+
+func (m *mockValidatingScheme) ValidateFacilitatorSupport(_ Network, _ types.SupportedKind, _ []string) error {
+	m.validateCalls++
+	if m.problem == "" {
+		return nil
+	}
+	return errors.New(m.problem)
+}
+
+func TestServerInitializeRejectsCapabilityProblems(t *testing.T) {
+	ctx := context.Background()
+	mockClient := &mockServerFacilitatorClient{
+		kinds: []SupportedKind{
+			{X402Version: 2, Scheme: "exact", Network: "eip155:8453"},
+		},
+	}
+	server := Newx402ResourceServer(
+		WithFacilitatorClient(mockClient),
+		WithSchemeServer("eip155:8453", &mockValidatingScheme{
+			mockSchemeNetworkServer: mockSchemeNetworkServer{scheme: "exact"},
+			problem:                 "needs a signer",
+		}),
+	)
+
+	err := server.Initialize(ctx)
+	if err == nil {
+		t.Fatal("Expected capability error")
+	}
+	if !strings.Contains(err.Error(), "exact on eip155:8453: needs a signer") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var capErr *FacilitatorCapabilityError
+	if !errors.As(err, &capErr) {
+		t.Fatalf("Expected FacilitatorCapabilityError, got %T: %v", err, err)
+	}
+}
+
+func TestServerInitializeAcceptsValidCapabilityHook(t *testing.T) {
+	ctx := context.Background()
+	mockClient := &mockServerFacilitatorClient{
+		kinds: []SupportedKind{
+			{X402Version: 2, Scheme: "exact", Network: "eip155:8453"},
+		},
+	}
+	scheme := &mockValidatingScheme{
+		mockSchemeNetworkServer: mockSchemeNetworkServer{scheme: "exact"},
+	}
+	server := Newx402ResourceServer(
+		WithFacilitatorClient(mockClient),
+		WithSchemeServer("eip155:8453", scheme),
+	)
+
+	if err := server.Initialize(ctx); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if scheme.validateCalls != 1 {
+		t.Fatalf("expected 1 validate call, got %d", scheme.validateCalls)
+	}
+}
+
+func TestServerInitializeSkipsUnsupportedSchemeCapabilityHook(t *testing.T) {
+	ctx := context.Background()
+	mockClient := &mockServerFacilitatorClient{
+		kinds: []SupportedKind{
+			{X402Version: 2, Scheme: "exact", Network: "eip155:8453"},
+		},
+	}
+	scheme := &mockValidatingScheme{
+		mockSchemeNetworkServer: mockSchemeNetworkServer{scheme: "unsupported"},
+		problem:                 "should not be reported",
+	}
+	server := Newx402ResourceServer(
+		WithFacilitatorClient(mockClient),
+		WithSchemeServer("eip155:8453", scheme),
+	)
+
+	if err := server.Initialize(ctx); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if scheme.validateCalls != 0 {
+		t.Fatalf("expected 0 validate calls, got %d", scheme.validateCalls)
+	}
+}
+
 func TestServerInitializeWithMultipleFacilitators(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
Port of https://github.com/x402-foundation/x402/pull/3346 from TypeScript to Go SDK.

SVM upto can optionally delegate receiverAuthorizer to the facilitator, matching EVM batch-settlement: /supported may advertise receiverAuthorizer, and a server that omits ReceiverAuthorizerSigner no longer needs a voucher-signing key. The facilitator signs the claim voucher only after binding the deposit to a caller identity and matching that same identity on claim; a lost binding fails closed. Self-managed server vouchers stay the default. Settle routing prefers server-stamped payload.type (deposit | claim) and falls back to voucher/amount inference so older non-delegating servers keep working. HTTP adapters now exit on permanent FacilitatorCapabilityError or RouteConfigurationError at eager Initialize, while transient facilitator timeouts remain retryable.

AI disclosure: Automated by @phdargen. Use your own judgement