### PR TITLE
feat(fetch): optional paid-response validation hook

### DIFF
--- a/typescript/.changeset/fetch-paid-response-validation.md
+++ b/typescript/.changeset/fetch-paid-response-validation.md
@@ -1,0 +1,5 @@
+---
+"@x402/fetch": minor
+---
+
+Added optional validation for paid fetch responses.

--- a/typescript/packages/http/fetch/README.md
+++ b/typescript/packages/http/fetch/README.md
@@ -38,7 +38,7 @@ const data = await response.json();
 
 ## API
 
-### `wrapFetchWithPayment(fetch, client)`
+### `wrapFetchWithPayment(fetch, client, options?)`
 
 Wraps the native fetch API to handle 402 Payment Required responses automatically.
 
@@ -46,8 +46,20 @@ Wraps the native fetch API to handle 402 Payment Required responses automaticall
 
 - `fetch`: The fetch function to wrap (typically `globalThis.fetch`)
 - `client`: An x402Client instance with registered payment schemes
+- `options.validatePaidResponse`: Optional check of a paid response, run after payment processing on both the ordinary and recovery paths. The callback receives a `Response.clone()`, so the returned response body stays unread. Rejecting throws `PaidResponseValidationError` — carrying the original response and its `PAYMENT-RESPONSE` header — without paying again. Omit to keep existing behavior.
 
-### `wrapFetchWithPaymentFromConfig(fetch, config)`
+```typescript
+const fetchWithPayment = wrapFetchWithPayment(fetch, client, {
+  validatePaidResponse: async response => {
+    const body = await response.json();
+    if (!body?.report?.weather) {
+      throw new Error("paid body missing report.weather");
+    }
+  },
+});
+```
+
+### `wrapFetchWithPaymentFromConfig(fetch, config, options?)`
 
 Convenience wrapper that creates an x402Client from a configuration object.
 
@@ -60,6 +72,7 @@ Convenience wrapper that creates an x402Client from a configuration object.
     - `client`: The scheme client implementation (e.g., `ExactEvmScheme`, `ExactSvmScheme`)
     - `x402Version`: Optional protocol version (defaults to 2, set to 1 for legacy support)
   - `paymentRequirementsSelector`: Optional function to select payment requirements from multiple options
+- `options.validatePaidResponse`: Optional. Same validator as `wrapFetchWithPayment`.
 
 #### Returns
 

--- a/typescript/packages/http/fetch/src/index.test.ts
+++ b/typescript/packages/http/fetch/src/index.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { wrapFetchWithPayment, wrapFetchWithPaymentFromConfig } from "./index";
+import {
+  PaidResponseValidationError,
+  wrapFetchWithPayment,
+  wrapFetchWithPaymentFromConfig,
+  type ValidatePaidResponseContext,
+} from "./index";
 import type { x402Client, x402HTTPClient, x402ClientConfig } from "@x402/core/client";
 import type { PaymentPayload, PaymentRequired, PaymentRequirements } from "@x402/core/types";
 
@@ -23,82 +28,81 @@ vi.mock("@x402/core/client", () => {
   };
 });
 
+const validPaymentRequired: PaymentRequired = {
+  x402Version: 2,
+  resource: {
+    url: "https://api.example.com/resource",
+    description: "Test payment",
+    mimeType: "application/json",
+  },
+  accepts: [
+    {
+      scheme: "exact",
+      network: "eip155:84532" as const,
+      amount: "1000000",
+      asset: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+      payTo: "0x1234567890123456789012345678901234567890",
+      maxTimeoutSeconds: 300,
+      extra: {},
+    } as PaymentRequirements,
+  ],
+};
+
+const validPaymentPayload: PaymentPayload = {
+  x402Version: 2,
+  resource: validPaymentRequired.resource,
+  accepted: validPaymentRequired.accepts[0],
+  payload: { signature: "0xmocksignature" },
+};
+
+const createResponse = (
+  status: number,
+  data?: unknown,
+  headers?: Record<string, string>,
+): Response => {
+  return new Response(data ? JSON.stringify(data) : null, {
+    status,
+    statusText: status === 402 ? "Payment Required" : "OK",
+    headers: new Headers(headers),
+  });
+};
+
+const createDefaultMockClient = async (): Promise<x402Client> => {
+  const { x402Client: MockX402Client, x402HTTPClient: MockX402HTTPClient } = await import(
+    "@x402/core/client"
+  );
+
+  const mockClient = new MockX402Client() as unknown as x402Client;
+  (mockClient.createPaymentPayload as ReturnType<typeof vi.fn>).mockResolvedValue(
+    validPaymentPayload,
+  );
+  (
+    MockX402HTTPClient.prototype.getPaymentRequiredResponse as ReturnType<typeof vi.fn>
+  ).mockReturnValue(validPaymentRequired);
+  (
+    MockX402HTTPClient.prototype.encodePaymentSignatureHeader as ReturnType<typeof vi.fn>
+  ).mockReturnValue({
+    "PAYMENT-SIGNATURE": "encoded-payment-header",
+  });
+  (
+    MockX402HTTPClient.prototype.handlePaymentRequired as ReturnType<typeof vi.fn>
+  ).mockResolvedValue(null);
+  (MockX402HTTPClient.prototype.processPaymentResult as ReturnType<typeof vi.fn>).mockResolvedValue(
+    { recovered: false },
+  );
+
+  return mockClient;
+};
+
 describe("wrapFetchWithPayment()", () => {
   let mockFetch: ReturnType<typeof vi.fn>;
   let mockClient: x402Client;
   let wrappedFetch: ReturnType<typeof wrapFetchWithPayment>;
 
-  const validPaymentRequired: PaymentRequired = {
-    x402Version: 2,
-    resource: {
-      url: "https://api.example.com/resource",
-      description: "Test payment",
-      mimeType: "application/json",
-    },
-    accepts: [
-      {
-        scheme: "exact",
-        network: "eip155:84532" as const,
-        amount: "1000000",
-        asset: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
-        payTo: "0x1234567890123456789012345678901234567890",
-        maxTimeoutSeconds: 300,
-        extra: {},
-      } as PaymentRequirements,
-    ],
-  };
-
-  const validPaymentPayload: PaymentPayload = {
-    x402Version: 2,
-    resource: validPaymentRequired.resource,
-    accepted: validPaymentRequired.accepts[0],
-    payload: { signature: "0xmocksignature" },
-  };
-
-  const createResponse = (
-    status: number,
-    data?: unknown,
-    headers?: Record<string, string>,
-  ): Response => {
-    return new Response(data ? JSON.stringify(data) : null, {
-      status,
-      statusText: status === 402 ? "Payment Required" : "OK",
-      headers: new Headers(headers),
-    });
-  };
-
   beforeEach(async () => {
     vi.resetAllMocks();
-
     mockFetch = vi.fn();
-
-    // Create mock client
-    const { x402Client: MockX402Client, x402HTTPClient: MockX402HTTPClient } = await import(
-      "@x402/core/client"
-    );
-
-    mockClient = new MockX402Client() as unknown as x402Client;
-
-    // Setup default mock implementations
-    (mockClient.createPaymentPayload as ReturnType<typeof vi.fn>).mockResolvedValue(
-      validPaymentPayload,
-    );
-
-    (
-      MockX402HTTPClient.prototype.getPaymentRequiredResponse as ReturnType<typeof vi.fn>
-    ).mockReturnValue(validPaymentRequired);
-    (
-      MockX402HTTPClient.prototype.encodePaymentSignatureHeader as ReturnType<typeof vi.fn>
-    ).mockReturnValue({
-      "PAYMENT-SIGNATURE": "encoded-payment-header",
-    });
-    (
-      MockX402HTTPClient.prototype.handlePaymentRequired as ReturnType<typeof vi.fn>
-    ).mockResolvedValue(null);
-    (
-      MockX402HTTPClient.prototype.processPaymentResult as ReturnType<typeof vi.fn>
-    ).mockResolvedValue({ recovered: false });
-
+    mockClient = await createDefaultMockClient();
     wrappedFetch = wrapFetchWithPayment(mockFetch, mockClient);
   });
 
@@ -521,5 +525,328 @@ describe("wrapFetchWithPaymentFromConfig()", () => {
 
     expect(result).toBe(successResponse);
     expect(mockFetch).toHaveBeenCalled();
+  });
+});
+
+describe("wrapFetchWithPayment() paid-response validation", () => {
+  let mockFetch: ReturnType<typeof vi.fn>;
+  let mockClient: x402Client;
+
+  const wrapWithValidator = (
+    validator?: (response: Response, context: ValidatePaidResponseContext) => void | Promise<void>,
+  ) => wrapFetchWithPayment(mockFetch, mockClient, { validatePaidResponse: validator });
+
+  const expectDetachedValidationCall = (
+    validator: ReturnType<typeof vi.fn>,
+    response: Response,
+    recovered: boolean,
+  ): void => {
+    expect(validator).toHaveBeenCalledTimes(1);
+    const [view, context] = validator.mock.calls[0] as [Response, ValidatePaidResponseContext];
+    expect(view).not.toBe(response);
+    expect(view.status).toBe(response.status);
+    expect(context.recovered).toBe(recovered);
+    expect(context.paymentRequired).toEqual(validPaymentRequired);
+  };
+
+  const setupRecoveryFlow = async (finalResponse: Response): Promise<void> => {
+    const { x402HTTPClient: MockX402HTTPClient } = await import("@x402/core/client");
+    (MockX402HTTPClient.prototype.processPaymentResult as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ recovered: true })
+      .mockResolvedValueOnce({ recovered: false });
+    mockFetch
+      .mockResolvedValueOnce(createResponse(402, validPaymentRequired))
+      .mockResolvedValueOnce(
+        createResponse(402, validPaymentRequired, { "PAYMENT-REQUIRED": "corrective" }),
+      )
+      .mockResolvedValueOnce(finalResponse);
+  };
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    mockFetch = vi.fn();
+    mockClient = await createDefaultMockClient();
+  });
+
+  it("should not invoke a validator on a free initial 200", async () => {
+    const validator = vi.fn();
+    const wrappedFetch = wrapWithValidator(validator);
+    const successResponse = createResponse(200, { ok: true });
+    mockFetch.mockResolvedValue(successResponse);
+
+    const result = await wrappedFetch("https://api.example.com");
+
+    expect(result).toBe(successResponse);
+    expect(validator).not.toHaveBeenCalled();
+    expect(mockClient.createPaymentPayload).not.toHaveBeenCalled();
+  });
+
+  it("should not invoke a validator on pre-payment hook success", async () => {
+    const { x402HTTPClient: MockX402HTTPClient } = await import("@x402/core/client");
+    const validator = vi.fn();
+    const wrappedFetch = wrapWithValidator(validator);
+    const hookResponse = createResponse(200, { hooked: true });
+
+    (
+      MockX402HTTPClient.prototype.handlePaymentRequired as ReturnType<typeof vi.fn>
+    ).mockResolvedValue({ "X-HOOK": "handled" });
+    mockFetch
+      .mockResolvedValueOnce(createResponse(402, validPaymentRequired))
+      .mockResolvedValueOnce(hookResponse);
+
+    const result = await wrappedFetch("https://api.example.com");
+
+    expect(result).toBe(hookResponse);
+    expect(validator).not.toHaveBeenCalled();
+    expect(mockClient.createPaymentPayload).not.toHaveBeenCalled();
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("should keep current behavior when the validator option is absent", async () => {
+    const wrappedFetch = wrapFetchWithPayment(mockFetch, mockClient, {});
+    const successResponse = createResponse(
+      200,
+      { report: { weather: "sunny" } },
+      { "PAYMENT-RESPONSE": "settled-header" },
+    );
+    mockFetch
+      .mockResolvedValueOnce(createResponse(402, validPaymentRequired))
+      .mockResolvedValueOnce(successResponse);
+
+    const result = await wrappedFetch("https://api.example.com");
+
+    expect(result).toBe(successResponse);
+    expect(result.bodyUsed).toBe(false);
+    await expect(result.json()).resolves.toEqual({ report: { weather: "sunny" } });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockClient.createPaymentPayload).toHaveBeenCalledTimes(1);
+  });
+
+  it("should return the original paid response with an unread body when the validator succeeds", async () => {
+    const { x402HTTPClient: MockX402HTTPClient } = await import("@x402/core/client");
+    const validator = vi.fn().mockImplementation(async (view: Response) => {
+      await expect(view.json()).resolves.toEqual({ report: { weather: "sunny" } });
+    });
+    const wrappedFetch = wrapWithValidator(validator);
+    const successResponse = createResponse(
+      200,
+      { report: { weather: "sunny" } },
+      { "PAYMENT-RESPONSE": "settled-header" },
+    );
+    mockFetch
+      .mockResolvedValueOnce(createResponse(402, validPaymentRequired))
+      .mockResolvedValueOnce(successResponse);
+
+    const result = await wrappedFetch("https://api.example.com");
+
+    expect(result).toBe(successResponse);
+    expect(result.bodyUsed).toBe(false);
+    await expect(result.json()).resolves.toEqual({ report: { weather: "sunny" } });
+    expectDetachedValidationCall(validator, successResponse, false);
+    expect(
+      (MockX402HTTPClient.prototype.processPaymentResult as ReturnType<typeof vi.fn>).mock
+        .invocationCallOrder[0],
+    ).toBeLessThan(validator.mock.invocationCallOrder[0]);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockClient.createPaymentPayload).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not validate a terminal post-payment 402", async () => {
+    const { x402HTTPClient: MockX402HTTPClient } = await import("@x402/core/client");
+    const validator = vi.fn();
+    const wrappedFetch = wrapWithValidator(validator);
+    const terminalResponse = createResponse(402, validPaymentRequired, {
+      "PAYMENT-REQUIRED": "terminal-payment-required",
+    });
+    mockFetch
+      .mockResolvedValueOnce(createResponse(402, validPaymentRequired))
+      .mockResolvedValueOnce(terminalResponse);
+
+    const result = await wrappedFetch("https://api.example.com");
+
+    expect(result).toBe(terminalResponse);
+    expect(validator).not.toHaveBeenCalled();
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockClient.createPaymentPayload).toHaveBeenCalledTimes(1);
+    expect(MockX402HTTPClient.prototype.processPaymentResult).toHaveBeenCalledTimes(1);
+  });
+
+  it("should preserve settlement evidence and not repay when the validator fails", async () => {
+    const validator = vi.fn().mockImplementation(() => {
+      throw new Error("missing report.weather");
+    });
+    const wrappedFetch = wrapWithValidator(validator);
+    const successResponse = createResponse(
+      200,
+      { report: {} },
+      { "PAYMENT-RESPONSE": "settled-header" },
+    );
+    mockFetch
+      .mockResolvedValueOnce(createResponse(402, validPaymentRequired))
+      .mockResolvedValueOnce(successResponse);
+
+    const error = await wrappedFetch("https://api.example.com").catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(PaidResponseValidationError);
+    expect(error).toMatchObject({
+      name: "PaidResponseValidationError",
+      message: "missing report.weather",
+      response: successResponse,
+      paymentRequired: validPaymentRequired,
+      recovered: false,
+      paymentResponseHeader: "settled-header",
+    });
+    expect((error as PaidResponseValidationError).cause).toBeInstanceOf(Error);
+    expect((error as PaidResponseValidationError).response.bodyUsed).toBe(false);
+    await expect((error as PaidResponseValidationError).response.json()).resolves.toEqual({
+      report: {},
+    });
+    expect(validator).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockClient.createPaymentPayload).toHaveBeenCalledTimes(1);
+  });
+
+  it("should validate and preserve absent PAYMENT-RESPONSE evidence when validation fails", async () => {
+    const validator = vi.fn().mockImplementation(() => {
+      throw new Error("invalid body");
+    });
+    const wrappedFetch = wrapWithValidator(validator);
+    mockFetch
+      .mockResolvedValueOnce(createResponse(402, validPaymentRequired))
+      .mockResolvedValueOnce(createResponse(200, { report: {} }));
+
+    const error = await wrappedFetch("https://api.example.com").catch((caught: unknown) => caught);
+
+    expect(error).toMatchObject({
+      name: "PaidResponseValidationError",
+      message: "invalid body",
+      recovered: false,
+    });
+    expect((error as PaidResponseValidationError).paymentResponseHeader).toBeUndefined();
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockClient.createPaymentPayload).toHaveBeenCalledTimes(1);
+  });
+
+  it("should return a recovered paid body when the validator succeeds", async () => {
+    const { x402HTTPClient: MockX402HTTPClient } = await import("@x402/core/client");
+    const validator = vi.fn();
+    const wrappedFetch = wrapWithValidator(validator);
+    const recoveredResponse = createResponse(
+      200,
+      { report: { weather: "cloudy" } },
+      { "PAYMENT-RESPONSE": "recovered-settled" },
+    );
+    await setupRecoveryFlow(recoveredResponse);
+
+    const result = await wrappedFetch("https://api.example.com");
+
+    expect(result).toBe(recoveredResponse);
+    expectDetachedValidationCall(validator, recoveredResponse, true);
+    const processPaymentResult = MockX402HTTPClient.prototype.processPaymentResult as ReturnType<
+      typeof vi.fn
+    >;
+    expect(processPaymentResult).toHaveBeenCalledTimes(2);
+    expect(processPaymentResult.mock.invocationCallOrder[1]).toBeLessThan(
+      validator.mock.invocationCallOrder[0],
+    );
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    expect(mockClient.createPaymentPayload).toHaveBeenCalledTimes(2);
+  });
+
+  it("should validate a recovery paid success exactly once and not repay on failure", async () => {
+    // Rejects asynchronously with a non-Error to cover the awaited path and the message fallback.
+    const validator = vi.fn().mockRejectedValue("invalid recovered body");
+    const wrappedFetch = wrapWithValidator(validator);
+    const recoveredResponse = createResponse(
+      200,
+      { report: {} },
+      { "X-PAYMENT-RESPONSE": "recovered-settled" },
+    );
+    await setupRecoveryFlow(recoveredResponse);
+
+    const error = await wrappedFetch("https://api.example.com").catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(PaidResponseValidationError);
+    expect(error).toMatchObject({
+      message: "Paid response validation failed",
+      response: recoveredResponse,
+      paymentRequired: validPaymentRequired,
+      recovered: true,
+      paymentResponseHeader: "recovered-settled",
+    });
+    expect(validator).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    expect(mockClient.createPaymentPayload).toHaveBeenCalledTimes(2);
+  });
+
+  it("should not validate a terminal 402 after one bounded recovery", async () => {
+    const validator = vi.fn();
+    const wrappedFetch = wrapWithValidator(validator);
+    const terminalResponse = createResponse(402, validPaymentRequired, {
+      "PAYMENT-REQUIRED": "terminal-payment-required",
+    });
+    await setupRecoveryFlow(terminalResponse);
+
+    const result = await wrappedFetch("https://api.example.com");
+
+    expect(result).toBe(terminalResponse);
+    expect(validator).not.toHaveBeenCalled();
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    expect(mockClient.createPaymentPayload).toHaveBeenCalledTimes(2);
+  });
+
+  it("should fail closed when the paid response cannot be cloned", async () => {
+    const validator = vi.fn();
+    const wrappedFetch = wrapWithValidator(validator);
+    const consumedResponse = createResponse(
+      200,
+      { report: { weather: "sunny" } },
+      { "PAYMENT-RESPONSE": "settled-header" },
+    );
+    await consumedResponse.text();
+    mockFetch
+      .mockResolvedValueOnce(createResponse(402, validPaymentRequired))
+      .mockResolvedValueOnce(consumedResponse);
+
+    const error = await wrappedFetch("https://api.example.com").catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(PaidResponseValidationError);
+    expect(error).toMatchObject({
+      name: "PaidResponseValidationError",
+      message: "Paid response cannot be detached for validation",
+      response: consumedResponse,
+      paymentRequired: validPaymentRequired,
+      recovered: false,
+      paymentResponseHeader: "settled-header",
+    });
+    expect((error as PaidResponseValidationError).cause).toBeInstanceOf(Error);
+    expect(validator).not.toHaveBeenCalled();
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockClient.createPaymentPayload).toHaveBeenCalledTimes(1);
+  });
+
+  it("should pass validatePaidResponse through wrapFetchWithPaymentFromConfig", async () => {
+    const { x402Client: MockX402Client } = await import("@x402/core/client");
+    const validator = vi.fn();
+    (MockX402Client.fromConfig as ReturnType<typeof vi.fn>).mockReturnValue(mockClient);
+    const wrappedFetch = wrapFetchWithPaymentFromConfig(
+      mockFetch,
+      { schemes: [] },
+      { validatePaidResponse: validator },
+    );
+    const successResponse = createResponse(
+      200,
+      { ok: true },
+      { "PAYMENT-RESPONSE": "from-config-settled" },
+    );
+    mockFetch
+      .mockResolvedValueOnce(createResponse(402, validPaymentRequired))
+      .mockResolvedValueOnce(successResponse);
+
+    const result = await wrappedFetch("https://api.example.com");
+
+    expect(result).toBe(successResponse);
+    expect(validator).toHaveBeenCalledTimes(1);
+    expect(mockClient.createPaymentPayload).toHaveBeenCalledTimes(1);
   });
 });

--- a/typescript/packages/http/fetch/src/index.ts
+++ b/typescript/packages/http/fetch/src/index.ts
@@ -2,6 +2,112 @@ import { x402Client, x402ClientConfig, x402HTTPClient } from "@x402/core/client"
 import { type PaymentRequired } from "@x402/core/types";
 
 /**
+ * Context passed to a caller-owned paid-response validator.
+ */
+export type ValidatePaidResponseContext = {
+  paymentRequired: PaymentRequired;
+  recovered: boolean;
+};
+
+/**
+ * Optional caller-owned check of a paid response.
+ *
+ * @param response - Clone of the paid response; reading it leaves the returned response unread
+ * @param context - Payment requirements and whether this was the recovery path
+ */
+export type ValidatePaidResponse = (
+  response: Response,
+  context: ValidatePaidResponseContext,
+) => void | Promise<void>;
+
+/**
+ * Optional behavior for wrapFetchWithPayment.
+ */
+export type WrapFetchWithPaymentOptions = {
+  /** Validates paid responses other than a terminal 402. Omit to keep current behavior. */
+  validatePaidResponse?: ValidatePaidResponse;
+};
+
+/**
+ * Evidence retained when paid-response validation fails.
+ */
+export type PaidResponseValidationErrorDetails = {
+  response: Response;
+  paymentRequired: PaymentRequired;
+  recovered: boolean;
+  paymentResponseHeader?: string;
+  cause?: unknown;
+};
+
+/**
+ * Thrown when a paid response fails caller-owned validation or cannot be cloned.
+ *
+ * The transport does not retry or create another payment after this error.
+ */
+export class PaidResponseValidationError extends Error {
+  readonly paymentRequired: PaymentRequired;
+  readonly paymentResponseHeader?: string;
+  readonly recovered: boolean;
+  readonly response: Response;
+
+  /**
+   * Creates an evidence-preserving paid-response validation error.
+   *
+   * @param message - Validation failure message
+   * @param details - Original response, payment requirements, recovery flag, pre-validator PAYMENT-RESPONSE, and cause
+   */
+  constructor(message: string, details: PaidResponseValidationErrorDetails) {
+    super(message, details.cause !== undefined ? { cause: details.cause } : undefined);
+    this.name = "PaidResponseValidationError";
+    this.response = details.response;
+    this.paymentRequired = details.paymentRequired;
+    this.recovered = details.recovered;
+    this.paymentResponseHeader = details.paymentResponseHeader;
+  }
+}
+
+/**
+ * Runs the caller-owned validator against a clone of a paid response.
+ *
+ * @param validator - Caller-supplied validator
+ * @param response - Original paid response about to be returned
+ * @param context - Payment requirements and recovery flag
+ */
+async function applyValidatePaidResponse(
+  validator: ValidatePaidResponse,
+  response: Response,
+  context: ValidatePaidResponseContext,
+): Promise<void> {
+  const evidence = {
+    response,
+    paymentRequired: context.paymentRequired,
+    recovered: context.recovered,
+    paymentResponseHeader:
+      response.headers.get("PAYMENT-RESPONSE") ??
+      response.headers.get("X-PAYMENT-RESPONSE") ??
+      undefined,
+  };
+
+  let detachedResponse: Response;
+  try {
+    detachedResponse = response.clone();
+  } catch (error) {
+    throw new PaidResponseValidationError("Paid response cannot be detached for validation", {
+      ...evidence,
+      cause: error,
+    });
+  }
+
+  try {
+    await validator(detachedResponse, context);
+  } catch (error) {
+    const message =
+      error instanceof Error && error.message ? error.message : "Paid response validation failed";
+    throw new PaidResponseValidationError(message, { ...evidence, cause: error });
+  }
+}
+
+/**
  * Enables the payment of APIs using the x402 payment protocol v2.
  *
  * This function wraps the native fetch API to automatically handle 402 Payment Required responses
@@ -13,6 +119,7 @@ import { type PaymentRequired } from "@x402/core/types";
  *
  * @param fetch - The fetch function to wrap (typically globalThis.fetch)
  * @param client - Configured x402Client or x402HTTPClient instance for handling payments
+ * @param options - Optional paid-response validation; see WrapFetchWithPaymentOptions
  * @returns A wrapped fetch function that handles 402 responses automatically
  *
  * @example
@@ -36,12 +143,15 @@ import { type PaymentRequired } from "@x402/core/types";
  * @throws {Error} If the request configuration is missing
  * @throws {Error} If a payment has already been attempted for this request
  * @throws {Error} If there's an error creating the payment header
+ * @throws {PaidResponseValidationError} If the optional paid-response validator rejects
  */
 export function wrapFetchWithPayment(
   fetch: typeof globalThis.fetch,
   client: x402Client | x402HTTPClient,
+  options?: WrapFetchWithPaymentOptions,
 ) {
   const httpClient = client instanceof x402HTTPClient ? client : new x402HTTPClient(client);
+  const validatePaidResponse = options?.validatePaidResponse;
 
   return async (input: RequestInfo | URL, init?: RequestInit) => {
     const request = new Request(input, init);
@@ -148,9 +258,22 @@ export function wrapFetchWithPayment(
         name => retryResponse.headers.get(name),
         retryResponse.status,
       );
+      // A terminal 402 is protocol evidence, not a paid application result.
+      if (validatePaidResponse && retryResponse.status !== 402) {
+        await applyValidatePaidResponse(validatePaidResponse, retryResponse, {
+          paymentRequired,
+          recovered: true,
+        });
+      }
       return retryResponse;
     }
 
+    if (validatePaidResponse && secondResponse.status !== 402) {
+      await applyValidatePaidResponse(validatePaidResponse, secondResponse, {
+        paymentRequired,
+        recovered: false,
+      });
+    }
     return secondResponse;
   };
 }
@@ -160,14 +283,16 @@ export function wrapFetchWithPayment(
  *
  * @param fetch - The fetch function to wrap (typically globalThis.fetch)
  * @param config - Configuration options including scheme registrations and selectors
+ * @param options - Same options as wrapFetchWithPayment
  * @returns A wrapped fetch function that handles 402 responses automatically
  */
 export function wrapFetchWithPaymentFromConfig(
   fetch: typeof globalThis.fetch,
   config: x402ClientConfig,
+  options?: WrapFetchWithPaymentOptions,
 ) {
   const client = x402Client.fromConfig(config);
-  return wrapFetchWithPayment(fetch, client);
+  return wrapFetchWithPayment(fetch, client, options);
 }
 
 // Re-export types and utilities for convenience

--- a/typescript/packages/http/fetch/tsconfig.json
+++ b/typescript/packages/http/fetch/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "allowJs": false,
     "checkJs": false,
-    "lib": ["DOM"]
+    "lib": ["ES2022", "DOM"]
   },
   "include": ["src", "test/unit/index.test.ts"]
 }


### PR DESCRIPTION
## Description

Adds an optional `validatePaidResponse` callback to `@x402/fetch`. It runs after `processPaymentResult` on ordinary and bounded-recovery paid responses, validates a `Response.clone()`, and throws `PaidResponseValidationError` with the original unread response and settlement header when validation fails. Validation never triggers another payment, and behavior is unchanged when the option is omitted.

Terminal 402 responses remain protocol responses and bypass validation. `wrapFetchWithPaymentFromConfig` forwards the same option so both public construction paths behave consistently.

The package override at `typescript/packages/http/fetch/tsconfig.json:6` previously replaced the base ES2022 library with DOM-only types. Restoring `ES2022` allows the standard `Error` cause option used by the typed validation error to compile.

Closes #3260.

## Tests

- `pnpm --filter @x402/fetch format:check`
- `pnpm --filter @x402/fetch lint:check`
- `pnpm --filter @x402/fetch build`
- `pnpm --filter @x402/fetch test` — 33 tests passed
- `pnpm test --force` — 55 workspace tasks passed

The package checks were also run on Node 22.23.2 with pnpm 11.1.1 to match CI.

### AI usage disclosure

Most of this PR was developed with Claude Code. I reviewed the complete diff against #3260, corrected issues found during review, and ran the checks listed above.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed
- [x] I added a changelog fragment for the user-facing change
