### PR TITLE
feat(svm): use linear backoff for upto channel re-reads

### DIFF
--- a/typescript/.changeset/svm-upto-linear-channel-backoff.md
+++ b/typescript/.changeset/svm-upto-linear-channel-backoff.md
@@ -1,0 +1,5 @@
+---
+"@x402/svm": patch
+---
+
+SVM upto facilitator channel-account re-reads now back off linearly (200/400/600/800/1000ms across 6 reads) rather than doubling (200/400/800/1600ms across 5 reads). Replica lag behind a confirmed open is a small multiple of Solana's slot time, so the same 3.0s budget now buys one more read and caps any single wait at 1s. `UptoSvmFacilitatorConfig.channelReadMaxAttempts` and `channelReadBackoffStepMs` make it configurable.

--- a/typescript/packages/mechanisms/svm/src/upto/facilitator/channel.ts
+++ b/typescript/packages/mechanisms/svm/src/upto/facilitator/channel.ts
@@ -63,8 +63,18 @@ const MAX_TRANSACTION_COMPUTE_UNITS = 1_400_000;
  *  per-transaction max because the composite (open + settle + distribute) can
  *  exceed the client open's 400k ceiling. */
 const SIM_COMPUTE_UNIT_LIMIT = MAX_TRANSACTION_COMPUTE_UNITS;
-const CHANNEL_READ_MAX_ATTEMPTS = 5;
-const CHANNEL_READ_INITIAL_BACKOFF_MS = 200;
+
+/**
+ * Channel reads can briefly lag a confirmed open when an RPC provider
+ * serves transaction status and account state from different replicas.
+ *
+ * The backoff is linear, not exponential: replica lag is a small multiple of
+ * Solana's ~400ms slot time, so doubling spends the budget on single waits
+ * far longer than the lag being absorbed. The defaults sleep
+ * 200/400/600/800/1000ms across 6 reads, totalling 3.0s.
+ */
+export const DEFAULT_CHANNEL_READ_MAX_ATTEMPTS = 6;
+export const DEFAULT_CHANNEL_READ_BACKOFF_STEP_MS = 200;
 
 /**
  * Default `SetComputeUnitLimit` for facilitator-submitted settlement
@@ -156,6 +166,44 @@ export async function channelExists(
   return info !== null;
 }
 
+/**
+ * Bounds how long {@link fetchAndVerifyOpenChannel} waits for a confirmed open
+ * to become visible. Unset / non-positive fields resolve to the package defaults.
+ */
+export interface ChannelReadPolicy {
+  backoffStepMs?: number;
+  maxAttempts?: number;
+}
+
+/**
+ * Fill unset channel-read fields with the package defaults, so callers can
+ * pass a zero value.
+ *
+ * @param policy - Optional attempt/backoff overrides
+ * @returns Policy with positive defaults applied
+ */
+export function resolveChannelReadPolicy(
+  policy: ChannelReadPolicy = {},
+): Required<ChannelReadPolicy> {
+  const maxAttempts = policy.maxAttempts ?? 0;
+  const backoffStepMs = policy.backoffStepMs ?? 0;
+  return {
+    maxAttempts: maxAttempts > 0 ? maxAttempts : DEFAULT_CHANNEL_READ_MAX_ATTEMPTS,
+    backoffStepMs: backoffStepMs > 0 ? backoffStepMs : DEFAULT_CHANNEL_READ_BACKOFF_STEP_MS,
+  };
+}
+
+/**
+ * How long to wait before the read following the given 1-based attempt.
+ *
+ * @param policy - Resolved channel-read policy
+ * @param attempt - 1-based attempt that just observed a missing account
+ * @returns Linear delay in milliseconds (`backoffStepMs * attempt`)
+ */
+export function delayAfterAttempt(policy: Required<ChannelReadPolicy>, attempt: number): number {
+  return policy.backoffStepMs * attempt;
+}
+
 /** Challenge-bound terms that must match the confirmed channel account. */
 export interface ExpectedOpenChannel {
   authorizedSigner: string;
@@ -188,6 +236,7 @@ export interface VerifiedOpenChannel {
  * @param network - CAIP-2 network identifier
  * @param channelId - Channel PDA
  * @param expected - Challenge-bound channel terms
+ * @param policy - Optional re-read attempt/backoff overrides
  * @returns Verified channel facts for settlement
  */
 export async function fetchAndVerifyOpenChannel(
@@ -195,9 +244,11 @@ export async function fetchAndVerifyOpenChannel(
   network: string,
   channelId: string,
   expected: ExpectedOpenChannel,
+  policy: ChannelReadPolicy = {},
 ): Promise<VerifiedOpenChannel> {
+  const resolved = resolveChannelReadPolicy(policy);
   const rpc = accountFetchRpc(signer, network);
-  for (let attempt = 1; attempt <= CHANNEL_READ_MAX_ATTEMPTS; attempt++) {
+  for (let attempt = 1; attempt <= resolved.maxAttempts; attempt++) {
     const account = await fetchMaybeChannel(rpc, address(channelId), {
       commitment: STATE_COMMITMENT,
     });
@@ -206,11 +257,11 @@ export async function fetchAndVerifyOpenChannel(
       // caused by replica visibility lag.
       return verifyOpenChannelAccount(channelId, account.data, expected);
     }
-    if (attempt === CHANNEL_READ_MAX_ATTEMPTS) {
+    if (attempt === resolved.maxAttempts) {
       break;
     }
 
-    const delayMs = CHANNEL_READ_INITIAL_BACKOFF_MS * 2 ** (attempt - 1);
+    const delayMs = delayAfterAttempt(resolved, attempt);
     await new Promise(resolve => setTimeout(resolve, delayMs));
   }
 

--- a/typescript/packages/mechanisms/svm/src/upto/facilitator/index.ts
+++ b/typescript/packages/mechanisms/svm/src/upto/facilitator/index.ts
@@ -19,6 +19,8 @@ export type {
 export { ErrSettlementPending } from "../../exact/facilitator/errors";
 export {
   ChannelOpenConfirmationError,
+  DEFAULT_CHANNEL_READ_BACKOFF_STEP_MS,
+  DEFAULT_CHANNEL_READ_MAX_ATTEMPTS,
   SettlementConfirmationTimeoutError,
   SettlementSimulationError,
 } from "./channel";

--- a/typescript/packages/mechanisms/svm/src/upto/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/svm/src/upto/facilitator/scheme.ts
@@ -51,6 +51,7 @@ import {
   SettlementSimulationError,
   simulateOpenSettleDistribute,
   submitSettle,
+  type ChannelReadPolicy,
   type UptoSvmSigner,
 } from "./channel";
 import {
@@ -232,6 +233,20 @@ export interface UptoSvmFacilitatorConfig {
    * Inject a shared implementation for a multi-replica facilitator.
    */
   delegatedAuthStore?: UptoDelegatedAuthStore;
+  /**
+   * Caps how many times settle re-reads a channel account that a confirmed
+   * open has not made visible yet. Unset defaults to
+   * `DEFAULT_CHANNEL_READ_MAX_ATTEMPTS` (6).
+   */
+  channelReadMaxAttempts?: number;
+  /**
+   * Linear backoff step in milliseconds between those re-reads: attempt N
+   * waits `N * step`, totalling `step * (attempts-1) * attempts / 2`.
+   * Unset defaults to `DEFAULT_CHANNEL_READ_BACKOFF_STEP_MS` (200). Raise
+   * either field to widen the budget on a provider with slower replica
+   * convergence.
+   */
+  channelReadBackoffStepMs?: number;
 }
 
 type OpenAuthFailure = {
@@ -544,6 +559,18 @@ export class UptoSvmScheme implements SchemeNetworkFacilitator {
   }
 
   /**
+   * Builds the channel-account re-read policy from configured overrides.
+   *
+   * @returns Unresolved policy; {@link fetchAndVerifyOpenChannel} fills defaults
+   */
+  private resolveChannelReadPolicy(): ChannelReadPolicy {
+    return {
+      maxAttempts: this.config.channelReadMaxAttempts,
+      backoffStepMs: this.config.channelReadBackoffStepMs,
+    };
+  }
+
+  /**
    * Deposit path: validate open authorization, then sim → broadcast → bind.
    * Rejects when the channel already exists (one request, one open).
    *
@@ -765,16 +792,22 @@ export class UptoSvmScheme implements SchemeNetworkFacilitator {
     }
 
     try {
-      await fetchAndVerifyOpenChannel(this.signer, network, p.channelId, {
-        authorizedSigner: channelConfig.receiverAuthorizer,
-        deposit: maxAmount,
-        gracePeriod: channelConfig.withdrawDelay,
-        mint: requirements.asset,
-        payee: feePayer,
-        payer: p.from,
-        rentPayer: feePayer,
-        splits: channelConfig.splits,
-      });
+      await fetchAndVerifyOpenChannel(
+        this.signer,
+        network,
+        p.channelId,
+        {
+          authorizedSigner: channelConfig.receiverAuthorizer,
+          deposit: maxAmount,
+          gracePeriod: channelConfig.withdrawDelay,
+          mint: requirements.asset,
+          payee: feePayer,
+          payer: p.from,
+          rentPayer: feePayer,
+          splits: channelConfig.splits,
+        },
+        this.resolveChannelReadPolicy(),
+      );
     } catch (error) {
       this.settlementCache.delete(depositChannelKey);
       return {
@@ -934,16 +967,22 @@ export class UptoSvmScheme implements SchemeNetworkFacilitator {
     }
     const network = requirements.network;
 
-    const channelPromise = fetchAndVerifyOpenChannel(this.signer, network, p.channelId, {
-      authorizedSigner: channelConfig.receiverAuthorizer,
-      deposit: payloadMaxAmount,
-      gracePeriod: channelConfig.withdrawDelay,
-      mint: requirements.asset,
-      payee: channelConfig.feePayer,
-      payer: p.from,
-      rentPayer: channelConfig.feePayer,
-      splits: channelConfig.splits,
-    });
+    const channelPromise = fetchAndVerifyOpenChannel(
+      this.signer,
+      network,
+      p.channelId,
+      {
+        authorizedSigner: channelConfig.receiverAuthorizer,
+        deposit: payloadMaxAmount,
+        gracePeriod: channelConfig.withdrawDelay,
+        mint: requirements.asset,
+        payee: channelConfig.feePayer,
+        payer: p.from,
+        rentPayer: channelConfig.feePayer,
+        splits: channelConfig.splits,
+      },
+      this.resolveChannelReadPolicy(),
+    );
     const blockhashPromise = this.signer.getLatestBlockhash(network);
 
     let channel: Awaited<ReturnType<typeof fetchAndVerifyOpenChannel>>;

--- a/typescript/packages/mechanisms/svm/test/unit/upto.channel.test.ts
+++ b/typescript/packages/mechanisms/svm/test/unit/upto.channel.test.ts
@@ -19,8 +19,12 @@ vi.mock("../../src/payment-channels/generated/accounts/channel", async importOri
 });
 
 import {
+  DEFAULT_CHANNEL_READ_BACKOFF_STEP_MS,
+  DEFAULT_CHANNEL_READ_MAX_ATTEMPTS,
+  delayAfterAttempt,
   fetchAndVerifyOpenChannel,
   getChannelDistributionHash,
+  resolveChannelReadPolicy,
   type ExpectedOpenChannel,
 } from "../../src/upto/facilitator/channel";
 import { SOLANA_DEVNET_CAIP2 } from "../../src/constants";
@@ -83,6 +87,35 @@ describe("upto SVM channel reads", () => {
     vi.clearAllMocks();
   });
 
+  // Pins the exact schedule, so a change back to `backoffStepMs * 2 ** (attempt-1)` fails here.
+  it("backs off linearly across the default attempt budget", () => {
+    const policy = resolveChannelReadPolicy();
+
+    expect(policy.maxAttempts).toBe(DEFAULT_CHANNEL_READ_MAX_ATTEMPTS);
+    expect(policy.backoffStepMs).toBe(DEFAULT_CHANNEL_READ_BACKOFF_STEP_MS);
+
+    const delays: number[] = [];
+    let total = 0;
+    for (let attempt = 1; attempt < policy.maxAttempts; attempt++) {
+      const delay = delayAfterAttempt(policy, attempt);
+      delays.push(delay);
+      total += delay;
+    }
+
+    expect(delays).toEqual([200, 400, 600, 800, 1000]);
+    expect(total).toBe(3_000);
+    expect(delays[delays.length - 1]).toBe(1_000);
+  });
+
+  // Config overrides must reach the retry loop rather than it using the defaults unconditionally.
+  it("honours scheme config overrides", () => {
+    const policy = resolveChannelReadPolicy({ maxAttempts: 8, backoffStepMs: 50 });
+
+    expect(policy.maxAttempts).toBe(8);
+    expect(policy.backoffStepMs).toBe(50);
+    expect(delayAfterAttempt(policy, 8)).toBe(400);
+  });
+
   it("retries a missing confirmed channel until it becomes visible", async () => {
     vi.useFakeTimers();
     channelAccountMocks.fetchMaybeChannel
@@ -96,7 +129,7 @@ describe("upto SVM channel reads", () => {
     expect(channelAccountMocks.fetchMaybeChannel).toHaveBeenCalledTimes(2);
   });
 
-  it("stops after five missing reads", async () => {
+  it("stops after six missing reads", async () => {
     vi.useFakeTimers();
     channelAccountMocks.fetchMaybeChannel.mockResolvedValue(missingAccount);
 
@@ -105,7 +138,23 @@ describe("upto SVM channel reads", () => {
     await vi.advanceTimersByTimeAsync(3_000);
 
     await assertion;
-    expect(channelAccountMocks.fetchMaybeChannel).toHaveBeenCalledTimes(5);
+    expect(channelAccountMocks.fetchMaybeChannel).toHaveBeenCalledTimes(6);
+  });
+
+  // A channel that never becomes visible must be read exactly maxAttempts times.
+  it("stops at the configured attempt count", async () => {
+    vi.useFakeTimers();
+    channelAccountMocks.fetchMaybeChannel.mockResolvedValue(missingAccount);
+
+    const result = fetchAndVerifyOpenChannel(signer, NETWORK, CHANNEL_ID, expected, {
+      maxAttempts: 3,
+      backoffStepMs: 1,
+    });
+    const assertion = expect(result).rejects.toThrow(`channel ${CHANNEL_ID} does not exist`);
+    await vi.advanceTimersByTimeAsync(10);
+
+    await assertion;
+    expect(channelAccountMocks.fetchMaybeChannel).toHaveBeenCalledTimes(3);
   });
 
   it("does not retry an existing channel with invalid state", async () => {

--- a/typescript/packages/mechanisms/svm/test/unit/upto.facilitator.test.ts
+++ b/typescript/packages/mechanisms/svm/test/unit/upto.facilitator.test.ts
@@ -215,6 +215,37 @@ describe("UptoSvmScheme facilitator channel lifecycle", () => {
     );
   });
 
+  it("passes the configured channel-read policy through to fetchAndVerifyOpenChannel", async () => {
+    const { facilitator, payload, requirements, receiverAuthorizer, uptoPayload } =
+      await buildFixture({
+        channelReadMaxAttempts: 8,
+        channelReadBackoffStepMs: 50,
+      });
+
+    const voucherSignature = await signVoucher(receiverAuthorizer, {
+      channelId: uptoPayload.channelId,
+      cumulativeAmount: 0n,
+      expiresAt: BigInt(uptoPayload.expiresAt),
+    });
+    await expect(
+      facilitator.settle(
+        {
+          ...payload,
+          payload: { ...uptoPayload, voucherSignature },
+        },
+        { ...requirements, amount: "0" },
+      ),
+    ).resolves.toMatchObject({ success: true });
+
+    expect(channelMocks.fetchAndVerifyOpenChannel).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      { maxAttempts: 8, backoffStepMs: 50 },
+    );
+  });
+
   it("rejects settlement that exceeds the signed ceiling without touching the chain", async () => {
     const { facilitator, payload, requirements } = await buildFixture();
 


### PR DESCRIPTION
Port of https://github.com/x402-foundation/x402/pull/3355 (SVM linear backoff) from Go to TypeScript SDK.

TypeScript SVM `upto` facilitator channel re-reads used exponential backoff across 5 attempts (200/400/800/1600ms). That diverged from Go after #3355, which switched to linear backoff (200/400/600/800/1000ms across 6 reads) so replica lag behind a confirmed open is absorbed with one extra read and a 1s max wait inside the same 3.0s budget. This ports that schedule and adds `UptoSvmFacilitatorConfig.channelReadMaxAttempts` / `channelReadBackoffStepMs` to match Go `Config`. Related to https://github.com/x402-foundation/x402/issues/3361; this slice does not close it. Python and Go are unchanged. Other #3355 items (asset-contract cache, ERC-6492 settle reuse, HTTP body caps) are out of scope.

AI disclosure: Automated by @phdargen. Use your own judgement