### PR TITLE
fix(python): exit on fatal HTTP adapter initialize errors

### DIFF
--- a/python/x402/__init__.py
+++ b/python/x402/__init__.py
@@ -104,11 +104,12 @@ from .schemas import (
     AbortResult,
     AssetAmount,
     CompletedSettlement,
+    # Errors
+    FacilitatorCapabilityError,
     # Config
     FacilitatorConfig,
     Money,
     Network,
-    # Errors
     NoMatchingRequirementsError,
     PaymentAbortedError,
     PaymentCreatedContext,
@@ -275,6 +276,7 @@ __all__ = [
     "SchemeNotFoundError",
     "NoMatchingRequirementsError",
     "PaymentAbortedError",
+    "FacilitatorCapabilityError",
     # Types - Helpers
     "detect_version",
     "match_payload_to_requirements",

--- a/python/x402/changelog.d/3364.bugfix.md
+++ b/python/x402/changelog.d/3364.bugfix.md
@@ -1,0 +1,1 @@
+HTTP adapters now exit on permanent facilitator capability or route configuration errors during initialize, matching TypeScript and Go. Transient facilitator timeouts stay retryable.

--- a/python/x402/http/__init__.py
+++ b/python/x402/http/__init__.py
@@ -4,6 +4,7 @@ Provides HTTP-specific components for client-side payment handling,
 server-side resource protection, and facilitator communication.
 """
 
+from .background_init import handle_background_init_error, is_fatal_startup_init_error
 from .constants import (
     DEFAULT_FACILITATOR_URL,
     HTTP_STATUS_PAYMENT_REQUIRED,
@@ -121,6 +122,9 @@ __all__ = [
     "UnpaidResponseBody",
     "RouteValidationError",
     "RouteConfigurationError",
+    # Background init
+    "handle_background_init_error",
+    "is_fatal_startup_init_error",
     # Utils
     "safe_base64_encode",
     "safe_base64_decode",

--- a/python/x402/http/background_init.py
+++ b/python/x402/http/background_init.py
@@ -1,0 +1,41 @@
+"""Fatal vs retryable handling for HTTP adapter initialize() failures."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+from ..schemas.errors import FacilitatorCapabilityError
+from .types import RouteConfigurationError
+
+# os._exit, overridable in tests so fatal-init coverage does not kill the
+# test process.
+_process_exit = os._exit
+
+
+def is_fatal_startup_init_error(error: BaseException | None) -> bool:
+    """Report whether a resource-server initialize() failure is a permanent misconfiguration.
+
+    Transient facilitator timeouts stay retryable on the next protected request.
+    Capability and route mismatches will not become valid later and must not
+    leave the process listening.
+    """
+    if error is None:
+        return False
+    return isinstance(error, (FacilitatorCapabilityError, RouteConfigurationError))
+
+
+def handle_background_init_error(error: BaseException | None) -> None:
+    """Handle an initialize() failure from HTTP adapters.
+
+    Retryable failures are logged so they are not silent; the original error is
+    still available to the caller. Fatal configuration errors exit the process
+    so a misconfigured server does not stay up until the first paid request.
+    """
+    if error is None:
+        return
+    if not is_fatal_startup_init_error(error):
+        print(f"Warning: failed to initialize x402 server: {error}")
+        return
+    print(error, file=sys.stderr)
+    _process_exit(1)

--- a/python/x402/http/middleware/fastapi.py
+++ b/python/x402/http/middleware/fastapi.py
@@ -21,6 +21,7 @@ except ImportError as e:
     ) from e
 
 from ...schemas import SettleResponse, VerifiedPaymentCancelOptions
+from ..background_init import handle_background_init_error
 from ..constants import SETTLEMENT_OVERRIDES_HEADER
 from ..facilitator_client_base import FacilitatorResponseError
 from ..types import (
@@ -178,7 +179,7 @@ def payment_middleware(
         server: Pre-configured x402ResourceServer.
         paywall_config: Optional paywall UI configuration.
         paywall_provider: Optional custom paywall provider.
-        sync_facilitator_on_start: Fetch facilitator support on first request.
+        sync_facilitator_on_start: Fetch facilitator support when the middleware is created.
 
     Returns:
         FastAPI middleware function.
@@ -226,9 +227,19 @@ def payment_middleware(
     if paywall_provider:
         http_server.register_paywall_provider(paywall_provider)
 
-    # Lazy initialization state with async lock for concurrency safety
+    # Initialization state with async lock for concurrency safety
     init_done = False
     init_lock = asyncio.Lock()
+
+    # Initialize if requested - queries facilitator /supported to populate
+    # facilitator clients. Fatal capability / route mismatches exit the process
+    # so a misconfigured server does not stay up until the first paid request.
+    if sync_facilitator_on_start:
+        try:
+            http_server.initialize()
+            init_done = True
+        except Exception as error:
+            handle_background_init_error(error)
 
     async def middleware(
         request: Request,
@@ -478,7 +489,7 @@ def payment_middleware_from_config(
         schemes: Scheme registrations for server-side processing.
         paywall_config: Optional paywall UI configuration.
         paywall_provider: Optional custom paywall provider.
-        sync_facilitator_on_start: Fetch facilitator support on first request.
+        sync_facilitator_on_start: Fetch facilitator support when the middleware is created.
 
     Returns:
         FastAPI middleware function.

--- a/python/x402/http/middleware/flask.py
+++ b/python/x402/http/middleware/flask.py
@@ -20,6 +20,7 @@ except ImportError as e:
     ) from e
 
 from ...schemas import SettleResponse, VerifiedPaymentCancelOptions
+from ..background_init import handle_background_init_error
 from ..constants import SETTLEMENT_OVERRIDES_HEADER
 from ..facilitator_client_base import FacilitatorResponseError
 from ..types import (
@@ -313,7 +314,7 @@ class PaymentMiddleware:
             server: x402ResourceServerSync instance (must be sync variant).
             paywall_config: Optional paywall configuration.
             paywall_provider: Optional custom paywall provider.
-            sync_facilitator_on_start: Initialize on first protected request.
+            sync_facilitator_on_start: Initialize when the middleware is created.
         """
         # Auto-register bazaar extension if routes declare it
         if _check_if_bazaar_needed(routes):
@@ -330,6 +331,16 @@ class PaymentMiddleware:
 
         if paywall_provider:
             self._http_server.register_paywall_provider(paywall_provider)
+
+        # Initialize if requested - queries facilitator /supported to populate
+        # facilitator clients. Fatal capability / route mismatches exit the process
+        # so a misconfigured server does not stay up until the first paid request.
+        if self._sync_on_start:
+            try:
+                self._http_server.initialize()
+                self._init_done = True
+            except Exception as error:
+                handle_background_init_error(error)
 
         # Replace WSGI app
         app.wsgi_app = self._wsgi_middleware  # type: ignore
@@ -623,7 +634,7 @@ def payment_middleware(
         server: Pre-configured x402ResourceServerSync (must be sync variant).
         paywall_config: Optional paywall UI configuration.
         paywall_provider: Optional custom paywall provider.
-        sync_facilitator_on_start: Fetch facilitator support on first request.
+        sync_facilitator_on_start: Fetch facilitator support when the middleware is created.
 
     Returns:
         PaymentMiddleware instance.
@@ -651,7 +662,7 @@ def payment_middleware_from_config(
         schemes: Scheme registrations for server-side processing.
         paywall_config: Optional paywall UI configuration.
         paywall_provider: Optional custom paywall provider.
-        sync_facilitator_on_start: Fetch facilitator support on first request.
+        sync_facilitator_on_start: Fetch facilitator support when the middleware is created.
 
     Returns:
         PaymentMiddleware instance.

--- a/python/x402/schemas/__init__.py
+++ b/python/x402/schemas/__init__.py
@@ -33,6 +33,7 @@ from .config import (
 
 # Error types
 from .errors import (
+    FacilitatorCapabilityError,
     NoMatchingRequirementsError,
     PaymentAbortedError,
     PaymentError,
@@ -216,4 +217,5 @@ __all__ = [
     "SchemeNotFoundError",
     "NoMatchingRequirementsError",
     "PaymentAbortedError",
+    "FacilitatorCapabilityError",
 ]

--- a/python/x402/schemas/errors.py
+++ b/python/x402/schemas/errors.py
@@ -79,3 +79,14 @@ class PaymentAbortedError(PaymentError):
     def __init__(self, reason: str):
         self.reason = reason
         super().__init__(f"Payment aborted: {reason}")
+
+
+class FacilitatorCapabilityError(Exception):
+    """Raised when a registered scheme's configuration is incompatible with
+    the capabilities the facilitator advertised for that scheme and network.
+    """
+
+    def __init__(self, problems: list[str]) -> None:
+        details = "\n".join(f"  - {p}" for p in problems)
+        super().__init__(f"x402 facilitator capability errors:\n{details}")
+        self.problems = problems

--- a/python/x402/server_base.py
+++ b/python/x402/server_base.py
@@ -38,6 +38,7 @@ from .pending_settlement_store import ERR_SETTLEMENT_PENDING
 from .schemas import (
     X402_VERSION,
     AbortResult,
+    FacilitatorCapabilityError,
     Network,
     PaymentCancellationDispatcher,
     PaymentPayload,
@@ -627,7 +628,7 @@ class x402ResourceServerBase:
         schemes exposing a `validate_facilitator_support` hook participate.
 
         Raises:
-            ValueError: Listing every capability problem when one or more are reported.
+            FacilitatorCapabilityError: Listing every capability problem when one or more are reported.
         """
         problems: list[str] = []
 
@@ -647,8 +648,7 @@ class x402ResourceServerBase:
                     problems.append(f"{scheme} on {network}: {problem}")
 
         if problems:
-            details = "\n".join(f"  - {p}" for p in problems)
-            raise ValueError(f"x402 facilitator capability errors:\n{details}")
+            raise FacilitatorCapabilityError(problems)
 
     def _facilitator_extensions(self, network: Network, scheme: str) -> list[str]:
         """Return the extensions a facilitator advertises for a scheme/network."""

--- a/python/x402/server_base.py
+++ b/python/x402/server_base.py
@@ -617,6 +617,14 @@ class x402ResourceServerBase:
                 if scheme not in self._supported_responses[network]:
                     self._supported_responses[network][scheme] = supported
 
+        # Empty /supported is transient (timeout, deploy blip) and must stay
+        # retryable. Route validation would otherwise raise RouteConfigurationError
+        # (missing_facilitator) and HTTP adapters would treat that as fatal.
+        if not self._supported_responses:
+            raise RuntimeError(
+                "Failed to initialize: no supported payment kinds loaded from any facilitator."
+            )
+
         self._validate_facilitator_capabilities()
         self._initialized = True
 

--- a/python/x402/tests/unit/core/test_server.py
+++ b/python/x402/tests/unit/core/test_server.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from x402 import x402ResourceServer, x402ResourceServerSync
+from x402 import FacilitatorCapabilityError, x402ResourceServer, x402ResourceServerSync
 from x402.schemas import (
     PaymentPayload,
     PaymentRequirements,
@@ -302,7 +302,7 @@ class TestValidateFacilitatorCapabilities:
         server = x402ResourceServer(self._client())
         server.register("eip155:8453", _ValidatingSchemeServer("mock", problem="needs authorizer"))
 
-        with pytest.raises(ValueError, match="needs authorizer"):
+        with pytest.raises(FacilitatorCapabilityError, match="needs authorizer"):
             server.initialize()
 
     def test_initialize_succeeds_when_hook_returns_none(self):

--- a/python/x402/tests/unit/core/test_server.py
+++ b/python/x402/tests/unit/core/test_server.py
@@ -276,6 +276,19 @@ class TestServerInitialization:
         # First client should be registered
         assert server._facilitator_clients_map["eip155:8453"]["exact"] is client1
 
+    def test_initialize_raises_when_no_kinds_loaded(self):
+        """Empty /supported must fail retryably, matching TypeScript."""
+        server = x402ResourceServer(MockFacilitatorClient([]))
+
+        with pytest.raises(
+            RuntimeError,
+            match="no supported payment kinds loaded from any facilitator",
+        ):
+            server.initialize()
+
+        assert server._initialized is False
+        assert server._supported_responses == {}
+
 
 class _ValidatingSchemeServer(MockSchemeServer):
     """Mock scheme exposing the optional validate_facilitator_support hook."""

--- a/python/x402/tests/unit/http/middleware/test_fastapi.py
+++ b/python/x402/tests/unit/http/middleware/test_fastapi.py
@@ -30,6 +30,7 @@ from x402.http.types import (
     RouteConfig,
 )
 from x402.schemas import PaymentPayload, PaymentRequirements
+from x402.schemas.errors import FacilitatorCapabilityError
 from x402.schemas.hooks import (
     CompletedSettlement,
     PaymentCancellationDispatcher,
@@ -1053,20 +1054,80 @@ class TestFastAPIMiddlewareConcurrency:
             mock_http_server.return_value = mock_http_server_instance
 
             mw = payment_middleware(routes, mock_server, sync_facilitator_on_start=True)
+            assert call_count == 1
 
             request = make_mock_fastapi_request(path="/api/protected")
 
             async def call_next(req):
                 return MagicMock()
 
-            # First request fails
+            # First request retries after the eager attempt failed
             response1 = await mw(request, call_next)
             assert response1.status_code == 502
 
             # Second request should also attempt init since first failed
             response2 = await mw(request, call_next)
             assert response2.status_code == 502
-            assert call_count == 2
+            assert call_count == 3
+
+
+# =============================================================================
+# Eager background init
+# =============================================================================
+
+
+class TestFastAPIBackgroundInit:
+    """Fatal capability errors at eager initialize must exit the process."""
+
+    def test_eager_init_exits_on_capability_mismatch(self):
+        mock_server = MagicMock()
+        routes = {
+            "GET /api/protected": RouteConfig(
+                accepts=PaymentOption(
+                    scheme="exact",
+                    pay_to="0x1234567890123456789012345678901234567890",
+                    price="$0.01",
+                    network="eip155:8453",
+                ),
+            )
+        }
+        exit_codes: list[int] = []
+        with patch("x402.http.middleware.fastapi.x402HTTPResourceServer") as mock_http_server:
+            instance = MagicMock()
+            instance.initialize.side_effect = FacilitatorCapabilityError(
+                ["upto on solana:devnet: missing"]
+            )
+            mock_http_server.return_value = instance
+            with patch(
+                "x402.http.background_init._process_exit",
+                lambda code: exit_codes.append(code),
+            ):
+                payment_middleware(routes, mock_server, sync_facilitator_on_start=True)
+        assert exit_codes == [1]
+
+    def test_eager_init_does_not_exit_on_retryable_timeout(self):
+        mock_server = MagicMock()
+        routes = {
+            "GET /api/protected": RouteConfig(
+                accepts=PaymentOption(
+                    scheme="exact",
+                    pay_to="0x1234567890123456789012345678901234567890",
+                    price="$0.01",
+                    network="eip155:8453",
+                ),
+            )
+        }
+        exit_codes: list[int] = []
+        with patch("x402.http.middleware.fastapi.x402HTTPResourceServer") as mock_http_server:
+            instance = MagicMock()
+            instance.initialize.side_effect = Exception("facilitator request timed out")
+            mock_http_server.return_value = instance
+            with patch(
+                "x402.http.background_init._process_exit",
+                lambda code: exit_codes.append(code),
+            ):
+                payment_middleware(routes, mock_server, sync_facilitator_on_start=True)
+        assert exit_codes == []
 
 
 # =============================================================================

--- a/python/x402/tests/unit/http/middleware/test_fastapi.py
+++ b/python/x402/tests/unit/http/middleware/test_fastapi.py
@@ -1129,6 +1129,32 @@ class TestFastAPIBackgroundInit:
                 payment_middleware(routes, mock_server, sync_facilitator_on_start=True)
         assert exit_codes == []
 
+    def test_eager_init_does_not_exit_on_empty_supported(self):
+        mock_server = MagicMock()
+        routes = {
+            "GET /api/protected": RouteConfig(
+                accepts=PaymentOption(
+                    scheme="exact",
+                    pay_to="0x1234567890123456789012345678901234567890",
+                    price="$0.01",
+                    network="eip155:8453",
+                ),
+            )
+        }
+        exit_codes: list[int] = []
+        with patch("x402.http.middleware.fastapi.x402HTTPResourceServer") as mock_http_server:
+            instance = MagicMock()
+            instance.initialize.side_effect = RuntimeError(
+                "Failed to initialize: no supported payment kinds loaded from any facilitator."
+            )
+            mock_http_server.return_value = instance
+            with patch(
+                "x402.http.background_init._process_exit",
+                lambda code: exit_codes.append(code),
+            ):
+                payment_middleware(routes, mock_server, sync_facilitator_on_start=True)
+        assert exit_codes == []
+
 
 # =============================================================================
 # ASGI Middleware Class Tests

--- a/python/x402/tests/unit/http/middleware/test_flask.py
+++ b/python/x402/tests/unit/http/middleware/test_flask.py
@@ -541,6 +541,33 @@ class TestFlaskBackgroundInit:
                 PaymentMiddleware(app, routes, mock_server, sync_facilitator_on_start=True)
         assert exit_codes == []
 
+    def test_eager_init_does_not_exit_on_empty_supported(self):
+        app = Flask(__name__)
+        mock_server = MagicMock()
+        routes = {
+            "GET /api/protected": RouteConfig(
+                accepts=PaymentOption(
+                    scheme="exact",
+                    pay_to="0x1234567890123456789012345678901234567890",
+                    price="$0.01",
+                    network="eip155:8453",
+                ),
+            )
+        }
+        exit_codes: list[int] = []
+        with patch("x402.http.middleware.flask.x402HTTPResourceServerSync") as mock_http_server:
+            instance = MagicMock()
+            instance.initialize.side_effect = RuntimeError(
+                "Failed to initialize: no supported payment kinds loaded from any facilitator."
+            )
+            mock_http_server.return_value = instance
+            with patch(
+                "x402.http.background_init._process_exit",
+                lambda code: exit_codes.append(code),
+            ):
+                PaymentMiddleware(app, routes, mock_server, sync_facilitator_on_start=True)
+        assert exit_codes == []
+
 
 class TestPaymentMiddlewareFunction:
     """Tests for payment_middleware convenience function."""

--- a/python/x402/tests/unit/http/middleware/test_flask.py
+++ b/python/x402/tests/unit/http/middleware/test_flask.py
@@ -32,6 +32,7 @@ from x402.http.types import (
     RouteConfig,
 )
 from x402.schemas import PaymentPayload, PaymentRequirements
+from x402.schemas.errors import FacilitatorCapabilityError
 from x402.schemas.hooks import (
     CompletedSettlement,
     PaymentCancellationDispatcher,
@@ -472,16 +473,73 @@ class TestFlaskMiddlewareConcurrency:
             mock_http_server.return_value = mock_http_server_instance
 
             PaymentMiddleware(app, routes, mock_server, sync_facilitator_on_start=True)
+            assert call_count == 1
 
             with app.test_client() as client:
-                # First request fails
+                # First request retries after the eager attempt failed
                 response1 = client.get("/api/protected")
                 assert response1.status_code == 502
 
                 # Second request retries init since first failed
                 response2 = client.get("/api/protected")
                 assert response2.status_code == 502
-                assert call_count == 2
+                assert call_count == 3
+
+
+class TestFlaskBackgroundInit:
+    """Fatal capability errors at eager initialize must exit the process."""
+
+    def test_eager_init_exits_on_capability_mismatch(self):
+        app = Flask(__name__)
+        mock_server = MagicMock()
+        routes = {
+            "GET /api/protected": RouteConfig(
+                accepts=PaymentOption(
+                    scheme="exact",
+                    pay_to="0x1234567890123456789012345678901234567890",
+                    price="$0.01",
+                    network="eip155:8453",
+                ),
+            )
+        }
+        exit_codes: list[int] = []
+        with patch("x402.http.middleware.flask.x402HTTPResourceServerSync") as mock_http_server:
+            instance = MagicMock()
+            instance.initialize.side_effect = FacilitatorCapabilityError(
+                ["upto on solana:devnet: missing"]
+            )
+            mock_http_server.return_value = instance
+            with patch(
+                "x402.http.background_init._process_exit",
+                lambda code: exit_codes.append(code),
+            ):
+                PaymentMiddleware(app, routes, mock_server, sync_facilitator_on_start=True)
+        assert exit_codes == [1]
+
+    def test_eager_init_does_not_exit_on_retryable_timeout(self):
+        app = Flask(__name__)
+        mock_server = MagicMock()
+        routes = {
+            "GET /api/protected": RouteConfig(
+                accepts=PaymentOption(
+                    scheme="exact",
+                    pay_to="0x1234567890123456789012345678901234567890",
+                    price="$0.01",
+                    network="eip155:8453",
+                ),
+            )
+        }
+        exit_codes: list[int] = []
+        with patch("x402.http.middleware.flask.x402HTTPResourceServerSync") as mock_http_server:
+            instance = MagicMock()
+            instance.initialize.side_effect = Exception("facilitator request timed out")
+            mock_http_server.return_value = instance
+            with patch(
+                "x402.http.background_init._process_exit",
+                lambda code: exit_codes.append(code),
+            ):
+                PaymentMiddleware(app, routes, mock_server, sync_facilitator_on_start=True)
+        assert exit_codes == []
 
 
 class TestPaymentMiddlewareFunction:
@@ -1196,6 +1254,7 @@ def test_payment_middleware_from_config_builds_with_sync_server():
         app,
         {"/api/protected": {"price": "$0.01", "pay_to": "0x" + "1" * 40}},
         facilitator_client=facilitator,
+        sync_facilitator_on_start=False,
     )
 
     assert middleware is not None

--- a/python/x402/tests/unit/http/test_background_init.py
+++ b/python/x402/tests/unit/http/test_background_init.py
@@ -1,0 +1,64 @@
+"""Unit tests for fatal vs retryable HTTP adapter initialize() handling."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from x402.http.background_init import (
+    handle_background_init_error,
+    is_fatal_startup_init_error,
+)
+from x402.http.types import RouteConfigurationError, RouteValidationError
+from x402.schemas.errors import FacilitatorCapabilityError
+
+
+def test_is_fatal_startup_init_error_treats_capability_and_route_errors_as_fatal() -> None:
+    assert is_fatal_startup_init_error(
+        FacilitatorCapabilityError(["upto on solana:devnet: missing"])
+    )
+    assert is_fatal_startup_init_error(
+        RouteConfigurationError(
+            [
+                RouteValidationError(
+                    route_pattern="GET /api/generate",
+                    scheme="upto",
+                    network="solana:devnet",
+                    reason="missing_facilitator",
+                    message="missing facilitator",
+                )
+            ]
+        )
+    )
+
+
+def test_is_fatal_startup_init_error_treats_timeouts_as_retryable() -> None:
+    assert not is_fatal_startup_init_error(Exception("facilitator request timed out"))
+
+
+def test_handle_background_init_error_exits_on_capability_mismatch() -> None:
+    exit_code: int | None = None
+    called = False
+
+    def fake_exit(code: int) -> None:
+        nonlocal called, exit_code
+        called = True
+        exit_code = code
+
+    with patch("x402.http.background_init._process_exit", fake_exit):
+        handle_background_init_error(FacilitatorCapabilityError(["upto on solana:devnet: missing"]))
+
+    assert called, "expected process exit on capability mismatch"
+    assert exit_code == 1, f"expected exit code 1, got {exit_code}"
+
+
+def test_handle_background_init_error_does_not_exit_on_retryable_timeout() -> None:
+    called = False
+
+    def fake_exit(_code: int) -> None:
+        nonlocal called
+        called = True
+
+    with patch("x402.http.background_init._process_exit", fake_exit):
+        handle_background_init_error(Exception("facilitator request timed out"))
+
+    assert not called, "expected no process exit on retryable facilitator timeout"

--- a/python/x402/tests/unit/http/test_background_init.py
+++ b/python/x402/tests/unit/http/test_background_init.py
@@ -4,11 +4,21 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+import pytest
+
+from x402 import x402ResourceServer
 from x402.http.background_init import (
     handle_background_init_error,
     is_fatal_startup_init_error,
 )
-from x402.http.types import RouteConfigurationError, RouteValidationError
+from x402.http.types import (
+    PaymentOption,
+    RouteConfig,
+    RouteConfigurationError,
+    RouteValidationError,
+)
+from x402.http.x402_http_server import x402HTTPResourceServer
+from x402.schemas import SupportedResponse
 from x402.schemas.errors import FacilitatorCapabilityError
 
 
@@ -33,6 +43,14 @@ def test_is_fatal_startup_init_error_treats_capability_and_route_errors_as_fatal
 
 def test_is_fatal_startup_init_error_treats_timeouts_as_retryable() -> None:
     assert not is_fatal_startup_init_error(Exception("facilitator request timed out"))
+
+
+def test_is_fatal_startup_init_error_treats_empty_supported_as_retryable() -> None:
+    assert not is_fatal_startup_init_error(
+        RuntimeError(
+            "Failed to initialize: no supported payment kinds loaded from any facilitator."
+        )
+    )
 
 
 def test_handle_background_init_error_exits_on_capability_mismatch() -> None:
@@ -62,3 +80,54 @@ def test_handle_background_init_error_does_not_exit_on_retryable_timeout() -> No
         handle_background_init_error(Exception("facilitator request timed out"))
 
     assert not called, "expected no process exit on retryable facilitator timeout"
+
+
+def test_handle_background_init_error_does_not_exit_on_empty_supported() -> None:
+    called = False
+
+    def fake_exit(_code: int) -> None:
+        nonlocal called
+        called = True
+
+    with patch("x402.http.background_init._process_exit", fake_exit):
+        handle_background_init_error(
+            RuntimeError(
+                "Failed to initialize: no supported payment kinds loaded from any facilitator."
+            )
+        )
+
+    assert not called, "expected no process exit when facilitator returned no kinds"
+
+
+class _EmptySupportedClient:
+    def get_supported(self) -> SupportedResponse:
+        return SupportedResponse(kinds=[], extensions=[], signers={})
+
+
+class _ExactScheme:
+    scheme = "exact"
+
+
+def test_http_initialize_empty_supported_is_retryable_not_route_config_error() -> None:
+    """A 200 /supported with no kinds must not become a fatal RouteConfigurationError."""
+    resource_server = x402ResourceServer(_EmptySupportedClient())
+    resource_server.register("eip155:8453", _ExactScheme())
+    http_server = x402HTTPResourceServer(
+        resource_server,
+        {
+            "GET /api/protected": RouteConfig(
+                accepts=PaymentOption(
+                    scheme="exact",
+                    pay_to="0x1234567890123456789012345678901234567890",
+                    price="$0.01",
+                    network="eip155:8453",
+                ),
+            )
+        },
+    )
+
+    with pytest.raises(RuntimeError, match="no supported payment kinds") as exc_info:
+        http_server.initialize()
+
+    assert not is_fatal_startup_init_error(exc_info.value)
+    assert not isinstance(exc_info.value, RouteConfigurationError)


### PR DESCRIPTION
Port of https://github.com/x402-foundation/x402/pull/3346 and https://github.com/x402-foundation/x402/pull/3347 from TypeScript/Go to Python SDK.

Python HTTP adapters now exit on permanent FacilitatorCapabilityError or RouteConfigurationError during eager initialize(), matching TypeScript and Go. Transient facilitator timeouts stay retryable on the next protected request. This is the Python half of the drift in https://github.com/x402-foundation/x402/issues/3361. Do not close #3361; that issue tracks other SDK gaps as well.

AI disclosure: Automated by @phdargen. Use your own judgement