### PR TITLE
Add e2e pass/fail breakdowns to GitHub job summary

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -183,6 +183,12 @@ jobs:
         run: |
           pnpm test --testnet --min --parallel -v --log=e2e-run.log --output-json=e2e-results.json --families=${{ steps.families.outputs.families }} --versions=${{ steps.families.outputs.versions }} --transport=http
 
+      # Always render the JSON breakdown into the job summary so pass/fail
+      # tables are visible at the top of the GitHub job page
+      - name: Write e2e job summary
+        if: always() && steps.families.outputs.configured == 'true'
+        run: pnpm results:summary e2e-results.json
+
       - name: Upload test results
         if: always() && steps.families.outputs.configured == 'true'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -17,7 +17,8 @@
     "permit2:revoke": "tsx scripts/permit2-approval.ts revoke",
     "swig:setup": "tsx scripts/swig-setup.ts",
     "xrpl:iou:setup": "tsx scripts/xrpl-iou-setup.ts",
-    "wallet:status": "tsx scripts/print-wallet-status.ts"
+    "wallet:status": "tsx scripts/print-wallet-status.ts",
+    "results:summary": "tsx scripts/print-e2e-summary.ts"
   },
   "dependencies": {
     "@aptos-labs/ts-sdk": "^5.2.1",

--- a/e2e/scripts/print-e2e-summary.ts
+++ b/e2e/scripts/print-e2e-summary.ts
@@ -1,0 +1,196 @@
+/**
+ * Render e2e-results.json as a GitHub job summary (and stdout).
+ *
+ * Usage:
+ *   pnpm results:summary
+ *   pnpm results:summary e2e-results.json
+ *
+ * When GITHUB_STEP_SUMMARY is set (Actions), appends Markdown there so the
+ * breakdown is visible at the top of the job page without scrolling the log.
+ */
+
+import { appendFileSync, existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+interface BreakdownStats {
+  passed: number;
+  failed: number;
+}
+
+interface E2eTestResult {
+  testNumber: number;
+  client: string;
+  server: string;
+  endpoint: string;
+  facilitator: string;
+  protocolFamily: string;
+  scheme?: string;
+  assetTransferMethod?: string;
+  paymentFlow?: string;
+  transport?: string;
+  version?: string;
+  passed: boolean;
+  error?: string;
+  network?: string;
+}
+
+interface E2eResultsJson {
+  summary: {
+    total: number;
+    passed: number;
+    failed: number;
+    networkMode: string;
+    durationMinutes?: number;
+  };
+  results: E2eTestResult[];
+  breakdowns: {
+    byFacilitator: Record<string, BreakdownStats>;
+    byServer: Record<string, BreakdownStats>;
+    byClient: Record<string, BreakdownStats>;
+    byScheme?: Record<string, BreakdownStats>;
+    byAssetTransferMethod?: Record<string, BreakdownStats>;
+    byTransport?: Record<string, BreakdownStats>;
+    byVersion?: Record<string, BreakdownStats>;
+    byPaymentFlow?: Record<string, BreakdownStats>;
+    byProtocolFamily: Record<string, BreakdownStats>;
+  };
+}
+
+function mdCell(value: string): string {
+  return value.replace(/\|/g, "\\|").replace(/\r?\n/g, " ");
+}
+
+function truncate(value: string, max = 160): string {
+  if (value.length <= max) {
+    return value;
+  }
+  return `${value.slice(0, max - 1)}…`;
+}
+
+function passRate(stats: BreakdownStats): string {
+  const total = stats.passed + stats.failed;
+  if (total === 0) {
+    return "—";
+  }
+  return `${Math.round((stats.passed / total) * 100)}%`;
+}
+
+function sortBreakdown(entries: [string, BreakdownStats][]): [string, BreakdownStats][] {
+  return [...entries].sort((a, b) => {
+    if (a[1].failed !== b[1].failed) {
+      return b[1].failed - a[1].failed;
+    }
+    return a[0].localeCompare(b[0]);
+  });
+}
+
+function breakdownTable(title: string, breakdown: Record<string, BreakdownStats>, label: string): string[] {
+  const entries = sortBreakdown(Object.entries(breakdown));
+  if (entries.length === 0) {
+    return [];
+  }
+
+  const lines = [
+    `### ${title}`,
+    "",
+    `| ${label} | Passed | Failed | Rate |`,
+    "| --- | ---: | ---: | ---: |",
+  ];
+  for (const [name, stats] of entries) {
+    const mark = stats.failed > 0 ? "❌" : "✅";
+    lines.push(`| ${mark} \`${mdCell(name)}\` | ${stats.passed} | ${stats.failed} | ${passRate(stats)} |`);
+  }
+  lines.push("");
+  return lines;
+}
+
+function formatMarkdown(data: E2eResultsJson): string {
+  const { summary, results, breakdowns } = data;
+  const headline = summary.failed > 0 ? "❌ e2e results" : "✅ e2e results";
+  const duration =
+    summary.durationMinutes !== undefined ? ` · ⏱️ ${summary.durationMinutes.toFixed(2)} min` : "";
+
+  const lines = [
+    `## ${headline}`,
+    "",
+    `**${summary.total}** total · ✅ **${summary.passed}** passed · ❌ **${summary.failed}** failed · ${summary.networkMode}${duration}`,
+    "",
+  ];
+
+  const failed = results.filter(r => !r.passed).sort((a, b) => a.testNumber - b.testNumber);
+  if (failed.length === 0) {
+    lines.push("✅ All combinations passed", "");
+  } else {
+    lines.push("### Failed combinations", "");
+    lines.push("| # | Client | Server | Endpoint | Facilitator | Network | Error |");
+    lines.push("| ---: | --- | --- | --- | --- | --- | --- |");
+    for (const test of failed) {
+      const error = truncate(test.error || "Unknown error");
+      lines.push(
+        `| ${test.testNumber} | \`${mdCell(test.client)}\` | \`${mdCell(test.server)}\` | \`${mdCell(test.endpoint)}\` | \`${mdCell(test.facilitator)}\` | ${mdCell(test.network || "—")} | ${mdCell(error)} |`,
+      );
+    }
+    lines.push("");
+  }
+
+  lines.push(...breakdownTable("Breakdown by Facilitator", breakdowns.byFacilitator, "Facilitator"));
+  lines.push(...breakdownTable("Breakdown by Server", breakdowns.byServer, "Server"));
+  lines.push(...breakdownTable("Breakdown by Client", breakdowns.byClient, "Client"));
+
+  if (breakdowns.byScheme) {
+    lines.push(...breakdownTable("Breakdown by Scheme", breakdowns.byScheme, "Scheme"));
+  }
+  if (breakdowns.byAssetTransferMethod) {
+    lines.push(...breakdownTable("Breakdown by Asset Transfer Method", breakdowns.byAssetTransferMethod, "ATM"));
+  }
+  if (breakdowns.byTransport) {
+    lines.push(...breakdownTable("Breakdown by Transport", breakdowns.byTransport, "Transport"));
+  }
+  if (breakdowns.byVersion) {
+    lines.push(...breakdownTable("Breakdown by Version", breakdowns.byVersion, "x402 version"));
+  }
+  if (breakdowns.byPaymentFlow && Object.keys(breakdowns.byPaymentFlow).length > 1) {
+    lines.push(...breakdownTable("Breakdown by Payment Flow", breakdowns.byPaymentFlow, "Payment flow"));
+  }
+
+  const familyEntries = Object.entries(breakdowns.byProtocolFamily);
+  if (familyEntries.length > 0) {
+    lines.push("### Protocol Family Breakdown", "");
+    lines.push("| Family | Passed | Failed | Total | Rate |");
+    lines.push("| --- | ---: | ---: | ---: | ---: |");
+    for (const [family, stats] of sortBreakdown(familyEntries)) {
+      const total = stats.passed + stats.failed;
+      const mark = stats.failed > 0 ? "❌" : "✅";
+      lines.push(
+        `| ${mark} ${mdCell(family.toUpperCase())} | ${stats.passed} | ${stats.failed} | ${total} | ${passRate(stats)} |`,
+      );
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+function main(): void {
+  const inputPath = resolve(process.argv[2] || "e2e-results.json");
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+
+  if (!existsSync(inputPath)) {
+    const missing = `## e2e results\n\nNo results file at \`${inputPath}\`.\n`;
+    console.error(`No e2e results JSON at ${inputPath}`);
+    if (summaryPath) {
+      appendFileSync(summaryPath, missing);
+    }
+    process.exit(1);
+  }
+
+  const data = JSON.parse(readFileSync(inputPath, "utf8")) as E2eResultsJson;
+  const markdown = formatMarkdown(data);
+  console.log(markdown);
+
+  if (summaryPath) {
+    appendFileSync(summaryPath, `${markdown}\n`);
+  }
+}
+
+main();

--- a/e2e/test.ts
+++ b/e2e/test.ts
@@ -6,7 +6,7 @@ import { createWalletClient, createPublicClient, http, parseEther, formatEther, 
 import { privateKeyToAccount } from 'viem/accounts';
 import { base, baseSepolia } from 'viem/chains';
 import { TestDiscovery } from './src/discovery';
-import { ClientConfig, ScenarioResult, ServerConfig, TestScenario, endpointAssetTransferMethod, endpointPaymentScheme, endpointUsesBatchSettlement } from './src/types';
+import { ClientConfig, ScenarioResult, ServerConfig, TestScenario, endpointAssetTransferMethod, endpointPaymentFlow, endpointPaymentScheme, endpointUsesBatchSettlement } from './src/types';
 import { config as loggerConfig, log, verboseLog, errorLog, close as closeLogger, createComboLogger } from './src/logger';
 import { handleDiscoveryValidation, shouldRunDiscoveryValidation, type TestedDiscoveryScenario } from './extensions/bazaar';
 import { parseArgs, printHelp } from './src/cli/args';
@@ -1129,12 +1129,61 @@ async function runTest() {
     endpoint: string;
     facilitator: string;
     protocolFamily: string;
+    scheme: string;
+    assetTransferMethod: string;
+    paymentFlow: string;
+    transport: string;
+    version: string;
     passed: boolean;
     error?: string;
     transaction?: string;
     depositTransaction?: string;
     refundTransaction?: string;
     network?: string;
+  }
+
+  function scenarioDimensions(
+    scenario: TestScenario,
+  ): Pick<DetailedTestResult, 'scheme' | 'assetTransferMethod' | 'paymentFlow' | 'transport' | 'version'> {
+    return {
+      scheme: endpointPaymentScheme(scenario.endpoint),
+      assetTransferMethod: endpointAssetTransferMethod(scenario.endpoint) ?? 'n/a',
+      paymentFlow: endpointPaymentFlow(scenario.endpoint),
+      transport: scenario.server.config.transport || 'http',
+      version: String(scenario.server.config.x402Version ?? 1),
+    };
+  }
+
+  function buildBreakdown(
+    results: DetailedTestResult[],
+    key: keyof DetailedTestResult,
+  ): Record<string, { passed: number; failed: number }> {
+    return results.reduce((acc, test) => {
+      const k = String(test[key]);
+      if (!acc[k]) acc[k] = { passed: 0, failed: 0 };
+      if (test.passed) acc[k].passed++;
+      else acc[k].failed++;
+      return acc;
+    }, {} as Record<string, { passed: number; failed: number }>);
+  }
+
+  function logBreakdown(
+    title: string,
+    breakdown: Record<string, { passed: number; failed: number }>,
+    padEnd = 15,
+    style: 'rate' | 'total' = 'rate',
+  ): void {
+    log(`📊 ${title}:`);
+    Object.entries(breakdown).forEach(([name, stats]) => {
+      const total = stats.passed + stats.failed;
+      if (style === 'total') {
+        log(` ${name.toUpperCase()}: ✅ ${stats.passed} / ❌ ${stats.failed} / 📈 ${total} total`);
+        return;
+      }
+      const passRate = total > 0 ? Math.round((stats.passed / total) * 100) : 0;
+      log(` ${name.padEnd(padEnd)} ✅ ${stats.passed} / ❌ ${stats.failed} (${passRate}%)`);
+    });
+    log('');
   }
 
   let testResults: DetailedTestResult[] = [];
@@ -1330,6 +1379,7 @@ async function runTest() {
             endpoint: scenario.endpoint.path,
             facilitator: scenario.facilitator?.name || 'none',
             protocolFamily: scenario.protocolFamily,
+            ...scenarioDimensions(scenario),
             passed: !fullError,
             error: fullError,
             transaction: refundTransaction || depositTransaction,
@@ -1370,6 +1420,7 @@ async function runTest() {
             endpoint: scenario.endpoint.path,
             facilitator: scenario.facilitator?.name || 'none',
             protocolFamily: scenario.protocolFamily,
+            ...scenarioDimensions(scenario),
             passed: false,
             error: initialError,
             depositTransaction: getBatchStep(initialResult, 'deposit')?.payment_response?.transaction,
@@ -1410,6 +1461,7 @@ async function runTest() {
             endpoint: scenario.endpoint.path,
             facilitator: scenario.facilitator?.name || 'none',
             protocolFamily: scenario.protocolFamily,
+            ...scenarioDimensions(scenario),
             passed: false,
             error: recoveryError,
             transaction: refundTransaction || depositTransaction,
@@ -1434,6 +1486,7 @@ async function runTest() {
           endpoint: scenario.endpoint.path,
           facilitator: scenario.facilitator?.name || 'none',
           protocolFamily: scenario.protocolFamily,
+          ...scenarioDimensions(scenario),
           passed: true,
           transaction: refundTransaction || depositTransaction,
           depositTransaction,
@@ -1454,6 +1507,7 @@ async function runTest() {
         endpoint: scenario.endpoint.path,
         facilitator: scenario.facilitator?.name || 'none',
         protocolFamily: scenario.protocolFamily,
+        ...scenarioDimensions(scenario),
         passed: result.success,
         error: result.error,
         transaction: result.payment_response?.transaction,
@@ -1483,6 +1537,7 @@ async function runTest() {
         endpoint: scenario.endpoint.path,
         facilitator: scenario.facilitator?.name || 'none',
         protocolFamily: scenario.protocolFamily,
+        ...scenarioDimensions(scenario),
         passed: false,
         error: errorMsg,
       };
@@ -1549,6 +1604,7 @@ async function runTest() {
         endpoint: scenario.endpoint.path,
         facilitator: scenario.facilitator?.name || 'none',
         protocolFamily: scenario.protocolFamily,
+        ...scenarioDimensions(scenario),
         passed: false,
         error: 'Server failed to start',
       }));
@@ -1585,6 +1641,7 @@ async function runTest() {
             endpoint: scenario.endpoint.path,
             facilitator: scenario.facilitator?.name || 'none',
             protocolFamily: scenario.protocolFamily,
+            ...scenarioDimensions(scenario),
             passed: false,
             error,
           });
@@ -1846,99 +1903,45 @@ async function runTest() {
     log('');
   }
 
-  // Breakdown by facilitator
-  const facilitatorBreakdown = testResults.reduce((acc, test) => {
-    const key = test.facilitator;
-    if (!acc[key]) acc[key] = { passed: 0, failed: 0 };
-    if (test.passed) acc[key].passed++;
-    else acc[key].failed++;
-    return acc;
-  }, {} as Record<string, { passed: number; failed: number }>);
+  logBreakdown('Breakdown by Facilitator', buildBreakdown(testResults, 'facilitator'));
+  logBreakdown('Breakdown by Server', buildBreakdown(testResults, 'server'), 20);
+  logBreakdown('Breakdown by Client', buildBreakdown(testResults, 'client'), 20);
+  logBreakdown('Breakdown by Scheme', buildBreakdown(testResults, 'scheme'));
+  logBreakdown('Breakdown by Asset Transfer Method', buildBreakdown(testResults, 'assetTransferMethod'), 20);
+  logBreakdown('Breakdown by Transport', buildBreakdown(testResults, 'transport'));
+  logBreakdown('Breakdown by Version', buildBreakdown(testResults, 'version'));
 
-  log('📊 Breakdown by Facilitator:');
-  Object.entries(facilitatorBreakdown).forEach(([facilitator, stats]) => {
-    const total = stats.passed + stats.failed;
-    const passRate = total > 0 ? Math.round((stats.passed / total) * 100) : 0;
-    log(` ${facilitator.padEnd(15)} ✅ ${stats.passed} / ❌ ${stats.failed} (${passRate}%)`);
-  });
-  log('');
+  const paymentFlowBreakdown = buildBreakdown(testResults, 'paymentFlow');
+  if (Object.keys(paymentFlowBreakdown).length > 1) {
+    logBreakdown('Breakdown by Payment Flow', paymentFlowBreakdown);
+  }
 
-  // Breakdown by server
-  const serverBreakdown = testResults.reduce((acc, test) => {
-    const key = test.server;
-    if (!acc[key]) acc[key] = { passed: 0, failed: 0 };
-    if (test.passed) acc[key].passed++;
-    else acc[key].failed++;
-    return acc;
-  }, {} as Record<string, { passed: number; failed: number }>);
-
-  log('📊 Breakdown by Server:');
-  Object.entries(serverBreakdown).forEach(([server, stats]) => {
-    const total = stats.passed + stats.failed;
-    const passRate = total > 0 ? Math.round((stats.passed / total) * 100) : 0;
-    log(` ${server.padEnd(20)} ✅ ${stats.passed} / ❌ ${stats.failed} (${passRate}%)`);
-  });
-  log('');
-
-  // Breakdown by client
-  const clientBreakdown = testResults.reduce((acc, test) => {
-    const key = test.client;
-    if (!acc[key]) acc[key] = { passed: 0, failed: 0 };
-    if (test.passed) acc[key].passed++;
-    else acc[key].failed++;
-    return acc;
-  }, {} as Record<string, { passed: number; failed: number }>);
-
-  log('📊 Breakdown by Client:');
-  Object.entries(clientBreakdown).forEach(([client, stats]) => {
-    const total = stats.passed + stats.failed;
-    const passRate = total > 0 ? Math.round((stats.passed / total) * 100) : 0;
-    log(`   ${client.padEnd(20)} ✅ ${stats.passed} / ❌ ${stats.failed} (${passRate}%)`);
-  });
-  log('');
-
-  // Protocol family breakdown
-  const protocolBreakdown = testResults.reduce((acc, test) => {
-    const key = test.protocolFamily;
-    if (!acc[key]) acc[key] = { passed: 0, failed: 0 };
-    if (test.passed) acc[key].passed++;
-    else acc[key].failed++;
-    return acc;
-  }, {} as Record<string, { passed: number; failed: number }>);
-
+  const protocolBreakdown = buildBreakdown(testResults, 'protocolFamily');
   if (Object.keys(protocolBreakdown).length > 1) {
-    log('📊 Protocol Family Breakdown:');
-    Object.entries(protocolBreakdown).forEach(([protocol, stats]) => {
-      const total = stats.passed + stats.failed;
-      log(` ${protocol.toUpperCase()}: ✅ ${stats.passed} / ❌ ${stats.failed} / 📈 ${total} total`);
-    });
-    log('');
+    logBreakdown('Protocol Family Breakdown', protocolBreakdown, 15, 'total');
   }
 
   // Write structured JSON output if requested
   if (parsedArgs.outputJson) {
-    const breakdown = (results: DetailedTestResult[], key: keyof DetailedTestResult) =>
-      results.reduce((acc, test) => {
-        const k = String(test[key]);
-        if (!acc[k]) acc[k] = { passed: 0, failed: 0 };
-        if (test.passed) acc[k].passed++;
-        else acc[k].failed++;
-        return acc;
-      }, {} as Record<string, { passed: number; failed: number }>);
-
     const jsonOutput = {
       summary: {
         total: passed + failed,
         passed,
         failed,
         networkMode,
+        durationMinutes: Number(((Date.now() - startTime) / 60_000).toFixed(2)),
       },
       results: testResults,
       breakdowns: {
-        byFacilitator: breakdown(testResults, 'facilitator'),
-        byServer: breakdown(testResults, 'server'),
-        byClient: breakdown(testResults, 'client'),
-        byProtocolFamily: breakdown(testResults, 'protocolFamily'),
+        byFacilitator: buildBreakdown(testResults, 'facilitator'),
+        byServer: buildBreakdown(testResults, 'server'),
+        byClient: buildBreakdown(testResults, 'client'),
+        byScheme: buildBreakdown(testResults, 'scheme'),
+        byAssetTransferMethod: buildBreakdown(testResults, 'assetTransferMethod'),
+        byTransport: buildBreakdown(testResults, 'transport'),
+        byVersion: buildBreakdown(testResults, 'version'),
+        byPaymentFlow: buildBreakdown(testResults, 'paymentFlow'),
+        byProtocolFamily: buildBreakdown(testResults, 'protocolFamily'),
       },
     };
 


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

Adds pnpm results:summary to render e2e-results.json as Markdown (stdout and GITHUB_STEP_SUMMARY), and wires it into the e2e CI workflow so pass/fail tables appear at the top of the job page. Extends --output-json results with catalog dimensions (scheme, asset transfer method, payment flow, transport, version) and breakdown tables beyond facilitator/server/client/protocol family. Refactors breakdown logging in test.ts around shared helpers and includes run duration in the JSON summary.

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [ ] I have formatted and linted my code
- [ ] All new and existing tests pass
- [ ] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [ ] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 