### PR TITLE
fix(ts,go): update auth-capture v1.1 contracts to canonical deployment

### DIFF
--- a/go/mechanisms/evm/auth-capture/constants.go
+++ b/go/mechanisms/evm/auth-capture/constants.go
@@ -25,16 +25,16 @@ const (
 	OperatorRefundCollectorV1_0Address = "0x934907bffd0901b6A21e398B9C53A4A38F02fa5d"
 
 	// AuthCaptureEscrowV1_1Address is the commerce-payments v1.1 AuthCaptureEscrow deployment (default).
-	AuthCaptureEscrowV1_1Address = "0x13AC3b34322D12FE27D5e192D0c2b2266d4F29CB"
+	AuthCaptureEscrowV1_1Address = "0xf96815976523E00e65Be8f34cA5e64b4f41EB19c"
 
 	// EIP3009TokenCollectorV1_1Address is the commerce-payments v1.1 EIP-3009 token collector.
-	EIP3009TokenCollectorV1_1Address = "0xEA902B37036bcb4944577ec2101ABdEDF56EbD28"
+	EIP3009TokenCollectorV1_1Address = "0x8612dfdc421f80336cd14E8EF9cb1E765dB5ab88"
 
 	// Permit2TokenCollectorV1_1Address is the commerce-payments v1.1 Permit2 token collector.
-	Permit2TokenCollectorV1_1Address = "0x1aacb38b16a1a8709e80746825E53A0C9Cae9b70"
+	Permit2TokenCollectorV1_1Address = "0xD69831Aed5bfe262067ec4c751f4F830EcdD446e"
 
 	// OperatorRefundCollectorV1_1Address is the commerce-payments v1.1 operator refund collector.
-	OperatorRefundCollectorV1_1Address = "0x6a1ADdEEb4bD9c5811a613e20c172b6CE61A4aaB"
+	OperatorRefundCollectorV1_1Address = "0x7a03443724d14798c4AB4622F1DAAcA761Fea486"
 
 	// AuthCaptureEscrowAddress is the default AuthCaptureEscrow deployment (v1.1).
 	AuthCaptureEscrowAddress = AuthCaptureEscrowV1_1Address

--- a/go/mechanisms/evm/auth-capture/nonce_test.go
+++ b/go/mechanisms/evm/auth-capture/nonce_test.go
@@ -57,7 +57,7 @@ func TestComputePayerAgnosticPaymentInfoHash_Golden84532(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	want := "0x341988b065a5131b3a82818eb7aba9010135f326af1af7695fce4d2bbebd0b76"
+	want := "0x695990db5fd8f3f541f505b117da619dace4d28a039e35646ce7b660e699ff4b"
 	if hash != want {
 		t.Fatalf("hash = %q, want %q", hash, want)
 	}
@@ -68,7 +68,7 @@ func TestComputePayerAgnosticPaymentInfoHash_Golden8453(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	want := "0xa393f8f76a2327a7678488b2d504bda611b7586bb3f334b255a11bb5a75e79ca"
+	want := "0x37588eff80093203c128c6622608c6e972e41c2fd79da91ef5294a26e647e4e2"
 	if hash != want {
 		t.Fatalf("hash = %q, want %q", hash, want)
 	}

--- a/specs/schemes/auth-capture/scheme_auth_capture_evm.md
+++ b/specs/schemes/auth-capture/scheme_auth_capture_evm.md
@@ -88,7 +88,7 @@ Every other `extra` field means the same thing in all three, as its [`extra` ent
       "extra": {
         "name": "USDC",
         "version": "2",
-        "authCaptureEscrow": "0x13AC3b34322D12FE27D5e192D0c2b2266d4F29CB",
+        "authCaptureEscrow": "0xf96815976523E00e65Be8f34cA5e64b4f41EB19c",
         "captureAuthorizer": "0xOperatorAddress",
         "operatorType": "custom",
         "receiverAuthorizer": "0xReceiverAuthorizerAddress",
@@ -139,10 +139,10 @@ Treat an omitted `extra.authCaptureEscrow` as the v1.1 escrow. A facilitator MUS
 
 | Constant                            | v1.1 (default)                                 | v1.0                                               |
 | ----------------------------------- | ---------------------------------------------- | -------------------------------------------------- |
-| `AUTH_CAPTURE_ESCROW_ADDRESS`       | `0x13AC3b34322D12FE27D5e192D0c2b2266d4F29CB`   | `0xBdEA0D1bcC5966192B070Fdf62aB4EF5b4420cff`       |
-| `EIP3009_TOKEN_COLLECTOR_ADDRESS`   | `0xEA902B37036bcb4944577ec2101ABdEDF56EbD28`   | `0x0E3dF9510de65469C4518D7843919c0b8C7A7757`       |
-| `PERMIT2_TOKEN_COLLECTOR_ADDRESS`   | `0x1aacb38b16a1a8709e80746825E53A0C9Cae9b70`   | `0x992476B9Ee81d52a5BdA0622C333938D0Af0aB26`       |
-| `OPERATOR_REFUND_COLLECTOR_ADDRESS` | `0x6a1ADdEEb4bD9c5811a613e20c172b6CE61A4aaB`   | `0x934907bffd0901b6A21e398B9C53A4A38F02fa5d`       |
+| `AUTH_CAPTURE_ESCROW_ADDRESS`       | `0xf96815976523E00e65Be8f34cA5e64b4f41EB19c`   | `0xBdEA0D1bcC5966192B070Fdf62aB4EF5b4420cff`       |
+| `EIP3009_TOKEN_COLLECTOR_ADDRESS`   | `0x8612dfdc421f80336cd14E8EF9cb1E765dB5ab88`   | `0x0E3dF9510de65469C4518D7843919c0b8C7A7757`       |
+| `PERMIT2_TOKEN_COLLECTOR_ADDRESS`   | `0xD69831Aed5bfe262067ec4c751f4F830EcdD446e`   | `0x992476B9Ee81d52a5BdA0622C333938D0Af0aB26`       |
+| `OPERATOR_REFUND_COLLECTOR_ADDRESS` | `0x7a03443724d14798c4AB4622F1DAAcA761Fea486`   | `0x934907bffd0901b6A21e398B9C53A4A38F02fa5d`       |
 
 
 The client's `signatureNonce` commits to the resolved escrow, and `authorization.to` / `permit2Authorization.spender` MUST be the matching collector. `PaymentInfo` is the same struct in both deployments, including `minFeeBps` / `maxFeeBps`. What differs is the submitted fee on `charge` and `capture`: v1.1 takes an absolute `feeAmount` in atomic units; v1.0 takes `feeBps`. See [Fee system](#fee-system). `PERMIT2_ADDRESS` is the canonical [Uniswap Permit2 contract](https://docs.uniswap.org/contracts/v4/deployments) in both cases.

--- a/typescript/packages/mechanisms/evm/src/auth-capture/constants.ts
+++ b/typescript/packages/mechanisms/evm/src/auth-capture/constants.ts
@@ -30,13 +30,13 @@ export const OPERATOR_REFUND_COLLECTOR_V1_0_ADDRESS =
 
 // commerce-payments v1.1 (default)
 export const AUTH_CAPTURE_ESCROW_V1_1_ADDRESS =
-  "0x13AC3b34322D12FE27D5e192D0c2b2266d4F29CB" as const satisfies `0x${string}`;
+  "0xf96815976523E00e65Be8f34cA5e64b4f41EB19c" as const satisfies `0x${string}`;
 export const EIP3009_TOKEN_COLLECTOR_V1_1_ADDRESS =
-  "0xEA902B37036bcb4944577ec2101ABdEDF56EbD28" as const satisfies `0x${string}`;
+  "0x8612dfdc421f80336cd14E8EF9cb1E765dB5ab88" as const satisfies `0x${string}`;
 export const PERMIT2_TOKEN_COLLECTOR_V1_1_ADDRESS =
-  "0x1aacb38b16a1a8709e80746825E53A0C9Cae9b70" as const satisfies `0x${string}`;
+  "0xD69831Aed5bfe262067ec4c751f4F830EcdD446e" as const satisfies `0x${string}`;
 export const OPERATOR_REFUND_COLLECTOR_V1_1_ADDRESS =
-  "0x6a1ADdEEb4bD9c5811a613e20c172b6CE61A4aaB" as const satisfies `0x${string}`;
+  "0x7a03443724d14798c4AB4622F1DAAcA761Fea486" as const satisfies `0x${string}`;
 
 /** Default deployment aliases (v1.1). */
 export const AUTH_CAPTURE_ESCROW_ADDRESS = AUTH_CAPTURE_ESCROW_V1_1_ADDRESS;

--- a/typescript/packages/mechanisms/evm/test/unit/auth-capture/nonce.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/auth-capture/nonce.test.ts
@@ -36,10 +36,10 @@ describe("nonce utilities", () => {
 
     it("should produce fixed hashes for the default and v1.0 escrow domains", () => {
       expect(computePayerAgnosticPaymentInfoHash(84532, mockPaymentInfo)).toBe(
-        "0x341988b065a5131b3a82818eb7aba9010135f326af1af7695fce4d2bbebd0b76",
+        "0x695990db5fd8f3f541f505b117da619dace4d28a039e35646ce7b660e699ff4b",
       );
       expect(computePayerAgnosticPaymentInfoHash(8453, mockPaymentInfo)).toBe(
-        "0xa393f8f76a2327a7678488b2d504bda611b7586bb3f334b255a11bb5a75e79ca",
+        "0x37588eff80093203c128c6622608c6e972e41c2fd79da91ef5294a26e647e4e2",
       );
       expect(
         computePayerAgnosticPaymentInfoHash(


### PR DESCRIPTION
## Description

Updates auth-capture with canonical v1.1 base commerce contract deployments

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [ ] I have formatted and linted my code
- [ ] All new and existing tests pass
- [ ] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [ ] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 