### PR TITLE
docs: add MadeOnSol x402 to Third-Party Extensions

### DIFF
--- a/docs/dev-tools/third-party-extensions.md
+++ b/docs/dev-tools/third-party-extensions.md
@@ -6,6 +6,7 @@ description: "Packages built by ecosystem partners that extend x402 beyond the c
 | Name | Description | Languages | Links |
 | ---- | ----------- | --------- | ----- |
 | [World AgentKit](https://docs.world.org/agents/agent-kit/integrate) | Verify human-backed agents | TypeScript | [GitHub](https://github.com/worldcoin/agentkit) · [npm](https://www.npmjs.com/package/@worldcoin/agentkit) |
+| [MadeOnSol x402](https://madeonsol.com/x402) | USDG payments on Robinhood Chain (chain 4663) — self-hosted facilitator + dual-accept clients (USDG or Solana USDC) | TypeScript, Python | [GitHub](https://github.com/madeonsol/madeonsol-x402) · [npm](https://www.npmjs.com/package/madeonsol-x402) · [PyPI](https://pypi.org/project/madeonsol-x402/) |
 | [OMATrust](https://www.omatrust.org/x402) | Key authorizations for Signed Offers and Receipts | TypeScript | [GitHub](https://github.com/oma3dao/omatrust-sdk) · [npm](https://www.npmjs.com/package/@oma3/omatrust) |
 | [PEAC Protocol](https://x402.peacprotocol.org) | Verifiable receipts for x402 payments | TypeScript | [GitHub](https://github.com/peacprotocol/peac) · [npm](https://www.npmjs.com/package/@peac/adapter-x402) |
 | [x402r](https://x402r.org) | Non-custodial refund and arbitration protocol | Typescript | [GitHub](https://github.com/BackTrackCo/x402r-sdk) · [npm](https://www.npmjs.com/package/@x402r/sdk ) |


### PR DESCRIPTION
Adds MadeOnSol x402 to the third-party extensions table.

**What it extends beyond core:** x402 payments in **USDG on Robinhood Chain (chain id 4663)** — a network outside core/CDP facilitator coverage — via a self-hosted EIP-3009 facilitator (verify + settle, gas-only relayer, no custody), plus dual-accept client SDKs that let one endpoint accept either USDG-on-RHC or USDC-on-Solana.

**Live since 2026-07-22:** 10 USDG endpoints at https://madeonsol.com/api/x402/rhc (discovery endpoint included), alongside 26 Solana-USDC endpoints. SDKs: `madeonsol-x402` on npm (TS) and PyPI (Python), both handling the 402 → sign → retry loop, MIT-licensed.

Row follows the existing table format and alphabetical order. Happy to adjust wording or placement.

(Reopens #3322 — that PR's branch had to be force-pushed to add a signed commit per the verified-commits requirement, which blocks GitHub's native reopen.)