### PR TITLE
feat: optimize go facilitator SDK - EVM and SVM

### DIFF
--- a/go/.changes/unreleased/changed-20260902-230501.yaml
+++ b/go/.changes/unreleased/changed-20260902-230501.yaml
@@ -1,0 +1,3 @@
+kind: added
+body: EVM exact facilitator verify can start the onchain transfer simulation concurrently with signature classification, removing one RPC round trip. Opt in with ExactEvmSchemeConfig.EnableParallelVerifySimulation (or VerifyPermit2Options.EnableParallelSimulation for direct VerifyPermit2 callers); it covers EIP-3009 and the Permit2 standard settle path. Off by default, since the tradeoff is one wasted eth_call per payment rejected on signature grounds.
+time: 2026-09-02T23:05:01.000000-04:00

--- a/go/.changes/unreleased/changed-20260902-230612.yaml
+++ b/go/.changes/unreleased/changed-20260902-230612.yaml
@@ -1,0 +1,3 @@
+kind: changed
+body: 'EVM facilitators now cache a positive asset-contract check for 15 minutes instead of issuing a fresh eth_getCode on the payment token for every payment. Only positive results are cached, so a token observed mid-deployment still recovers on the next request. Breaking: evm.ValidateAssetIsContract takes a network argument, which scopes the cache so entries cannot collide across chains.'
+time: 2026-09-02T23:06:12.000000-04:00

--- a/go/.changes/unreleased/changed-20260902-230725.yaml
+++ b/go/.changes/unreleased/changed-20260902-230725.yaml
@@ -1,0 +1,3 @@
+kind: changed
+body: EVM exact settle's ERC-6492 branch now reads payer deployment from the verify it already awaited rather than issuing a second eth_getCode. Both reads happen within one settle call and before any deploy transaction, so this is not the post-deploy re-read that races RPC state propagation. Settle consequently no longer emits invalid_exact_evm_failed_to_check_deployment.
+time: 2026-09-02T23:07:25.000000-04:00

--- a/go/.changes/unreleased/changed-20260902-230840.yaml
+++ b/go/.changes/unreleased/changed-20260902-230840.yaml
@@ -1,0 +1,3 @@
+kind: changed
+body: SVM upto facilitator channel-account re-reads now back off linearly (200/400/600/800/1000ms across 6 reads) rather than doubling (200/400/800/1600ms across 5 reads). Replica lag behind a confirmed open is a small multiple of Solana's slot time, so the same 3.0s budget now buys one more read and caps any single wait at 1s. Config.ChannelReadMaxAttempts and Config.ChannelReadBackoffStep make it configurable.
+time: 2026-09-02T23:08:40.000000-04:00

--- a/go/mechanisms/evm/asset_cache.go
+++ b/go/mechanisms/evm/asset_cache.go
@@ -1,0 +1,124 @@
+package evm
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// DefaultAssetContractCacheTTL bounds how long a positive asset-contract check is reused.
+const DefaultAssetContractCacheTTL = 15 * time.Minute
+
+// maxAssetContractCacheEntries bounds the cache so callers naming many distinct deployed
+// contracts cannot grow it without limit. A facilitator serves few assets per chain.
+const maxAssetContractCacheEntries = 4096
+
+// assetContractCache memoizes "this asset address has bytecode" per network. It is process-wide
+// because ValidateAssetIsContract is a free function shared by every EVM facilitator scheme.
+//
+// Only positive results are stored: a negative result may be a token observed mid-deployment,
+// which has to self-heal on the next request.
+type assetContractCache struct {
+	mu       sync.RWMutex
+	ttl      time.Duration
+	expiries map[assetContractCacheKey]time.Time
+}
+
+type assetContractCacheKey struct {
+	network string
+	asset   string
+}
+
+var globalAssetContractCache = &assetContractCache{
+	ttl:      DefaultAssetContractCacheTTL,
+	expiries: make(map[assetContractCacheKey]time.Time),
+}
+
+// isFresh reports whether an unexpired positive result is cached. An empty network is never
+// cached, since entries would otherwise collide across chains where one address can hold
+// bytecode on one chain and nothing on another.
+func (c *assetContractCache) isFresh(key assetContractCacheKey, now time.Time) bool {
+	if key.network == "" {
+		return false
+	}
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	expiry, ok := c.expiries[key]
+	return ok && now.Before(expiry)
+}
+
+func (c *assetContractCache) record(key assetContractCacheKey, now time.Time) {
+	if key.network == "" {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for existing, expiry := range c.expiries {
+		if now.After(expiry) {
+			delete(c.expiries, existing)
+		}
+	}
+	if _, ok := c.expiries[key]; !ok && len(c.expiries) >= maxAssetContractCacheEntries {
+		return
+	}
+	c.expiries[key] = now.Add(c.ttl)
+}
+
+// ResetAssetContractCache clears the process-wide asset-contract cache, for tests that assert
+// on eth_getCode call counts across cases sharing an asset address.
+func ResetAssetContractCache() {
+	globalAssetContractCache.mu.Lock()
+	defer globalAssetContractCache.mu.Unlock()
+
+	globalAssetContractCache.expiries = make(map[assetContractCacheKey]time.Time)
+}
+
+// AssetContractCheck is an asset-contract check running in the background.
+type AssetContractCheck struct {
+	network string
+	asset   string
+	results chan assetContractResult
+}
+
+type assetContractResult struct {
+	reason string
+	err    error
+}
+
+// StartAssetContractCheck runs ValidateAssetIsContract in the background so callers can overlap
+// it with signature verification. The result is delivered by Await.
+func StartAssetContractCheck(
+	ctx context.Context,
+	signer FacilitatorEvmSigner,
+	network string,
+	asset string,
+) *AssetContractCheck {
+	check := &AssetContractCheck{
+		network: network,
+		asset:   asset,
+		results: make(chan assetContractResult, 1),
+	}
+	go func() {
+		reason, err := ValidateAssetIsContract(ctx, signer, network, asset)
+		check.results <- assetContractResult{reason: reason, err: err}
+	}()
+	return check
+}
+
+// Await returns the check's result, caching a positive one for DefaultAssetContractCacheTTL.
+// Recording on Await rather than in the goroutine keeps cache contents independent of goroutine
+// scheduling: a check abandoned by an early return cannot publish a result.
+func (c *AssetContractCheck) Await() (string, error) {
+	result := <-c.results
+	if result.err == nil && result.reason == "" {
+		globalAssetContractCache.record(
+			assetContractCacheKey{network: c.network, asset: NormalizeAddress(c.asset)},
+			time.Now(),
+		)
+	}
+	return result.reason, result.err
+}

--- a/go/mechanisms/evm/asset_cache_test.go
+++ b/go/mechanisms/evm/asset_cache_test.go
@@ -1,0 +1,98 @@
+package evm
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const cacheTestAsset = "0x00000000000000000000000000000000000000bb"
+
+// countingCodeSigner reports the asset as deployed and counts eth_getCode calls.
+type countingCodeSigner struct {
+	mockStrictSigner
+	calls int
+}
+
+func (s *countingCodeSigner) GetCode(_ context.Context, _ string) ([]byte, error) {
+	s.calls++
+	return []byte{0x60, 0x60}, nil
+}
+
+func TestAssetContractCheckCachesPositiveResult(t *testing.T) {
+	ResetAssetContractCache()
+
+	signer := &countingCodeSigner{}
+	for range 3 {
+		reason, err := StartAssetContractCheck(context.Background(), signer, "eip155:84532", cacheTestAsset).Await()
+		require.NoError(t, err)
+		assert.Empty(t, reason)
+	}
+
+	assert.Equal(t, 1, signer.calls, "only the first check should reach the RPC")
+}
+
+// A caller that never awaits must leave the cache untouched, so cache contents do not depend on
+// goroutine scheduling.
+func TestAssetContractCheckWithoutAwaitDoesNotCache(t *testing.T) {
+	ResetAssetContractCache()
+
+	signer := &countingCodeSigner{}
+	abandoned := StartAssetContractCheck(context.Background(), signer, "eip155:84532", cacheTestAsset)
+	<-abandoned.results
+
+	reason, err := StartAssetContractCheck(context.Background(), signer, "eip155:84532", cacheTestAsset).Await()
+	require.NoError(t, err)
+	assert.Empty(t, reason)
+	assert.Equal(t, 2, signer.calls, "the abandoned check must not have populated the cache")
+}
+
+// An empty network cannot be cached: entries would otherwise collide across chains, where one
+// address can hold bytecode on one chain and nothing on another.
+func TestAssetContractCacheSkipsEmptyNetwork(t *testing.T) {
+	ResetAssetContractCache()
+
+	signer := &countingCodeSigner{}
+	for range 2 {
+		_, err := StartAssetContractCheck(context.Background(), signer, "", cacheTestAsset).Await()
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, 2, signer.calls, "an empty network must bypass the cache")
+	assert.False(t, globalAssetContractCache.isFresh(assetContractCacheKey{asset: cacheTestAsset}, time.Now()))
+}
+
+func TestAssetContractCacheEntriesExpire(t *testing.T) {
+	ResetAssetContractCache()
+
+	key := assetContractCacheKey{network: "eip155:84532", asset: cacheTestAsset}
+	start := time.Now()
+	globalAssetContractCache.record(key, start)
+
+	assert.True(t, globalAssetContractCache.isFresh(key, start.Add(DefaultAssetContractCacheTTL-time.Second)))
+	assert.False(t, globalAssetContractCache.isFresh(key, start.Add(DefaultAssetContractCacheTTL+time.Second)))
+}
+
+// The cache is keyed partly by caller-supplied asset addresses, so it must not grow without
+// bound when many distinct deployed contracts are named within one TTL window.
+func TestAssetContractCacheIsBounded(t *testing.T) {
+	ResetAssetContractCache()
+
+	now := time.Now()
+	for i := range maxAssetContractCacheEntries + 500 {
+		globalAssetContractCache.record(
+			assetContractCacheKey{network: "eip155:84532", asset: fmt.Sprintf("0x%040x", i)},
+			now,
+		)
+	}
+
+	globalAssetContractCache.mu.RLock()
+	size := len(globalAssetContractCache.expiries)
+	globalAssetContractCache.mu.RUnlock()
+
+	assert.LessOrEqual(t, size, maxAssetContractCacheEntries)
+}

--- a/go/mechanisms/evm/exact/facilitator/eip3009.go
+++ b/go/mechanisms/evm/exact/facilitator/eip3009.go
@@ -15,81 +15,94 @@ import (
 	"github.com/x402-foundation/x402/go/v2/types"
 )
 
-// verifyEIP3009 verifies an EIP-3009 payment payload.
+// verifyEIP3009 verifies an EIP-3009 payment payload. On success it also returns the signature
+// classification, so settle can reuse the payer code lookup instead of issuing a second
+// eth_getCode for the same address.
 func (f *ExactEvmScheme) verifyEIP3009(
 	ctx context.Context,
 	payload types.PaymentPayload,
 	requirements types.PaymentRequirements,
 	simulate bool,
-) (*x402.VerifyResponse, error) {
+) (*x402.VerifyResponse, *EIP3009SignatureClassification, error) {
 	if payload.Accepted.Scheme != evm.SchemeExact {
-		return nil, x402.NewVerifyError(ErrInvalidScheme, "", fmt.Sprintf("invalid scheme: %s", payload.Accepted.Scheme))
+		return nil, nil, x402.NewVerifyError(ErrInvalidScheme, "", fmt.Sprintf("invalid scheme: %s", payload.Accepted.Scheme))
 	}
 
 	if payload.Accepted.Network != requirements.Network {
-		return nil, x402.NewVerifyError(ErrNetworkMismatch, "", fmt.Sprintf("network mismatch: %s != %s", payload.Accepted.Network, requirements.Network))
+		return nil, nil, x402.NewVerifyError(ErrNetworkMismatch, "", fmt.Sprintf("network mismatch: %s != %s", payload.Accepted.Network, requirements.Network))
 	}
 
 	evmPayload, err := evm.PayloadFromMap(payload.Payload)
 	if err != nil {
-		return nil, x402.NewVerifyError(ErrInvalidPayload, "", fmt.Sprintf("failed to parse EVM payload: %s", err.Error()))
+		return nil, nil, x402.NewVerifyError(ErrInvalidPayload, "", fmt.Sprintf("failed to parse EVM payload: %s", err.Error()))
 	}
 
 	if evmPayload.Signature == "" {
-		return nil, x402.NewVerifyError(ErrMissingSignature, "", "missing signature")
+		return nil, nil, x402.NewVerifyError(ErrMissingSignature, "", "missing signature")
 	}
 
 	chainID, err := evm.GetEvmChainId(string(requirements.Network))
 	if err != nil {
-		return nil, x402.NewVerifyError(ErrFailedToGetNetworkConfig, "", err.Error())
+		return nil, nil, x402.NewVerifyError(ErrFailedToGetNetworkConfig, "", err.Error())
 	}
 
 	tokenAddress := evm.NormalizeAddress(requirements.Asset)
 
 	if !strings.EqualFold(evmPayload.Authorization.To, requirements.PayTo) {
-		return nil, x402.NewVerifyError(ErrRecipientMismatch, "", fmt.Sprintf("recipient mismatch: %s != %s", evmPayload.Authorization.To, requirements.PayTo))
+		return nil, nil, x402.NewVerifyError(ErrRecipientMismatch, "", fmt.Sprintf("recipient mismatch: %s != %s", evmPayload.Authorization.To, requirements.PayTo))
 	}
 
 	parsedAuthorization, err := ParseEIP3009Authorization(evmPayload.Authorization)
 	if err != nil {
-		return nil, x402.NewVerifyError(ErrInvalidPayload, evmPayload.Authorization.From, err.Error())
+		return nil, nil, x402.NewVerifyError(ErrInvalidPayload, evmPayload.Authorization.From, err.Error())
 	}
 
 	requiredValue, ok := new(big.Int).SetString(requirements.Amount, 10)
 	if !ok {
-		return nil, x402.NewVerifyError(ErrInvalidRequiredAmount, "", fmt.Sprintf("invalid required amount: %s", requirements.Amount))
+		return nil, nil, x402.NewVerifyError(ErrInvalidRequiredAmount, "", fmt.Sprintf("invalid required amount: %s", requirements.Amount))
 	}
 
 	if parsedAuthorization.Value.Cmp(requiredValue) != 0 {
-		return nil, x402.NewVerifyError(ErrAuthorizationValueMismatch, evmPayload.Authorization.From, fmt.Sprintf("authorization value mismatch: %s != %s", parsedAuthorization.Value.String(), requiredValue.String()))
+		return nil, nil, x402.NewVerifyError(ErrAuthorizationValueMismatch, evmPayload.Authorization.From, fmt.Sprintf("authorization value mismatch: %s != %s", parsedAuthorization.Value.String(), requiredValue.String()))
 	}
 
 	now := time.Now().Unix()
 	if parsedAuthorization.ValidBefore.Cmp(big.NewInt(now+6)) < 0 {
-		return nil, x402.NewVerifyError(ErrValidBeforeExpired, evmPayload.Authorization.From, fmt.Sprintf("valid before expired: %s", parsedAuthorization.ValidBefore.String()))
+		return nil, nil, x402.NewVerifyError(ErrValidBeforeExpired, evmPayload.Authorization.From, fmt.Sprintf("valid before expired: %s", parsedAuthorization.ValidBefore.String()))
 	}
 
 	if parsedAuthorization.ValidAfter.Cmp(big.NewInt(now)) > 0 {
-		return nil, x402.NewVerifyError(ErrValidAfterInFuture, evmPayload.Authorization.From, fmt.Sprintf("valid after in future: %s", parsedAuthorization.ValidAfter.String()))
+		return nil, nil, x402.NewVerifyError(ErrValidAfterInFuture, evmPayload.Authorization.From, fmt.Sprintf("valid after in future: %s", parsedAuthorization.ValidAfter.String()))
 	}
 
 	tokenName, _ := requirements.Extra["name"].(string)
 	tokenVersion, _ := requirements.Extra["version"].(string)
 	if tokenName == "" || tokenVersion == "" {
-		return nil, x402.NewVerifyError(ErrMissingEip712Domain, evmPayload.Authorization.From, "missing EIP-712 domain name/version in requirements.extra")
+		return nil, nil, x402.NewVerifyError(ErrMissingEip712Domain, evmPayload.Authorization.From, "missing EIP-712 domain name/version in requirements.extra")
 	}
 
 	signatureBytes, err := evm.HexToBytes(evmPayload.Signature)
 	if err != nil {
-		return nil, x402.NewVerifyError(ErrInvalidSignatureFormat, evmPayload.Authorization.From, err.Error())
+		return nil, nil, x402.NewVerifyError(ErrInvalidSignatureFormat, evmPayload.Authorization.From, err.Error())
 	}
 
 	// Run the asset-contract check concurrently with signature classification.
-	assetCheckCh := make(chan assetContractCheck, 1)
-	go func() {
-		reason, err := evm.ValidateAssetIsContract(ctx, f.signer, requirements.Asset)
-		assetCheckCh <- assetContractCheck{reason: reason, err: err}
-	}()
+	assetCheck := evm.StartAssetContractCheck(ctx, f.signer, string(requirements.Network), requirements.Asset)
+
+	// SimulateEIP3009Transfer branches only on Factory/FactoryCalldata and the inner signature
+	// length, never on SigData.CodeDeployed, so it does not need the eth_getCode classification
+	// issues and can start concurrently. Its result is still read after the classification and
+	// asset checks below, leaving error precedence unchanged.
+	var simulationCh chan simulationResult
+	if simulate && f.config.EnableParallelVerifySimulation {
+		if parsedSigData, parseErr := evm.ParseERC6492Signature(signatureBytes); parseErr == nil {
+			var cancelSimulation context.CancelFunc
+			simulationCh, cancelSimulation = startSimulation(ctx, func(ctx context.Context) (bool, error) {
+				return SimulateEIP3009Transfer(ctx, f.signer, tokenAddress, parsedAuthorization, parsedSigData)
+			})
+			defer cancelSimulation()
+		}
+	}
 
 	classification, err := ClassifyEIP3009Signature(
 		ctx,
@@ -102,15 +115,15 @@ func (f *ExactEvmScheme) verifyEIP3009(
 		tokenVersion,
 	)
 	if err != nil {
-		return nil, x402.NewVerifyError(ErrFailedToVerifySignature, evmPayload.Authorization.From, err.Error())
+		return nil, nil, x402.NewVerifyError(ErrFailedToVerifySignature, evmPayload.Authorization.From, err.Error())
 	}
 
 	if !classification.Valid && classification.IsUndeployed && !HasEIP6492Deployment(classification.SigData) {
-		return nil, x402.NewVerifyError(ErrUndeployedSmartWallet, evmPayload.Authorization.From, "")
+		return nil, nil, x402.NewVerifyError(ErrUndeployedSmartWallet, evmPayload.Authorization.From, "")
 	}
 
 	if !classification.Valid && !classification.IsSmartWallet {
-		return nil, x402.NewVerifyError(ErrInvalidSignature, evmPayload.Authorization.From, fmt.Sprintf("invalid signature: %s", evmPayload.Signature))
+		return nil, nil, x402.NewVerifyError(ErrInvalidSignature, evmPayload.Authorization.From, fmt.Sprintf("invalid signature: %s", evmPayload.Signature))
 	}
 
 	// Counterfactual ERC-6492 wallet: settle deploys via the factory, gated by the
@@ -118,28 +131,24 @@ func (f *ExactEvmScheme) verifyEIP3009(
 	// settle rejects with ErrFactoryNotAllowed must not verify as valid).
 	if !classification.Valid && classification.IsUndeployed && HasEIP6492Deployment(classification.SigData) {
 		if !evm.IsFactoryAllowed(classification.SigData.Factory, f.config.EIP6492AllowedFactories) {
-			return nil, x402.NewVerifyError(ErrFactoryNotAllowed, evmPayload.Authorization.From, "factory not in EIP6492AllowedFactories allowlist")
+			return nil, nil, x402.NewVerifyError(ErrFactoryNotAllowed, evmPayload.Authorization.From, "factory not in EIP6492AllowedFactories allowlist")
 		}
 	}
 
-	assetResult := <-assetCheckCh
-	if assetResult.err != nil {
-		return nil, fmt.Errorf("asset contract check failed: %w", assetResult.err)
+	assetReason, assetErr := assetCheck.Await()
+	if assetErr != nil {
+		return nil, nil, fmt.Errorf("asset contract check failed: %w", assetErr)
 	}
-	if assetResult.reason != "" {
-		return nil, x402.NewVerifyError(assetResult.reason, evmPayload.Authorization.From, fmt.Sprintf("asset %s is not a deployed contract", requirements.Asset))
+	if assetReason != "" {
+		return nil, nil, x402.NewVerifyError(assetReason, evmPayload.Authorization.From, fmt.Sprintf("asset %s is not a deployed contract", requirements.Asset))
 	}
 
 	if simulate {
-		simulationSucceeded, err := SimulateEIP3009Transfer(
-			ctx,
-			f.signer,
-			tokenAddress,
-			parsedAuthorization,
-			classification.SigData,
-		)
+		simulationSucceeded, err := awaitSimulation(simulationCh, func() (bool, error) {
+			return SimulateEIP3009Transfer(ctx, f.signer, tokenAddress, parsedAuthorization, classification.SigData)
+		})
 		if err != nil {
-			return nil, x402.NewVerifyError(ErrEip3009SimulationFailed, evmPayload.Authorization.From, err.Error())
+			return nil, nil, x402.NewVerifyError(ErrEip3009SimulationFailed, evmPayload.Authorization.From, err.Error())
 		}
 		if !simulationSucceeded {
 			reason := DiagnoseEIP3009SimulationFailure(
@@ -151,14 +160,14 @@ func (f *ExactEvmScheme) verifyEIP3009(
 				tokenName,
 				tokenVersion,
 			)
-			return nil, x402.NewVerifyError(reason, evmPayload.Authorization.From, "")
+			return nil, nil, x402.NewVerifyError(reason, evmPayload.Authorization.From, "")
 		}
 	}
 
 	return &x402.VerifyResponse{
 		IsValid: true,
 		Payer:   evmPayload.Authorization.From,
-	}, nil
+	}, classification, nil
 }
 
 // settleEIP3009 settles an EIP-3009 payment on-chain.
@@ -186,7 +195,7 @@ func (f *ExactEvmScheme) settleEIP3009(
 		}
 	}
 
-	verifyResp, err := f.verifyEIP3009(ctx, payload, requirements, f.config.SimulateInSettle)
+	verifyResp, classification, err := f.verifyEIP3009(ctx, payload, requirements, f.config.SimulateInSettle)
 	if err != nil {
 		ve := &x402.VerifyError{}
 		if errors.As(err, &ve) {
@@ -202,23 +211,16 @@ func (f *ExactEvmScheme) settleEIP3009(
 
 	tokenAddress := evm.NormalizeAddress(requirements.Asset)
 
-	signatureBytes, err := evm.HexToBytes(evmPayload.Signature)
-	if err != nil {
-		return nil, x402.NewSettleError(ErrInvalidSignatureFormat, verifyResp.Payer, network, "", err.Error())
+	if classification == nil {
+		return nil, x402.NewSettleError(ErrFailedToParseSignature, verifyResp.Payer, network, "", "verify returned no signature classification")
 	}
-
-	sigData, err := evm.ParseERC6492Signature(signatureBytes)
-	if err != nil {
-		return nil, x402.NewSettleError(ErrFailedToParseSignature, verifyResp.Payer, network, "", err.Error())
-	}
+	sigData := classification.SigData
 
 	if HasEIP6492Deployment(sigData) {
-		code, err := f.signer.GetCode(ctx, evmPayload.Authorization.From)
-		if err != nil {
-			return nil, x402.NewSettleError(ErrFailedToCheckDeployment, verifyResp.Payer, network, "", err.Error())
-		}
-
-		if len(code) == 0 {
+		// CodeDeployed comes from the eth_getCode the verify above already issued for this payer.
+		// Both reads happen before any deploy transaction, so reusing it does not reintroduce the
+		// post-deploy re-read that races RPC state propagation across replicas.
+		if !sigData.CodeDeployed {
 			if !evm.IsFactoryAllowed(sigData.Factory, f.config.EIP6492AllowedFactories) {
 				return nil, x402.NewSettleError(ErrFactoryNotAllowed, verifyResp.Payer, network, "", "")
 			}

--- a/go/mechanisms/evm/exact/facilitator/errors.go
+++ b/go/mechanisms/evm/exact/facilitator/errors.go
@@ -30,8 +30,10 @@ const (
 	ErrEip3009SimulationFailed     = "invalid_exact_evm_transaction_simulation_failed"
 
 	// EIP-3009 Settle errors
-	ErrVerificationFailed      = "invalid_exact_evm_verification_failed"
-	ErrFailedToParseSignature  = "invalid_exact_evm_failed_to_parse_signature"
+	ErrVerificationFailed     = "invalid_exact_evm_verification_failed"
+	ErrFailedToParseSignature = "invalid_exact_evm_failed_to_parse_signature"
+	// Reserved wire value: settle now reads deployment from the verify it already awaited, so
+	// it no longer performs the eth_getCode this reported on. Do not reassign.
 	ErrFailedToCheckDeployment = "invalid_exact_evm_failed_to_check_deployment"
 	ErrFailedToExecuteTransfer = "invalid_exact_evm_failed_to_execute_transfer"
 	// Reserved wire value (exact/v1); do not reassign.

--- a/go/mechanisms/evm/exact/facilitator/permit2.go
+++ b/go/mechanisms/evm/exact/facilitator/permit2.go
@@ -19,12 +19,40 @@ import (
 type VerifyPermit2Options struct {
 	// Simulate enables onchain simulation. Defaults to true when zero-value.
 	Simulate *bool
+	// EnableParallelSimulation starts the standard settle() simulation concurrently with the
+	// signature check rather than after it, removing one RPC round trip. Opt-in, because the
+	// cost is one wasted eth_call for payments rejected on signature grounds.
+	EnableParallelSimulation bool
 }
 
-// assetContractCheck carries evm.ValidateAssetIsContract's result out of a goroutine.
-type assetContractCheck struct {
-	reason string
-	err    error
+type simulationResult struct {
+	succeeded bool
+	err       error
+}
+
+// startSimulation runs simulate in the background. Cancelling stops the in-flight eth_call, so
+// a payment rejected before the result is read does not leave one running.
+func startSimulation(
+	ctx context.Context,
+	simulate func(context.Context) (bool, error),
+) (chan simulationResult, context.CancelFunc) {
+	simulationCtx, cancel := context.WithCancel(ctx)
+	results := make(chan simulationResult, 1)
+	go func() {
+		succeeded, err := simulate(simulationCtx)
+		results <- simulationResult{succeeded: succeeded, err: err}
+	}()
+	return results, cancel
+}
+
+// awaitSimulation reads the result of a simulation started by startSimulation, or runs simulate
+// inline when none was started.
+func awaitSimulation(started chan simulationResult, simulate func() (bool, error)) (bool, error) {
+	if started == nil {
+		return simulate()
+	}
+	result := <-started
+	return result.succeeded, result.err
 }
 
 func (o *VerifyPermit2Options) shouldSimulate() bool {
@@ -32,6 +60,32 @@ func (o *VerifyPermit2Options) shouldSimulate() bool {
 		return true
 	}
 	return *o.Simulate
+}
+
+func (o *VerifyPermit2Options) shouldSimulateInParallel() bool {
+	return o != nil && o.EnableParallelSimulation && o.shouldSimulate()
+}
+
+// resolveErc20ApprovalSponsor extracts the ERC-20 approval gas-sponsoring info and resolves the
+// extension signer for the payment's network. A nil signer means the ERC-20 approval branch does
+// not apply even when info is present, matching the fall-through to standard settle.
+func resolveErc20ApprovalSponsor(
+	payload types.PaymentPayload,
+	facilCtx *x402.FacilitatorContext,
+) (*erc20approvalgassponsor.Info, erc20approvalgassponsor.Erc20ApprovalGasSponsoringSigner) {
+	info, _ := erc20approvalgassponsor.ExtractInfo(payload.Extensions)
+	if info == nil || facilCtx == nil {
+		return nil, nil
+	}
+
+	ext, ok := facilCtx.GetExtension(
+		erc20approvalgassponsor.ERC20ApprovalGasSponsoring.Key(),
+	).(*erc20approvalgassponsor.Erc20ApprovalFacilitatorExtension)
+	if !ok || ext == nil {
+		return info, nil
+	}
+
+	return info, ext.ResolveSigner(payload.Accepted.Network)
 }
 
 // VerifyPermit2 verifies a Permit2 payment payload.
@@ -64,11 +118,7 @@ func VerifyPermit2(
 	tokenAddress := evm.NormalizeAddress(requirements.Asset)
 
 	// Run the asset-contract check concurrently with the signature check below.
-	assetCheckCh := make(chan assetContractCheck, 1)
-	go func() {
-		reason, err := evm.ValidateAssetIsContract(ctx, signer, requirements.Asset)
-		assetCheckCh <- assetContractCheck{reason: reason, err: err}
-	}()
+	assetCheck := evm.StartAssetContractCheck(ctx, signer, string(requirements.Network), requirements.Asset)
 
 	// Verify spender is x402ExactPermit2Proxy
 	if !strings.EqualFold(permit2Payload.Permit2Authorization.Spender, evm.X402ExactPermit2ProxyAddress) {
@@ -123,14 +173,31 @@ func VerifyPermit2(
 		return nil, x402.NewVerifyError(ErrInvalidSignatureFormat, payer, err.Error())
 	}
 
+	// Both inputs are local, so the applicable simulation branch is known before any RPC.
+	eip2612Info, _ := eip2612gassponsor.ExtractEip2612GasSponsoringInfo(payload.Extensions)
+	erc20Info, erc20Signer := resolveErc20ApprovalSponsor(payload, facilCtx)
+
+	// The standard settle() simulation depends only on permit2Payload, never on the eth_getCode
+	// that verifyPermit2Signature issues, so it can start concurrently. The result is still read
+	// after the signature and asset checks below, leaving error precedence unchanged. The
+	// gas-sponsoring branches simulate different calls and stay sequential.
+	var simulationCh chan simulationResult
+	if eip2612Info == nil && erc20Signer == nil && opts.shouldSimulateInParallel() {
+		var cancelSimulation context.CancelFunc
+		simulationCh, cancelSimulation = startSimulation(ctx, func(ctx context.Context) (bool, error) {
+			return SimulatePermit2Settle(ctx, signer, permit2Payload)
+		})
+		defer cancelSimulation()
+	}
+
 	sigValid, sigData, sigErr := verifyPermit2Signature(ctx, signer, permit2Payload.Permit2Authorization, signatureBytes, chainID)
 
-	assetResult := <-assetCheckCh
-	if assetResult.err != nil {
-		return nil, fmt.Errorf("asset contract check failed: %w", assetResult.err)
+	assetReason, assetErr := assetCheck.Await()
+	if assetErr != nil {
+		return nil, fmt.Errorf("asset contract check failed: %w", assetErr)
 	}
-	if assetResult.reason != "" {
-		return nil, x402.NewVerifyError(assetResult.reason, payer, fmt.Sprintf("asset %s is not a deployed contract", requirements.Asset))
+	if assetReason != "" {
+		return nil, x402.NewVerifyError(assetReason, payer, fmt.Sprintf("asset %s is not a deployed contract", requirements.Asset))
 	}
 
 	if sigErr != nil || !sigValid {
@@ -153,7 +220,6 @@ func VerifyPermit2(
 	}
 
 	// EIP-2612 gas sponsoring (atomic settleWithPermit via contract)
-	eip2612Info, _ := eip2612gassponsor.ExtractEip2612GasSponsoringInfo(payload.Extensions)
 	if eip2612Info != nil {
 		if validErr := validateEip2612PermitForPayment(eip2612Info, payer, tokenAddress); validErr != "" {
 			return nil, x402.NewVerifyError(validErr, payer, "eip2612 validation failed")
@@ -168,51 +234,44 @@ func VerifyPermit2(
 	}
 
 	// ERC-20 approval gas sponsoring
-	erc20Info, _ := erc20approvalgassponsor.ExtractInfo(payload.Extensions)
-	if erc20Info != nil && facilCtx != nil {
-		ext, ok := facilCtx.GetExtension(erc20approvalgassponsor.ERC20ApprovalGasSponsoring.Key()).(*erc20approvalgassponsor.Erc20ApprovalFacilitatorExtension)
-		var extensionSigner erc20approvalgassponsor.Erc20ApprovalGasSponsoringSigner
-		if ok && ext != nil {
-			extensionSigner = ext.ResolveSigner(payload.Accepted.Network)
+	if erc20Signer != nil {
+		if reason, msg := ValidateErc20ApprovalForPayment(erc20Info, payer, tokenAddress); reason != "" {
+			return nil, x402.NewVerifyError(reason, payer, msg)
 		}
 
-		if extensionSigner != nil {
-			if reason, msg := ValidateErc20ApprovalForPayment(erc20Info, payer, tokenAddress); reason != "" {
-				return nil, x402.NewVerifyError(reason, payer, msg)
-			}
-
-			// If the signer supports SimulateTransactions, use it for the approve+settle bundle
-			if simulator, ok := extensionSigner.(erc20approvalgassponsor.Erc20ApprovalGasSponsoringSimulator); ok {
-				simArgs, buildErr := BuildPermit2SettleArgs(permit2Payload)
-				if buildErr == nil {
-					simOk, simErr := simulator.SimulateTransactions(ctx, []erc20approvalgassponsor.TransactionRequest{
-						{Serialized: erc20Info.SignedTransaction},
-						{Call: &erc20approvalgassponsor.WriteContractCall{
-							Address:  evm.X402ExactPermit2ProxyAddress,
-							ABI:      evm.X402ExactPermit2ProxySettleABI,
-							Function: evm.FunctionSettle,
-							Args:     []interface{}{simArgs.permitStruct(), simArgs.Owner, simArgs.witnessStruct(), simArgs.Signature},
-						}},
-					})
-					if simErr == nil && simOk {
-						return &x402.VerifyResponse{IsValid: true, Payer: payer}, nil
-					}
+		// If the signer supports SimulateTransactions, use it for the approve+settle bundle
+		if simulator, ok := erc20Signer.(erc20approvalgassponsor.Erc20ApprovalGasSponsoringSimulator); ok {
+			simArgs, buildErr := BuildPermit2SettleArgs(permit2Payload)
+			if buildErr == nil {
+				simOk, simErr := simulator.SimulateTransactions(ctx, []erc20approvalgassponsor.TransactionRequest{
+					{Serialized: erc20Info.SignedTransaction},
+					{Call: &erc20approvalgassponsor.WriteContractCall{
+						Address:  evm.X402ExactPermit2ProxyAddress,
+						ABI:      evm.X402ExactPermit2ProxySettleABI,
+						Function: evm.FunctionSettle,
+						Args:     []interface{}{simArgs.permitStruct(), simArgs.Owner, simArgs.witnessStruct(), simArgs.Signature},
+					}},
+				})
+				if simErr == nil && simOk {
+					return &x402.VerifyResponse{IsValid: true, Payer: payer}, nil
 				}
-				resp := DiagnosePermit2SimulationFailure(ctx, signer, tokenAddress, permit2Payload, requirements.Amount)
-				return nil, x402.NewVerifyError(resp.InvalidReason, payer, "simulation failed")
 			}
-
-			// Fallback: signer does not support simulation; check prerequisites only
-			prereqResp := CheckPermit2Prerequisites(ctx, signer, tokenAddress, payer, requirements.Amount)
-			if !prereqResp.IsValid {
-				return nil, x402.NewVerifyError(prereqResp.InvalidReason, payer, "prerequisites check failed")
-			}
-			return &x402.VerifyResponse{IsValid: true, Payer: payer}, nil
+			resp := DiagnosePermit2SimulationFailure(ctx, signer, tokenAddress, permit2Payload, requirements.Amount)
+			return nil, x402.NewVerifyError(resp.InvalidReason, payer, "simulation failed")
 		}
+
+		// Fallback: signer does not support simulation; check prerequisites only
+		prereqResp := CheckPermit2Prerequisites(ctx, signer, tokenAddress, payer, requirements.Amount)
+		if !prereqResp.IsValid {
+			return nil, x402.NewVerifyError(prereqResp.InvalidReason, payer, "prerequisites check failed")
+		}
+		return &x402.VerifyResponse{IsValid: true, Payer: payer}, nil
 	}
 
 	// Standard settle (allowance already on-chain)
-	simOk, simErr := SimulatePermit2Settle(ctx, signer, permit2Payload)
+	simOk, simErr := awaitSimulation(simulationCh, func() (bool, error) {
+		return SimulatePermit2Settle(ctx, signer, permit2Payload)
+	})
 	if simErr != nil || !simOk {
 		resp := DiagnosePermit2SimulationFailure(ctx, signer, tokenAddress, permit2Payload, requirements.Amount)
 		return nil, x402.NewVerifyError(resp.InvalidReason, payer, "simulation failed")
@@ -231,6 +290,10 @@ type Permit2FacilitatorConfig struct {
 	// re-verifying and re-broadcasting. A nil value falls back to a fresh
 	// in-memory store (equivalent to no cross-call sharing).
 	PendingSettlementStore x402.PendingSettlementStore
+	// EnableParallelSimulation is forwarded to VerifyPermit2 as
+	// VerifyPermit2Options.EnableParallelSimulation. It only has an effect when
+	// SimulateInSettle is true, since otherwise settle runs no simulation at all.
+	EnableParallelSimulation bool
 }
 
 // ResolvePermit2ReceiptWaitSigner returns the signer that should wait for the
@@ -278,10 +341,12 @@ func SettlePermit2(
 	payer := permit2Payload.Permit2Authorization.From
 
 	simulate := false
+	enableParallelSimulation := false
 	var store x402.PendingSettlementStore
 	if config != nil {
 		simulate = config.SimulateInSettle
 		store = config.PendingSettlementStore
+		enableParallelSimulation = config.EnableParallelSimulation
 	}
 	if store == nil {
 		store = x402.NewInMemoryPendingSettlementStore()
@@ -302,7 +367,8 @@ func SettlePermit2(
 		}
 	}
 
-	if _, err := VerifyPermit2(ctx, signer, payload, requirements, permit2Payload, facilCtx, &VerifyPermit2Options{Simulate: &simulate}); err != nil {
+	verifyOpts := &VerifyPermit2Options{Simulate: &simulate, EnableParallelSimulation: enableParallelSimulation}
+	if _, err := VerifyPermit2(ctx, signer, payload, requirements, permit2Payload, facilCtx, verifyOpts); err != nil {
 		ve := &x402.VerifyError{}
 		if errors.As(err, &ve) {
 			return nil, x402.NewSettleError(ve.InvalidReason, ve.Payer, network, "", ve.InvalidMessage)

--- a/go/mechanisms/evm/exact/facilitator/roundtrip_test.go
+++ b/go/mechanisms/evm/exact/facilitator/roundtrip_test.go
@@ -1,0 +1,398 @@
+package facilitator
+
+import (
+	"context"
+	"math/big"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/x402-foundation/x402/go/v2/mechanisms/evm"
+	"github.com/x402-foundation/x402/go/v2/types"
+)
+
+// These tests pin the RPC round trips verify and settle make, so a regression that reintroduces
+// a sequential call or a duplicate eth_getCode fails here rather than quietly costing a round
+// trip. Concurrency is asserted by a happens-before rendezvous, not by elapsed time.
+
+const (
+	roundTripPayer = "0x00000000000000000000000000000000000000aa"
+	roundTripPayTo = "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0"
+	roundTripAsset = "0x00000000000000000000000000000000000000bb"
+)
+
+// roundTripSigner counts calls per RPC method and can hold a GetCode open until the transfer
+// simulation's eth_call arrives.
+type roundTripSigner struct {
+	mu           sync.Mutex
+	getCodeCalls map[string]int
+	readCalls    map[string]int
+
+	codeByAddress map[string][]byte
+
+	// blockGetCodeFor makes GetCode for that address wait until the transfer simulation starts.
+	blockGetCodeFor string
+	// blockTimeout bounds that wait so a sequential implementation fails the assertion rather
+	// than deadlocking the test.
+	blockTimeout time.Duration
+
+	simulationStarted      chan struct{}
+	signalSimulationOnce   sync.Once
+	getCodeGaveUpOnWaiting bool
+}
+
+func newRoundTripSigner(codeByAddress map[string][]byte) *roundTripSigner {
+	return &roundTripSigner{
+		getCodeCalls:      map[string]int{},
+		readCalls:         map[string]int{},
+		codeByAddress:     codeByAddress,
+		blockTimeout:      2 * time.Second,
+		simulationStarted: make(chan struct{}),
+	}
+}
+
+func (s *roundTripSigner) getCodeCount(address string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.getCodeCalls[strings.ToLower(address)]
+}
+
+func (s *roundTripSigner) readCount(functionName string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.readCalls[functionName]
+}
+
+func (s *roundTripSigner) gaveUpWaiting() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.getCodeGaveUpOnWaiting
+}
+
+func (s *roundTripSigner) GetAddresses() []string { return []string{"0xFac11"} }
+
+func (s *roundTripSigner) GetCode(_ context.Context, address string) ([]byte, error) {
+	normalized := strings.ToLower(address)
+
+	s.mu.Lock()
+	s.getCodeCalls[normalized]++
+	s.mu.Unlock()
+
+	if s.blockGetCodeFor != "" && normalized == strings.ToLower(s.blockGetCodeFor) {
+		select {
+		case <-s.simulationStarted:
+		case <-time.After(s.blockTimeout):
+			s.mu.Lock()
+			s.getCodeGaveUpOnWaiting = true
+			s.mu.Unlock()
+		}
+	}
+
+	return s.codeByAddress[normalized], nil
+}
+
+func (s *roundTripSigner) ReadContract(
+	_ context.Context,
+	_ string,
+	_ []byte,
+	functionName string,
+	_ ...interface{},
+) (interface{}, error) {
+	s.mu.Lock()
+	s.readCalls[functionName]++
+	s.mu.Unlock()
+
+	switch functionName {
+	case "isValidSignature":
+		// EIP-1271 magic value, so the deployed smart wallet accepts the signature.
+		return []byte{0x16, 0x26, 0xba, 0x7e}, nil
+	case evm.FunctionTransferWithAuthorization, evm.FunctionSettle:
+		// The EIP-3009 and Permit2 transfer simulations respectively.
+		s.signalSimulationOnce.Do(func() { close(s.simulationStarted) })
+		return nil, nil
+	default:
+		return nil, nil
+	}
+}
+
+func (s *roundTripSigner) VerifyTypedData(
+	_ context.Context,
+	_ string,
+	_ evm.TypedDataDomain,
+	_ map[string][]evm.TypedDataField,
+	_ string,
+	_ map[string]interface{},
+	_ []byte,
+) (bool, error) {
+	return false, nil
+}
+
+func (s *roundTripSigner) WriteContract(
+	_ context.Context,
+	_ string,
+	_ []byte,
+	_ string,
+	_ []byte,
+	_ ...interface{},
+) (string, error) {
+	return "0x" + strings.Repeat("ab", 32), nil
+}
+
+func (s *roundTripSigner) SendTransaction(_ context.Context, _ string, _ []byte) (string, error) {
+	return "0x" + strings.Repeat("cd", 32), nil
+}
+
+func (s *roundTripSigner) WaitForTransactionReceipt(_ context.Context, txHash string) (*evm.TransactionReceipt, error) {
+	return &evm.TransactionReceipt{Status: evm.TxStatusSuccess, TxHash: txHash}, nil
+}
+
+func (s *roundTripSigner) GetBalance(_ context.Context, _ string, _ string) (*big.Int, error) {
+	return big.NewInt(1_000_000_000), nil
+}
+
+func (s *roundTripSigner) GetChainID(_ context.Context) (*big.Int, error) {
+	return big.NewInt(84532), nil
+}
+
+// deployedSmartWalletPayload builds an EIP-3009 payment from a deployed smart-wallet payer: the
+// signature is not 65 bytes, so classification routes to EIP-1271 and the simulation takes the
+// bytes-signature transferWithAuthorization overload.
+func deployedSmartWalletPayload() (types.PaymentPayload, types.PaymentRequirements) {
+	payload := &evm.ExactEIP3009Payload{
+		Signature: "0x" + strings.Repeat("cc", 66),
+		Authorization: evm.ExactEIP3009Authorization{
+			From:        roundTripPayer,
+			To:          roundTripPayTo,
+			Value:       "1000000",
+			ValidAfter:  "0",
+			ValidBefore: "99999999999",
+			Nonce:       "0x" + strings.Repeat("00", 32),
+		},
+	}
+	requirements := types.PaymentRequirements{
+		Scheme:  "exact",
+		Network: "eip155:84532",
+		Amount:  "1000000",
+		Asset:   roundTripAsset,
+		PayTo:   roundTripPayTo,
+		Extra:   map[string]interface{}{"name": "USDC", "version": "2"},
+	}
+	return types.PaymentPayload{X402Version: 2, Payload: payload.ToMap(), Accepted: requirements}, requirements
+}
+
+func deployedSmartWalletSigner() *roundTripSigner {
+	return newRoundTripSigner(map[string][]byte{
+		strings.ToLower(roundTripAsset): {0x60, 0x60},
+		strings.ToLower(roundTripPayer): {0x60, 0x60},
+	})
+}
+
+// With EnableParallelVerifySimulation set, verify must issue the simulation without waiting for
+// the payer's eth_getCode, which holds until that eth_call arrives.
+func TestVerifyEIP3009_SimulationRunsConcurrentlyWithClassification(t *testing.T) {
+	evm.ResetAssetContractCache()
+
+	payload, requirements := deployedSmartWalletPayload()
+	signer := deployedSmartWalletSigner()
+	signer.blockGetCodeFor = roundTripPayer
+
+	scheme := NewExactEvmScheme(signer, &ExactEvmSchemeConfig{EnableParallelVerifySimulation: true})
+	if _, err := scheme.Verify(context.Background(), payload, requirements, nil); err != nil {
+		t.Fatalf("expected verify to succeed, got: %v", err)
+	}
+
+	if signer.gaveUpWaiting() {
+		t.Fatal("payer eth_getCode completed before the transfer simulation was issued: " +
+			"the simulation is running sequentially after classification")
+	}
+	if got := signer.readCount(evm.FunctionTransferWithAuthorization); got != 1 {
+		t.Fatalf("expected exactly 1 transfer simulation, got %d", got)
+	}
+}
+
+// Control for the test above: an unconfigured scheme must keep the sequential order, so a mock
+// that signalled the rendezvous early cannot make that assertion vacuous.
+func TestVerifyEIP3009_ParallelSimulationIsOptIn(t *testing.T) {
+	evm.ResetAssetContractCache()
+
+	payload, requirements := deployedSmartWalletPayload()
+	signer := deployedSmartWalletSigner()
+	signer.blockGetCodeFor = roundTripPayer
+	signer.blockTimeout = 150 * time.Millisecond
+
+	scheme := NewExactEvmScheme(signer, nil)
+	if _, err := scheme.Verify(context.Background(), payload, requirements, nil); err != nil {
+		t.Fatalf("expected verify to succeed, got: %v", err)
+	}
+
+	if !signer.gaveUpWaiting() {
+		t.Fatal("expected the transfer simulation to wait for classification unless " +
+			"EnableParallelVerifySimulation is set")
+	}
+}
+
+// Permit2's standard settle() simulation must likewise start before the payer's eth_getCode
+// resolves. The gas-sponsoring branches are excluded from the head start and absent here.
+func TestVerifyPermit2_SimulationRunsConcurrentlyWithSignatureCheck(t *testing.T) {
+	evm.ResetAssetContractCache()
+
+	payload, requirements, permit2Payload := plainPermit2Payload()
+	signer := newRoundTripSigner(map[string][]byte{
+		strings.ToLower(testToken): {0x60, 0x60},
+		strings.ToLower(testPayer): {0x60, 0x60}, // deployed, so the signature check falls through
+	})
+	signer.blockGetCodeFor = testPayer
+
+	opts := &VerifyPermit2Options{EnableParallelSimulation: true}
+	_, err := VerifyPermit2(context.Background(), signer, payload, requirements, permit2Payload, nil, opts)
+	if err != nil {
+		t.Fatalf("expected verify to succeed, got: %v", err)
+	}
+
+	if signer.gaveUpWaiting() {
+		t.Fatal("payer eth_getCode completed before the settle simulation was issued: " +
+			"the simulation is running sequentially after the signature check")
+	}
+	if got := signer.readCount(evm.FunctionSettle); got != 1 {
+		t.Fatalf("expected exactly 1 settle simulation, got %d", got)
+	}
+}
+
+// The control for the Permit2 test above: nil options must keep the sequential order.
+func TestVerifyPermit2_ParallelSimulationIsOptIn(t *testing.T) {
+	evm.ResetAssetContractCache()
+
+	payload, requirements, permit2Payload := plainPermit2Payload()
+	signer := newRoundTripSigner(map[string][]byte{
+		strings.ToLower(testToken): {0x60, 0x60},
+		strings.ToLower(testPayer): {0x60, 0x60},
+	})
+	signer.blockGetCodeFor = testPayer
+	signer.blockTimeout = 150 * time.Millisecond
+
+	_, err := VerifyPermit2(context.Background(), signer, payload, requirements, permit2Payload, nil, nil)
+	if err != nil {
+		t.Fatalf("expected verify to succeed, got: %v", err)
+	}
+
+	if !signer.gaveUpWaiting() {
+		t.Fatal("expected the settle simulation to wait for the signature check unless " +
+			"EnableParallelSimulation is set")
+	}
+}
+
+// The asset check is cached across payments; the payer's code is not, being mutable under
+// ERC-6492.
+func TestVerifyEIP3009_AssetContractCheckIsCachedButPayerCodeIsNot(t *testing.T) {
+	evm.ResetAssetContractCache()
+
+	payload, requirements := deployedSmartWalletPayload()
+	signer := deployedSmartWalletSigner()
+	scheme := NewExactEvmScheme(signer, nil)
+
+	for attempt := 1; attempt <= 3; attempt++ {
+		if _, err := scheme.Verify(context.Background(), payload, requirements, nil); err != nil {
+			t.Fatalf("verify %d failed: %v", attempt, err)
+		}
+	}
+
+	if got := signer.getCodeCount(roundTripAsset); got != 1 {
+		t.Fatalf("expected the asset eth_getCode to be cached after the first verify, got %d calls", got)
+	}
+	if got := signer.getCodeCount(roundTripPayer); got != 3 {
+		t.Fatalf("expected one payer eth_getCode per verify (never cached), got %d calls", got)
+	}
+}
+
+// The same address can hold bytecode on one chain and nothing on another, so a hit on one
+// network must not answer for another.
+func TestValidateAssetIsContract_CacheIsScopedPerNetwork(t *testing.T) {
+	evm.ResetAssetContractCache()
+
+	payload, requirements := deployedSmartWalletPayload()
+	signer := deployedSmartWalletSigner()
+	scheme := NewExactEvmScheme(signer, nil)
+
+	if _, err := scheme.Verify(context.Background(), payload, requirements, nil); err != nil {
+		t.Fatalf("verify on the first network failed: %v", err)
+	}
+
+	const otherNetwork = "eip155:8453"
+	requirements.Network = otherNetwork
+	payload.Accepted.Network = otherNetwork
+
+	if _, err := scheme.Verify(context.Background(), payload, requirements, nil); err != nil {
+		t.Fatalf("verify on the second network failed: %v", err)
+	}
+
+	if got := signer.getCodeCount(roundTripAsset); got != 2 {
+		t.Fatalf("expected the asset to be re-checked on a different network, got %d calls", got)
+	}
+}
+
+// Settle's ERC-6492 branch must decide whether to deploy from the code lookup verify already
+// performed, not a second eth_getCode for the same payer.
+func TestSettleEIP3009_ReusesVerifyPayerCodeOnErc6492Path(t *testing.T) {
+	evm.ResetAssetContractCache()
+
+	const factory = "0xca11bde05977b3631167028862be2a173976ca11"
+	payload, requirements := counterfactualErc6492Payload(t)
+	payer := payload.Payload["authorization"].(map[string]interface{})["from"].(string)
+
+	signer := newRoundTripSigner(map[string][]byte{
+		strings.ToLower(requirements.Asset): {0x60, 0x60}, // asset is deployed
+		strings.ToLower(payer):              {},           // payer is counterfactual
+	})
+	scheme := NewExactEvmScheme(signer, &ExactEvmSchemeConfig{
+		EIP6492AllowedFactories: []string{factory},
+	})
+
+	resp, err := scheme.Settle(context.Background(), payload, requirements, nil)
+	if err != nil {
+		t.Fatalf("expected settle to succeed, got: %v", err)
+	}
+	if !resp.Success {
+		t.Fatalf("expected resp.Success = true, got %+v", resp)
+	}
+
+	if got := signer.getCodeCount(payer); got != 1 {
+		t.Fatalf("expected a single payer eth_getCode across verify and settle, got %d calls", got)
+	}
+}
+
+// Guards the premise the concurrency rests on: the simulation branches only on the locally
+// parsed ERC-6492 wrapper, so it cannot depend on CodeDeployed, which is known only after
+// eth_getCode. Were that to change, starting it before classification would be incorrect.
+func TestSimulateEIP3009Transfer_IgnoresCodeDeployed(t *testing.T) {
+	parsed, err := ParseEIP3009Authorization(evm.ExactEIP3009Authorization{
+		From:        roundTripPayer,
+		To:          roundTripPayTo,
+		Value:       "1000000",
+		ValidAfter:  "0",
+		ValidBefore: "99999999999",
+		Nonce:       "0x" + strings.Repeat("00", 32),
+	})
+	if err != nil {
+		t.Fatalf("failed to parse authorization: %v", err)
+	}
+
+	innerSignature := common.FromHex("0x" + strings.Repeat("cc", 66))
+	for _, codeDeployed := range []bool{false, true} {
+		signer := newRoundTripSigner(nil)
+		sigData := &evm.ERC6492SignatureData{InnerSignature: innerSignature, CodeDeployed: codeDeployed}
+
+		ok, err := SimulateEIP3009Transfer(context.Background(), signer, roundTripAsset, parsed, sigData)
+		if err != nil {
+			t.Fatalf("simulation with CodeDeployed=%v failed: %v", codeDeployed, err)
+		}
+		if !ok {
+			t.Fatalf("simulation with CodeDeployed=%v reported failure", codeDeployed)
+		}
+		if got := signer.readCount(evm.FunctionTransferWithAuthorization); got != 1 {
+			t.Fatalf("CodeDeployed=%v: expected 1 transfer call, got %d", codeDeployed, got)
+		}
+	}
+}

--- a/go/mechanisms/evm/exact/facilitator/scheme.go
+++ b/go/mechanisms/evm/exact/facilitator/scheme.go
@@ -20,6 +20,12 @@ type ExactEvmSchemeConfig struct {
 	EIP6492AllowedFactories []string
 	// SimulateInSettle reruns transfer simulation during settle. Verify always simulates.
 	SimulateInSettle bool
+	// EnableParallelVerifySimulation makes verify start the onchain transfer simulation
+	// concurrently with signature classification instead of after it, removing one RPC round
+	// trip. The cost is one wasted eth_call per payment rejected on signature grounds, so it is
+	// opt-in: leave it unset on a metered RPC provider, or where invalid payments are common
+	// enough that the wasted calls outweigh the latency win.
+	EnableParallelVerifySimulation bool
 }
 
 // ExactEvmScheme implements the SchemeNetworkFacilitator interface for EVM exact payments (V2)
@@ -99,10 +105,13 @@ func (f *ExactEvmScheme) Verify(
 		if err != nil {
 			return nil, x402.NewVerifyError(ErrInvalidPayload, "", fmt.Sprintf("failed to parse Permit2 payload: %s", err.Error()))
 		}
-		return VerifyPermit2(ctx, f.signer, payload, requirements, permit2Payload, fctx, nil)
+		return VerifyPermit2(ctx, f.signer, payload, requirements, permit2Payload, fctx, &VerifyPermit2Options{
+			EnableParallelSimulation: f.config.EnableParallelVerifySimulation,
+		})
 	}
 
-	return f.verifyEIP3009(ctx, payload, requirements, true)
+	verifyResp, _, err := f.verifyEIP3009(ctx, payload, requirements, true)
+	return verifyResp, err
 }
 
 // Settle settles a V2 payment on-chain.
@@ -122,8 +131,9 @@ func (f *ExactEvmScheme) Settle(
 			return nil, x402.NewSettleError(ErrInvalidPayload, "", network, "", fmt.Sprintf("failed to parse Permit2 payload: %s", err.Error()))
 		}
 		return SettlePermit2(ctx, f.signer, payload, requirements, permit2Payload, fctx, &Permit2FacilitatorConfig{
-			SimulateInSettle:       f.config.SimulateInSettle,
-			PendingSettlementStore: f.pendingStore,
+			SimulateInSettle:         f.config.SimulateInSettle,
+			PendingSettlementStore:   f.pendingStore,
+			EnableParallelSimulation: f.config.EnableParallelVerifySimulation,
 		})
 	}
 

--- a/go/mechanisms/evm/upto/facilitator/permit2.go
+++ b/go/mechanisms/evm/upto/facilitator/permit2.go
@@ -16,12 +16,6 @@ import (
 	"github.com/x402-foundation/x402/go/v2/types"
 )
 
-// assetContractCheck carries evm.ValidateAssetIsContract's result out of a goroutine.
-type assetContractCheck struct {
-	reason string
-	err    error
-}
-
 // VerifyUptoPermit2 verifies an upto Permit2 payment payload against the given requirements.
 // simulate controls whether to run an eth_call simulation as part of verification.
 func VerifyUptoPermit2(
@@ -51,11 +45,7 @@ func VerifyUptoPermit2(
 	tokenAddress := evm.NormalizeAddress(requirements.Asset)
 
 	// Run the asset-contract check concurrently with the signature check below.
-	assetCheckCh := make(chan assetContractCheck, 1)
-	go func() {
-		reason, err := evm.ValidateAssetIsContract(ctx, signer, requirements.Asset)
-		assetCheckCh <- assetContractCheck{reason: reason, err: err}
-	}()
+	assetCheck := evm.StartAssetContractCheck(ctx, signer, string(requirements.Network), requirements.Asset)
 
 	if !strings.EqualFold(permit2Payload.Permit2Authorization.Spender, evm.X402UptoPermit2ProxyAddress) {
 		return nil, x402.NewVerifyError(ErrPermit2InvalidSpender, payer, "invalid spender")
@@ -119,12 +109,12 @@ func VerifyUptoPermit2(
 
 	sigValid, sigData, sigErr := verifyUptoPermit2Signature(ctx, signer, permit2Payload.Permit2Authorization, signatureBytes, chainID)
 
-	assetResult := <-assetCheckCh
-	if assetResult.err != nil {
-		return nil, fmt.Errorf("asset contract check failed: %w", assetResult.err)
+	assetReason, assetErr := assetCheck.Await()
+	if assetErr != nil {
+		return nil, fmt.Errorf("asset contract check failed: %w", assetErr)
 	}
-	if assetResult.reason != "" {
-		return nil, x402.NewVerifyError(assetResult.reason, payer, fmt.Sprintf("asset %s is not a deployed contract", requirements.Asset))
+	if assetReason != "" {
+		return nil, x402.NewVerifyError(assetReason, payer, fmt.Sprintf("asset %s is not a deployed contract", requirements.Asset))
 	}
 
 	if sigErr != nil || !sigValid {

--- a/go/mechanisms/evm/upto/facilitator/permit2_test.go
+++ b/go/mechanisms/evm/upto/facilitator/permit2_test.go
@@ -178,6 +178,10 @@ func buildValidRequirements() types.PaymentRequirements {
 
 func TestVerifyUptoPermit2_AssetIsEOA(t *testing.T) {
 	// When GetCode for the asset returns empty bytes, verify must reject with asset_not_deployed_contract.
+	// Other tests share testTokenAddr but model it as deployed, and positive asset checks are cached
+	// process-wide, so drop those entries to force a real GetCode here.
+	evm.ResetAssetContractCache()
+
 	signer := newMockSigner()
 	signer.getCodeByAddress = map[string][]byte{
 		strings.ToLower(testTokenAddr): {}, // token = EOA
@@ -189,6 +193,8 @@ func TestVerifyUptoPermit2_AssetIsEOA(t *testing.T) {
 
 func TestVerifyUptoPermit2_AssetGetCodeRPCError(t *testing.T) {
 	// An RPC error on GetCode must propagate as an internal error, not a 400.
+	evm.ResetAssetContractCache()
+
 	signer := newMockSigner()
 	signer.getCodeError = fmt.Errorf("rpc: connection refused")
 	p := buildValidUptoPayload(testFacilitatorAddr)

--- a/go/mechanisms/evm/utils.go
+++ b/go/mechanisms/evm/utils.go
@@ -352,8 +352,22 @@ func BytesToHex(data []byte) string {
 // ValidateAssetIsContract checks whether the payment asset is a deployed contract.
 // Returns (ErrAssetNotDeployedContract, nil) for an EOA/empty address,
 // ("", nil) for a deployed contract, or ("", err) if eth_getCode itself fails.
-func ValidateAssetIsContract(ctx context.Context, signer FacilitatorEvmSigner, asset string) (string, error) {
-	code, err := signer.GetCode(ctx, NormalizeAddress(asset))
+//
+// network identifies the chain the signer is bound to. It must be accurate, since it scopes the
+// cache that serves positive results; an empty network disables caching for the call. Only
+// StartAssetContractCheck populates that cache, so calling this directly always hits the RPC.
+func ValidateAssetIsContract(
+	ctx context.Context,
+	signer FacilitatorEvmSigner,
+	network string,
+	asset string,
+) (string, error) {
+	normalizedAsset := NormalizeAddress(asset)
+	if globalAssetContractCache.isFresh(assetContractCacheKey{network: network, asset: normalizedAsset}, time.Now()) {
+		return "", nil
+	}
+
+	code, err := signer.GetCode(ctx, normalizedAsset)
 	if err != nil {
 		return "", fmt.Errorf("failed to check whether asset is a contract: %w", err)
 	}

--- a/go/mechanisms/svm/upto/facilitator/channel.go
+++ b/go/mechanisms/svm/upto/facilitator/channel.go
@@ -27,8 +27,13 @@ const (
 
 	// Channel reads can briefly lag a confirmed open when an RPC provider
 	// serves transaction status and account state from different replicas.
-	channelReadMaxAttempts    = 5
-	channelReadInitialBackoff = 200 * time.Millisecond
+	//
+	// The backoff is linear, not exponential: replica lag is a small multiple of
+	// Solana's ~400ms slot time, so doubling spends the budget on single waits
+	// far longer than the lag being absorbed. The defaults sleep
+	// 200/400/600/800/1000ms across 6 reads, totalling 3.0s.
+	DefaultChannelReadMaxAttempts = 6
+	DefaultChannelReadBackoffStep = 200 * time.Millisecond
 
 	// DefaultSettleComputeUnitLimit is the default SetComputeUnitLimit for
 	// facilitator-submitted settlement transactions: claim (settle_and_seal +
@@ -167,6 +172,41 @@ func channelExists(
 	return account != nil && account.Value != nil, nil
 }
 
+// channelReadPolicy bounds how long fetchAndVerifyOpenChannel waits for a confirmed open to
+// become visible. The zero value resolves to the package defaults.
+type channelReadPolicy struct {
+	maxAttempts int
+	backoffStep time.Duration
+}
+
+// resolveChannelReadPolicy builds the policy from the scheme's configured overrides.
+func (f *UptoSvmScheme) resolveChannelReadPolicy() channelReadPolicy {
+	policy := channelReadPolicy{}
+	if f.config.ChannelReadMaxAttempts != nil {
+		policy.maxAttempts = *f.config.ChannelReadMaxAttempts
+	}
+	if f.config.ChannelReadBackoffStep != nil {
+		policy.backoffStep = *f.config.ChannelReadBackoffStep
+	}
+	return policy
+}
+
+// resolve fills unset fields with the package defaults, so callers can pass a zero value.
+func (p channelReadPolicy) resolve() channelReadPolicy {
+	if p.maxAttempts <= 0 {
+		p.maxAttempts = DefaultChannelReadMaxAttempts
+	}
+	if p.backoffStep <= 0 {
+		p.backoffStep = DefaultChannelReadBackoffStep
+	}
+	return p
+}
+
+// delayAfterAttempt returns how long to wait before the read following the given 1-based attempt.
+func (p channelReadPolicy) delayAfterAttempt(attempt int) time.Duration {
+	return p.backoffStep * time.Duration(attempt)
+}
+
 // fetchAndVerifyOpenChannel refetches the confirmed channel and rebinds it to
 // the challenge terms before the facilitator settles against it.
 func fetchAndVerifyOpenChannel(
@@ -175,8 +215,11 @@ func fetchAndVerifyOpenChannel(
 	network string,
 	channelID solana.PublicKey,
 	expected expectedOpenChannel,
+	policy channelReadPolicy,
 ) (*verifiedOpenChannel, error) {
-	for attempt := 1; attempt <= channelReadMaxAttempts; attempt++ {
+	policy = policy.resolve()
+
+	for attempt := 1; attempt <= policy.maxAttempts; attempt++ {
 		channel, exists, err := fetchChannelAccount(ctx, signer, network, channelID)
 		if err != nil {
 			return nil, err
@@ -186,12 +229,11 @@ func fetchAndVerifyOpenChannel(
 			// be caused by replica visibility lag.
 			return verifyOpenChannelAccount(channelID, channel, expected)
 		}
-		if attempt == channelReadMaxAttempts {
+		if attempt == policy.maxAttempts {
 			break
 		}
 
-		delay := channelReadInitialBackoff << (attempt - 1)
-		timer := time.NewTimer(delay)
+		timer := time.NewTimer(policy.delayAfterAttempt(attempt))
 		select {
 		case <-ctx.Done():
 			timer.Stop()

--- a/go/mechanisms/svm/upto/facilitator/channel_test.go
+++ b/go/mechanisms/svm/upto/facilitator/channel_test.go
@@ -14,6 +14,68 @@ import (
 	"github.com/x402-foundation/x402/go/v2/mechanisms/svm/paymentchannels"
 )
 
+// Pins the exact schedule, so a change back to `backoffStep << (attempt-1)` fails here.
+func TestChannelReadPolicyBackoffIsLinear(t *testing.T) {
+	policy := channelReadPolicy{}.resolve()
+
+	assert.Equal(t, DefaultChannelReadMaxAttempts, policy.maxAttempts)
+	assert.Equal(t, DefaultChannelReadBackoffStep, policy.backoffStep)
+
+	var (
+		delays []time.Duration
+		total  time.Duration
+	)
+	for attempt := 1; attempt < policy.maxAttempts; attempt++ {
+		delay := policy.delayAfterAttempt(attempt)
+		delays = append(delays, delay)
+		total += delay
+	}
+
+	assert.Equal(t, []time.Duration{
+		200 * time.Millisecond,
+		400 * time.Millisecond,
+		600 * time.Millisecond,
+		800 * time.Millisecond,
+		1000 * time.Millisecond,
+	}, delays)
+	assert.Equal(t, 3*time.Second, total)
+	assert.Equal(t, time.Second, delays[len(delays)-1], "longest single wait")
+}
+
+// Config overrides must reach the retry loop rather than it using the defaults unconditionally.
+func TestChannelReadPolicyHonoursSchemeConfig(t *testing.T) {
+	attempts := 8
+	step := 50 * time.Millisecond
+	scheme := &UptoSvmScheme{config: Config{
+		ChannelReadMaxAttempts: &attempts,
+		ChannelReadBackoffStep: &step,
+	}}
+
+	policy := scheme.resolveChannelReadPolicy().resolve()
+	assert.Equal(t, attempts, policy.maxAttempts)
+	assert.Equal(t, step, policy.backoffStep)
+	assert.Equal(t, 400*time.Millisecond, policy.delayAfterAttempt(8))
+}
+
+// A channel that never becomes visible must be read exactly maxAttempts times.
+func TestFetchAndVerifyOpenChannelStopsAtConfiguredAttemptCount(t *testing.T) {
+	signer := newMockSigner(t, 1)
+	fixture := newPaymentFixture(t, signer)
+	rpcStub := newStubRPC(t)
+	signer.attachRPC(rpc.New(rpcStub.url))
+
+	_, err := fetchAndVerifyOpenChannel(
+		context.Background(),
+		signer,
+		testNetwork,
+		fixture.channelID,
+		expectedFrom(fixture),
+		channelReadPolicy{maxAttempts: 3, backoffStep: time.Millisecond},
+	)
+	require.Error(t, err)
+	assert.Len(t, rpcStub.commitments["getAccountInfo"], 3)
+}
+
 // expectedFrom derives the binding the facilitator checks for a fixture channel.
 func expectedFrom(fixture *paymentFixture) expectedOpenChannel {
 	return expectedOpenChannel{
@@ -42,6 +104,7 @@ func TestFetchAndVerifyOpenChannelRetriesMissingAccount(t *testing.T) {
 		testNetwork,
 		fixture.channelID,
 		expectedFrom(fixture),
+		channelReadPolicy{},
 	)
 	require.NoError(t, err)
 	assert.Equal(t, fixture.channelID, verified.ChannelID)
@@ -62,6 +125,7 @@ func TestFetchAndVerifyOpenChannelStopsRetryingWhenContextEnds(t *testing.T) {
 		testNetwork,
 		fixture.channelID,
 		expectedFrom(fixture),
+		channelReadPolicy{},
 	)
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 	assert.Len(t, rpcStub.commitments["getAccountInfo"], 1)

--- a/go/mechanisms/svm/upto/facilitator/scheme.go
+++ b/go/mechanisms/svm/upto/facilitator/scheme.go
@@ -99,6 +99,17 @@ type Config struct {
 	// at deposit and checked at claim. Defaults to InMemoryDelegatedAuthStore.
 	// Inject a shared implementation for a multi-replica facilitator.
 	DelegatedAuthStore DelegatedAuthStore
+
+	// ChannelReadMaxAttempts caps how many times settle re-reads a channel
+	// account that a confirmed open has not made visible yet. Unset defaults to
+	// DefaultChannelReadMaxAttempts.
+	ChannelReadMaxAttempts *int
+
+	// ChannelReadBackoffStep is the linear backoff step between those re-reads:
+	// attempt N waits N * step, totalling step * (attempts-1) * attempts / 2.
+	// Unset defaults to DefaultChannelReadBackoffStep. Raise either field to
+	// widen the budget on a provider with slower replica convergence.
+	ChannelReadBackoffStep *time.Duration
 }
 
 // DelegatedSettleStep is the settle phase passed to ResolveCallerIdentity.
@@ -585,7 +596,7 @@ func (f *UptoSvmScheme) settleDeposit(
 		Deposit:          auth.maxAmount,
 		GracePeriod:      auth.channelConfig.WithdrawDelay,
 		Splits:           auth.channelConfig.Splits,
-	}); err != nil {
+	}, f.resolveChannelReadPolicy()); err != nil {
 		f.settlementCache.Delete(depositKey)
 		return nil, x402.NewSettleError(ErrChannelState, uptoPayload.From, network, openSignature, err.Error())
 	}
@@ -700,7 +711,7 @@ func (f *UptoSvmScheme) settleClaim(
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		channel, channelErr = fetchAndVerifyOpenChannel(ctx, f.signer, networkStr, channelID, expected)
+		channel, channelErr = fetchAndVerifyOpenChannel(ctx, f.signer, networkStr, channelID, expected, f.resolveChannelReadPolicy())
 	}()
 	go func() {
 		defer wg.Done()

--- a/go/test/unit/evm_client_facilitator_test.go
+++ b/go/test/unit/evm_client_facilitator_test.go
@@ -894,6 +894,11 @@ func TestAssetContractValidation(t *testing.T) {
 	}
 
 	t.Run("EIP-3009: rejects EOA asset", func(t *testing.T) {
+		// eoaAsset is the Base Sepolia USDC address that other tests model as deployed, and
+		// positive asset checks are cached process-wide, so drop those entries to force a real
+		// GetCode here.
+		evm.ResetAssetContractCache()
+
 		signer := makeEIP3009SignerWithEOAAsset()
 		scheme := evmfacilitator.NewExactEvmScheme(signer, nil)
 
@@ -907,6 +912,8 @@ func TestAssetContractValidation(t *testing.T) {
 	})
 
 	t.Run("EIP-3009: GetCode RPC failure propagates as internal error", func(t *testing.T) {
+		evm.ResetAssetContractCache()
+
 		signer := makeEIP3009SignerWithEOAAsset()
 		signer.getCodeError = fmt.Errorf("rpc: connection refused")
 		// getCodeError overrides codeByAddress in the mock, so both payer and asset
@@ -924,6 +931,8 @@ func TestAssetContractValidation(t *testing.T) {
 	})
 
 	t.Run("Permit2 exact: rejects EOA asset", func(t *testing.T) {
+		evm.ResetAssetContractCache()
+
 		permit2Payload, _ := signedPermit2TestData(t)
 		signer := &mockFacilitatorSigner{
 			verifyTypedDataResult: true,


### PR DESCRIPTION
## Description

Four targeted latency/RPC-volume optimizations to the Go facilitator's EVM and SVM verify/settle paths, audited against production reachability in `cdp-facilitator` (config facts, not guesses — see design rationale below). No behavior change to the default configuration except where called out as breaking.

**1. Parallel verify simulation (EVM exact + Permit2), opt-in**
`verifyEIP3009` and `VerifyPermit2` issue `GetCode`-based signature classification, then a separate `eth_call` simulation, sequentially — even though the simulation's calldata is fully determined by local ERC-6492/Permit2 parsing and never reads `GetCode`'s result (`SigData.CodeDeployed`). Root cause: `eip3009.go` line ~94-133 (pre-change) ran `ClassifyEIP3009Signature` to completion before starting `SimulateEIP3009Transfer`, with no data dependency between them. Now the simulation starts concurrently with classification and its result is read after classification/asset checks, so error precedence is unchanged. Gated behind `ExactEvmSchemeConfig.EnableParallelVerifySimulation` / `VerifyPermit2Options.EnableParallelSimulation`, both defaulting to `false`: the tradeoff is one wasted `eth_call` per payment rejected on signature grounds, which should be an explicit opt-in rather than inherited behavior. Saves one sequential RPC round trip on `/verify` when enabled. The Permit2 gas-sponsoring branches (EIP-2612, ERC-20 approval) are excluded — they simulate different calls and stay sequential.

**2. Network-scoped asset-contract cache**
`ValidateAssetIsContract` (`utils.go`) issued a fresh `eth_getCode` on the payment token for every verify *and* every settle, with no caching. Added a 15-minute, size-bounded (4096 entries), positive-result-only in-memory cache keyed by `(network, asset)` — negative results aren't cached so a token mid-deployment self-heals on the next request. **Breaking:** `evm.ValidateAssetIsContract` now takes a `network string` argument; without it, cache entries would collide across chains where the same address can hold bytecode on one chain and nothing on another. Callers use the new `evm.StartAssetContractCheck`/`.Await()` pair, which records the cache entry only after the caller has consumed the result — this avoids a race where an abandoned goroutine (e.g. from an early-returning verify) could populate the cache with a result nobody validated. This is primarily an RPC-volume and tail-latency win, not a p50 win: the asset check already ran concurrently with signature verification, so removing it mainly eliminates a recurring `eth_getCode` and the timeout/retry tail risk that came with it.

**3. Reuse verify's payer code lookup in ERC-6492 settle**
`settleEIP3009`'s ERC-6492 branch called `f.signer.GetCode(ctx, payer)` again to decide whether to deploy, duplicating the `GetCode` that `VerifyUniversalSignature` already performed inside the `verifyEIP3009` call settle had just awaited. `verifyEIP3009` now also returns the `EIP3009SignatureClassification` it computed, and settle reads `classification.SigData.CodeDeployed` instead of re-fetching. Both reads happen within one settle call, before any deploy transaction — this is not the previously-documented post-deploy re-read that races RPC state propagation across load-balanced nodes (that hazard is unaffected). `invalid_exact_evm_failed_to_check_deployment` is no longer emitted by this path; the wire constant is kept but marked reserved rather than removed, since it's part of the exported error surface. Applies the same fix in `permit2.go`'s equivalent `GetCode` fallback.

**4. Linear backoff for SVM upto channel-account reads**
`channel.go`'s `fetchAndVerifyOpenChannel` retried a lagging channel-account read with exponential backoff (200/400/800/1600ms, 5 reads, 3.0s total). A 1600ms single wait is ~4 Solana slots against replica lag that's typically a small multiple of the ~400ms slot time, so most of the budget was spent on one oversized wait. Changed to linear backoff (200/400/600/800/1000ms across 6 reads) — same 3.0s total budget, but one extra read and a max single wait of 1s (~2.5 slots) instead of 1.6s. Both `ChannelReadMaxAttempts` and `ChannelReadBackoffStep` are now configurable via `Config` for operators who need a wider budget.

## Tests

- `go test -race -count=1 ./...` — full suite, clean, no data races.
- `go test -count=1 -shuffle=on ./mechanisms/... ./test/unit/...` — run 3× to catch cache/goroutine ordering issues; clean.
- New `mechanisms/evm/exact/facilitator/roundtrip_test.go`: a mock signer that counts RPC calls per method and can hold `GetCode` open until the simulation's `eth_call` arrives, turning "runs concurrently" into a happens-before assertion rather than a timing threshold. Covers: parallel simulation for EIP-3009 and Permit2, opt-in-off sequential behavior (negative control for both), asset-cache hit/miss counts, per-network cache isolation, and settle reusing verify's payer-code lookup on the ERC-6492 path.
- New `mechanisms/evm/asset_cache_test.go`: cache hit/miss, the abandoned-goroutine-doesn't-cache case, empty-network bypass, TTL expiry, and the entry-count bound.
- New/extended tests in `mechanisms/svm/upto/facilitator/channel_test.go` for the linear backoff schedule, config overrides, and exact attempt-count enforcement.
- `make lint` — 0 issues. `make fmt` — no diff.
- Full Go e2e suite against Base Sepolia + Solana Devnet, exercising every changed path through the real Go facilitator: `go/http/echo` + `typescript/http/express` servers × `go/http/go-http` + `typescript/http/axios` clients, all 44 scenarios passing (EIP-3009, Permit2 direct/gas-sponsored, upto, batch-settlement).
- Cross-checked failures against a clean `HEAD` worktree to confirm zero regressions: several pre-existing integration-test failures (unrelated `valid_before` timing, a pre-existing `GetAccountInfo` panic in an SVM test helper, and a `cumulative_amount_mismatch` in batch-settlement) reproduce identically on unmodified `main` and are outside this PR's scope.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [ x My commits are signed (required for merge)
- [x] I added a changelog fragment for user-facing changes
