### PR TITLE
fix(python): reuse verify ERC-6492 payer code in settle

### DIFF
--- a/python/x402/changelog.d/3366.bugfix.md
+++ b/python/x402/changelog.d/3366.bugfix.md
@@ -1,0 +1,1 @@
+EVM exact settle's ERC-6492 branch now reads payer deployment from the verify it already awaited rather than issuing a second eth_getCode. Both reads happen within one settle call and before any deploy transaction, so this is not the post-deploy re-read that races RPC state propagation.

--- a/python/x402/mechanisms/evm/exact/eip3009_utils.py
+++ b/python/x402/mechanisms/evm/exact/eip3009_utils.py
@@ -23,13 +23,13 @@ from ..constants import (
     TRANSFER_WITH_AUTHORIZATION_VRS_ABI,
     VERSION_ABI,
 )
-from ..eip712 import build_typed_data_for_signing
-from ..erc6492 import has_deployment_info, parse_erc6492_signature
+from ..eip712 import hash_eip3009_authorization
+from ..erc6492 import has_deployment_info
 from ..multicall import MulticallCall, encode_contract_call, multicall
 from ..signer import FacilitatorEvmSigner
 from ..types import ERC6492SignatureData, ExactEIP3009Authorization
 from ..utils import bytes_to_hex, hex_to_bytes, normalize_address
-from ..verify import verify_typed_data_strict
+from ..verify import verify_universal_signature
 
 # keccak256("Transfer(address,address,uint256)")
 ERC20_TRANSFER_EVENT_TOPIC = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
@@ -85,26 +85,22 @@ def classify_eip3009_signature(
     token_version: str,
 ) -> EIP3009SignatureClassification:
     """Classify the signature before deciding whether simulation may rescue it."""
-    sig_data = parse_erc6492_signature(signature)
-    domain, types, primary_type, message = build_typed_data_for_signing(
+    digest = hash_eip3009_authorization(
         authorization,
         chain_id,
         token_address,
         token_name,
         token_version,
     )
-
-    is_smart_wallet = has_deployment_info(sig_data) or len(sig_data.inner_signature) != 65
-    # Uses the strict primitive that mirrors on-chain SignatureChecker (code-routed, no ECDSA fallback).
-    valid = verify_typed_data_strict(
+    valid, sig_data = verify_universal_signature(
         signer,
         authorization.from_address,
-        domain,
-        types,
-        primary_type,
-        message,
-        sig_data.inner_signature,
+        digest,
+        signature,
+        allow_undeployed=True,
     )
+
+    is_smart_wallet = has_deployment_info(sig_data) or len(sig_data.inner_signature) != 65
     if valid:
         return EIP3009SignatureClassification(
             valid=True,
@@ -113,8 +109,8 @@ def classify_eip3009_signature(
             sig_data=sig_data,
         )
 
-    code = signer.get_code(authorization.from_address)
-    if len(code) > 0:
+    # Reuse the get_code result verify_universal_signature already fetched.
+    if sig_data.code_deployed:
         return EIP3009SignatureClassification(
             valid=False,
             is_smart_wallet=True,

--- a/python/x402/mechanisms/evm/exact/facilitator.py
+++ b/python/x402/mechanisms/evm/exact/facilitator.py
@@ -35,8 +35,9 @@ from ..constants import (
     TX_STATUS_SUCCESS,
 )
 from ..data_suffix import resolve_data_suffix
-from ..erc6492 import has_deployment_info, parse_erc6492_signature
+from ..erc6492 import has_deployment_info
 from ..exact.eip3009_utils import (
+    EIP3009SignatureClassification,
     ParsedEIP3009Authorization,
     classify_eip3009_signature,
     diagnose_eip3009_simulation_failure,
@@ -149,14 +150,15 @@ class ExactEvmScheme:
     ) -> VerifyResponse:
         if is_permit2_payload(payload.payload):
             return verify_permit2(self._signer, payload, requirements, context)
-        return self._verify(payload, requirements, simulate=True)
+        verify_result, _ = self._verify(payload, requirements, simulate=True)
+        return verify_result
 
     def _verify(
         self,
         payload: PaymentPayload,
         requirements: PaymentRequirements,
         simulate: bool,
-    ) -> VerifyResponse:
+    ) -> tuple[VerifyResponse, EIP3009SignatureClassification | None]:
         """Verify EIP-3009 payment payload.
 
         Validates:
@@ -168,12 +170,15 @@ class ExactEvmScheme:
         - Nonce hasn't been used
         - Payer has sufficient balance
 
+        On success also returns the signature classification so settle can reuse
+        the payer code lookup instead of issuing a second eth_getCode.
+
         Args:
             payload: Payment payload from client.
             requirements: Payment requirements.
 
         Returns:
-            VerifyResponse with is_valid and payer.
+            (VerifyResponse, classification) where classification is set on success.
         """
         evm_payload = ExactEIP3009Payload.from_dict(payload.payload)
         payer = evm_payload.authorization.from_address
@@ -181,23 +186,30 @@ class ExactEvmScheme:
 
         # Validate scheme
         if payload.accepted.scheme != SCHEME_EXACT:
-            return VerifyResponse(
-                is_valid=False, invalid_reason=ERR_UNSUPPORTED_SCHEME, payer=payer
+            return (
+                VerifyResponse(is_valid=False, invalid_reason=ERR_UNSUPPORTED_SCHEME, payer=payer),
+                None,
             )
 
         # Validate network
         if payload.accepted.network != requirements.network:
-            return VerifyResponse(is_valid=False, invalid_reason=ERR_NETWORK_MISMATCH, payer=payer)
+            return (
+                VerifyResponse(is_valid=False, invalid_reason=ERR_NETWORK_MISMATCH, payer=payer),
+                None,
+            )
 
         # Parse chain ID from network identifier
         try:
             chain_id = get_evm_chain_id(network)
         except ValueError as e:
-            return VerifyResponse(
-                is_valid=False,
-                invalid_reason=ERR_FAILED_TO_GET_NETWORK_CONFIG,
-                invalid_message=str(e),
-                payer=payer,
+            return (
+                VerifyResponse(
+                    is_valid=False,
+                    invalid_reason=ERR_FAILED_TO_GET_NETWORK_CONFIG,
+                    invalid_message=str(e),
+                    payer=payer,
+                ),
+                None,
             )
 
         token_address = normalize_address(requirements.asset)
@@ -205,22 +217,29 @@ class ExactEvmScheme:
         # Check EIP-712 domain params
         extra = requirements.extra or {}
         if "name" not in extra or "version" not in extra:
-            return VerifyResponse(
-                is_valid=False, invalid_reason=ERR_MISSING_EIP712_DOMAIN, payer=payer
+            return (
+                VerifyResponse(
+                    is_valid=False, invalid_reason=ERR_MISSING_EIP712_DOMAIN, payer=payer
+                ),
+                None,
             )
 
         # Validate recipient
         if evm_payload.authorization.to.lower() != requirements.pay_to.lower():
-            return VerifyResponse(
-                is_valid=False, invalid_reason=ERR_RECIPIENT_MISMATCH, payer=payer
+            return (
+                VerifyResponse(is_valid=False, invalid_reason=ERR_RECIPIENT_MISMATCH, payer=payer),
+                None,
             )
 
         # Validate amount
         if int(evm_payload.authorization.value) != int(requirements.amount):
-            return VerifyResponse(
-                is_valid=False,
-                invalid_reason=ERR_AUTHORIZATION_VALUE_MISMATCH,
-                payer=payer,
+            return (
+                VerifyResponse(
+                    is_valid=False,
+                    invalid_reason=ERR_AUTHORIZATION_VALUE_MISMATCH,
+                    payer=payer,
+                ),
+                None,
             )
 
         # Validate timing
@@ -228,19 +247,26 @@ class ExactEvmScheme:
 
         # Check validBefore is in future (6 second buffer)
         if int(evm_payload.authorization.valid_before) < now + 6:
-            return VerifyResponse(
-                is_valid=False, invalid_reason=ERR_VALID_BEFORE_EXPIRED, payer=payer
+            return (
+                VerifyResponse(
+                    is_valid=False, invalid_reason=ERR_VALID_BEFORE_EXPIRED, payer=payer
+                ),
+                None,
             )
 
         # Check validAfter is not in future
         if int(evm_payload.authorization.valid_after) > now:
-            return VerifyResponse(
-                is_valid=False, invalid_reason=ERR_VALID_AFTER_FUTURE, payer=payer
+            return (
+                VerifyResponse(is_valid=False, invalid_reason=ERR_VALID_AFTER_FUTURE, payer=payer),
+                None,
             )
 
         # Verify signature
         if not evm_payload.signature:
-            return VerifyResponse(is_valid=False, invalid_reason=ERR_INVALID_SIGNATURE, payer=payer)
+            return (
+                VerifyResponse(is_valid=False, invalid_reason=ERR_INVALID_SIGNATURE, payer=payer),
+                None,
+            )
 
         try:
             signature = hex_to_bytes(evm_payload.signature)
@@ -255,22 +281,31 @@ class ExactEvmScheme:
             )
             if not classification.valid and classification.is_undeployed:
                 if not has_deployment_info(classification.sig_data):
-                    return VerifyResponse(
-                        is_valid=False,
-                        invalid_reason=ERR_UNDEPLOYED_SMART_WALLET,
-                        payer=payer,
+                    return (
+                        VerifyResponse(
+                            is_valid=False,
+                            invalid_reason=ERR_UNDEPLOYED_SMART_WALLET,
+                            payer=payer,
+                        ),
+                        None,
                     )
 
             if not classification.valid and not classification.is_smart_wallet:
-                return VerifyResponse(
-                    is_valid=False, invalid_reason=ERR_INVALID_SIGNATURE, payer=payer
+                return (
+                    VerifyResponse(
+                        is_valid=False, invalid_reason=ERR_INVALID_SIGNATURE, payer=payer
+                    ),
+                    None,
                 )
         except Exception as e:
-            return VerifyResponse(
-                is_valid=False,
-                invalid_reason=ERR_FAILED_TO_VERIFY_SIGNATURE,
-                invalid_message=str(e),
-                payer=payer,
+            return (
+                VerifyResponse(
+                    is_valid=False,
+                    invalid_reason=ERR_FAILED_TO_VERIFY_SIGNATURE,
+                    invalid_message=str(e),
+                    payer=payer,
+                ),
+                None,
             )
 
         # Counterfactual ERC-6492 wallet (undeployed + carries factory deployment info):
@@ -284,27 +319,36 @@ class ExactEvmScheme:
             factory_addr = bytes_to_hex(classification.sig_data.factory).lower()
             allowed = {f.strip().lower() for f in self._config.eip6492_allowed_factories}
             if factory_addr not in allowed:
-                return VerifyResponse(
-                    is_valid=False, invalid_reason=ERR_FACTORY_NOT_ALLOWED, payer=payer
+                return (
+                    VerifyResponse(
+                        is_valid=False, invalid_reason=ERR_FACTORY_NOT_ALLOWED, payer=payer
+                    ),
+                    None,
                 )
 
         code = self._signer.get_code(token_address)
         if len(code) == 0:
-            return VerifyResponse(
-                is_valid=False, invalid_reason=ERR_ASSET_NOT_DEPLOYED_CONTRACT, payer=payer
+            return (
+                VerifyResponse(
+                    is_valid=False, invalid_reason=ERR_ASSET_NOT_DEPLOYED_CONTRACT, payer=payer
+                ),
+                None,
             )
 
         if not simulate:
-            return VerifyResponse(is_valid=True, payer=payer)
+            return VerifyResponse(is_valid=True, payer=payer), classification
 
         try:
             parsed_authorization = parse_eip3009_authorization(evm_payload.authorization)
         except Exception as e:
-            return VerifyResponse(
-                is_valid=False,
-                invalid_reason=ERR_FAILED_TO_VERIFY_SIGNATURE,
-                invalid_message=str(e),
-                payer=payer,
+            return (
+                VerifyResponse(
+                    is_valid=False,
+                    invalid_reason=ERR_FAILED_TO_VERIFY_SIGNATURE,
+                    invalid_message=str(e),
+                    payer=payer,
+                ),
+                None,
             )
 
         sim_ok, sim_error = simulate_eip3009_transfer_result(
@@ -340,14 +384,17 @@ class ExactEvmScheme:
                 reason,
                 sim_error,
             )
-            return VerifyResponse(
-                is_valid=False,
-                invalid_reason=reason,
-                invalid_message=str(sim_error) if sim_error is not None else None,
-                payer=payer,
+            return (
+                VerifyResponse(
+                    is_valid=False,
+                    invalid_reason=reason,
+                    invalid_message=str(sim_error) if sim_error is not None else None,
+                    payer=payer,
+                ),
+                None,
             )
 
-        return VerifyResponse(is_valid=True, payer=payer)
+        return VerifyResponse(is_valid=True, payer=payer), classification
 
     def settle(
         self,
@@ -398,7 +445,7 @@ class ExactEvmScheme:
                 )
 
         # First verify
-        verify_result = self._verify(
+        verify_result, classification = self._verify(
             payload,
             requirements,
             simulate=self._config.simulate_in_settle,
@@ -416,9 +463,18 @@ class ExactEvmScheme:
         payer = evm_payload.authorization.from_address
         token_address = normalize_address(requirements.asset)
 
+        if classification is None:
+            return SettleResponse(
+                success=False,
+                error_reason=ERR_FAILED_TO_VERIFY_SIGNATURE,
+                error_message="verify returned no signature classification",
+                network=network,
+                payer=payer,
+                transaction="",
+            )
+        sig_data = classification.sig_data
+
         try:
-            signature = hex_to_bytes(evm_payload.signature or "")
-            sig_data = parse_erc6492_signature(signature)
             parsed_authorization = parse_eip3009_authorization(evm_payload.authorization)
         except Exception as e:
             return SettleResponse(
@@ -432,8 +488,10 @@ class ExactEvmScheme:
 
         # Deploy smart wallet if needed (allowlist is the sole gate)
         if has_deployment_info(sig_data):
-            code = self._signer.get_code(payer)
-            if len(code) == 0:
+            # code_deployed comes from the eth_getCode the verify above already issued for this
+            # payer. Both reads happen before any deploy transaction, so reusing it does not
+            # reintroduce the post-deploy re-read that races RPC state propagation across replicas.
+            if not sig_data.code_deployed:
                 factory_addr = bytes_to_hex(sig_data.factory)
                 allowed = [f.lower() for f in self._config.eip6492_allowed_factories]
                 if factory_addr.lower() not in allowed:

--- a/python/x402/mechanisms/evm/types.py
+++ b/python/x402/mechanisms/evm/types.py
@@ -316,6 +316,9 @@ class ERC6492SignatureData:
     factory: bytes  # 20-byte factory address (zero if not ERC-6492)
     factory_calldata: bytes  # Deployment calldata (empty if not ERC-6492)
     inner_signature: bytes  # The actual signature (EIP-1271 or EOA)
+    # Whether the signer had bytecode, as determined by verify_universal_signature.
+    # Zero value elsewhere.
+    code_deployed: bool = False
 
 
 # EIP-712 authorization types for signing

--- a/python/x402/mechanisms/evm/verify.py
+++ b/python/x402/mechanisms/evm/verify.py
@@ -141,6 +141,7 @@ def verify_universal_signature(
     # pre-verify to return valid for 7702 EOAs whose delegate rejects raw ECDSA on-chain.
     code = signer.get_code(signer_address)
     is_deployed = len(code) > 0
+    sig_data.code_deployed = is_deployed
 
     if not is_deployed:
         if has_deployment_info(sig_data):

--- a/python/x402/tests/unit/mechanisms/evm/test_facilitator.py
+++ b/python/x402/tests/unit/mechanisms/evm/test_facilitator.py
@@ -213,6 +213,7 @@ class MockFacilitatorSigner:
         self.transfer_simulation_calls = 0
         self.write_calls = 0
         self.send_calls = 0
+        self.get_code_calls: dict[str, int] = {}
 
     def get_addresses(self) -> list[str]:
         return self._addresses
@@ -271,7 +272,9 @@ class MockFacilitatorSigner:
         return 8453
 
     def get_code(self, address: str) -> bytes:
-        explicit = self._code_by_address.get(address.lower())
+        key = address.lower()
+        self.get_code_calls[key] = self.get_code_calls.get(key, 0) + 1
+        explicit = self._code_by_address.get(key)
         if explicit is not None:
             return explicit
         # After a factory deployment (send_transaction called), simulate that the
@@ -870,6 +873,34 @@ class TestSettleFactoryAllowlist:
 
         assert result.success is True
         assert signer.send_calls == 0
+
+
+class TestSettleReusesVerifyPayerCode:
+    """Settle's ERC-6492 branch must decide whether to deploy from the code lookup
+    verify already performed, not a second eth_getCode for the same payer.
+    """
+
+    def test_settle_eip3009_reuses_verify_payer_code_on_erc6492_path(self):
+        signer = MockFacilitatorSigner(
+            typed_data_valid=True,
+            code=b"",
+            code_by_address={
+                TOKEN_ADDRESS.lower(): b"\x60\x60",
+                PAYER.lower(): b"",
+            },
+        )
+        facilitator = ExactEvmFacilitatorScheme(
+            signer,
+            ExactEvmSchemeConfig(eip6492_allowed_factories=[FACTORY]),
+        )
+
+        result = facilitator.settle(
+            make_payment_payload(signature=make_erc6492_signature(b"\x33" * 66)),
+            make_requirements(),
+        )
+
+        assert result.success is True
+        assert signer.get_code_calls.get(PAYER.lower(), 0) == 1
 
 
 class TestVerifyV1:

--- a/python/x402/tests/unit/mechanisms/evm/test_verify.py
+++ b/python/x402/tests/unit/mechanisms/evm/test_verify.py
@@ -69,6 +69,7 @@ class TestVerifyUniversalSignature:
 
         assert valid is False  # deferred, not rejected
         assert sig_data.factory == FACTORY_ADDR  # factory info preserved for settle
+        assert sig_data.code_deployed is False
 
     def test_allow_undeployed_false_raises(self):
         erc6492_sig = make_erc6492_sig(FACTORY_ADDR, FACTORY_CALLDATA, GARBAGE_INNER_SIG)


### PR DESCRIPTION
Port of https://github.com/x402-foundation/x402/pull/3355 (ERC-6492 settle reuse) from Go to Python SDK.

Go exact EVM settle now reads payer deployment from the verify it already awaited. Python still issued a second eth_getCode on the ERC-6492 deploy path, so settle could disagree with verify under RPC lag. This ports that reuse: `verify_universal_signature` records `code_deployed` on `ERC6492SignatureData`, classify keeps that result, and v2 exact settle deploys from it instead of calling `get_code` again. Related to https://github.com/x402-foundation/x402/issues/3361. Scoped to this slice only; asset-contract cache, SVM backoff, and HTTP body caps are out of scope. `uvx ruff format && uvx ruff check && uv run pytest` in `python/x402/` are green (2199 passed, 71 skipped).

AI disclosure: Automated by @phdargen. Use your own judgement