### PR TITLE
fix(ts): patch hono/next buffers and raise facilitator timeout

### DIFF
--- a/typescript/packages/core/src/http/httpFacilitatorClient.ts
+++ b/typescript/packages/core/src/http/httpFacilitatorClient.ts
@@ -13,7 +13,7 @@ import { safeBase64Decode } from "../utils";
 
 const DEFAULT_FACILITATOR_URL = "https://x402.org/facilitator";
 /** Default per-request timeout for facilitator HTTP calls, in milliseconds */
-const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_TIMEOUT_MS = 90_000;
 /**
  * Upper bound for timeoutMs (2^31 - 1). AbortSignal.timeout() requires an
  * integer, and larger values overflow Node's 32-bit timers, which would
@@ -28,7 +28,7 @@ export interface FacilitatorConfig {
    * `verify()`, `settle()`, and every `getSupported()` attempt — covering both
    * response headers and body consumption. Must be a positive integer no
    * greater than 2_147_483_647 (2^31 - 1, about 24.8 days).
-   * Defaults to 30_000 (30 seconds), matching the Go and Python facilitator clients.
+   * Defaults to 90_000 (90 seconds).
    *
    * On expiry the operation rejects with {@link FacilitatorTimeoutError}. For
    * `settle()` a timeout is an indeterminate outcome: the facilitator may still

--- a/typescript/packages/core/test/unit/http/httpFacilitatorClient.test.ts
+++ b/typescript/packages/core/test/unit/http/httpFacilitatorClient.test.ts
@@ -484,8 +484,8 @@ describe("request timeout", () => {
     vi.unstubAllGlobals();
   });
 
-  it("defaults timeoutMs to 30 seconds", () => {
-    expect(new HTTPFacilitatorClient().timeoutMs).toBe(30_000);
+  it("defaults timeoutMs to 90 seconds", () => {
+    expect(new HTTPFacilitatorClient().timeoutMs).toBe(90_000);
     expect(new HTTPFacilitatorClient({ timeoutMs: 5_000 }).timeoutMs).toBe(5_000);
   });
 

--- a/typescript/packages/http/hono/src/index.test.ts
+++ b/typescript/packages/http/hono/src/index.test.ts
@@ -383,18 +383,8 @@ describe("paymentMiddleware", () => {
     );
     const context = createMockContext();
 
-    // Create a proper Response mock with headers and clone method
-    const responseHeaders = new Headers();
-    const mockResponse = {
-      status: 200,
-      headers: responseHeaders,
-      clone: () => ({
-        arrayBuffer: async () => new ArrayBuffer(0),
-      }),
-    } as unknown as Response;
-
     const next = vi.fn().mockImplementation(async () => {
-      context.res = mockResponse;
+      context.res = new Response("", { status: 200 });
     });
 
     await middleware(context, next);
@@ -414,7 +404,85 @@ describe("paymentMiddleware", () => {
       undefined,
       undefined,
     );
-    expect(responseHeaders.get("PAYMENT-RESPONSE")).toBe("settled");
+    expect(context.res?.headers.get("PAYMENT-RESPONSE")).toBe("settled");
+  });
+
+  it("returns the protected body after a delayed settlement", async () => {
+    setupMockHttpServer({
+      type: "payment-verified",
+      paymentPayload: mockPaymentPayload,
+      paymentRequirements: mockPaymentRequirements,
+    });
+    mockProcessSettlement.mockImplementation(
+      async () =>
+        new Promise(resolve => {
+          setTimeout(() => {
+            resolve({ success: true, headers: { "PAYMENT-RESPONSE": "settled" } });
+          }, 25);
+        }),
+    );
+
+    const middleware = paymentMiddleware(
+      mockRoutes,
+      {} as unknown as x402ResourceServer,
+      undefined,
+      undefined,
+      false,
+    );
+    const context = createMockContext();
+    const original = new Response("protected-body", {
+      status: 200,
+      headers: { "content-type": "text/plain" },
+    });
+    const next = vi.fn().mockImplementation(async () => {
+      context.res = original;
+    });
+
+    await middleware(context, next);
+
+    expect(context.res).not.toBe(original);
+    expect(await context.res?.text()).toBe("protected-body");
+    expect(context.res?.headers.get("PAYMENT-RESPONSE")).toBe("settled");
+  });
+
+  it("fully buffers a streaming handler body before settlement", async () => {
+    setupMockHttpServer({
+      type: "payment-verified",
+      paymentPayload: mockPaymentPayload,
+      paymentRequirements: mockPaymentRequirements,
+    });
+    const original = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("chunk-1-"));
+          controller.enqueue(new TextEncoder().encode("chunk-2"));
+          controller.close();
+        },
+      }),
+      { status: 200, headers: { "content-type": "text/plain" } },
+    );
+    mockProcessSettlement.mockImplementation(async () => {
+      expect(original.bodyUsed).toBe(true);
+      return { success: true, headers: { "PAYMENT-RESPONSE": "settled" } };
+    });
+
+    const middleware = paymentMiddleware(
+      mockRoutes,
+      {} as unknown as x402ResourceServer,
+      undefined,
+      undefined,
+      false,
+    );
+    const context = createMockContext();
+    const next = vi.fn().mockImplementation(async () => {
+      context.res = original;
+    });
+
+    await middleware(context, next);
+
+    expect(context.res).not.toBe(original);
+    expect(await context.res?.text()).toBe("chunk-1-chunk-2");
+    expect(context.res?.headers.get("PAYMENT-RESPONSE")).toBe("settled");
   });
 
   it("strips settlement override header from client response", async () => {
@@ -436,24 +504,17 @@ describe("paymentMiddleware", () => {
     );
     const context = createMockContext();
 
-    const responseHeaders = new Headers();
-    responseHeaders.set("Settlement-Overrides", JSON.stringify({ amount: "32%" }));
-    const mockResponse = {
-      status: 200,
-      headers: responseHeaders,
-      clone: () => ({
-        arrayBuffer: async () => new ArrayBuffer(0),
-      }),
-    } as unknown as Response;
-
     const next = vi.fn().mockImplementation(async () => {
-      context.res = mockResponse;
+      context.res = new Response("", {
+        status: 200,
+        headers: { "Settlement-Overrides": JSON.stringify({ amount: "32%" }) },
+      });
     });
 
     await middleware(context, next);
 
-    expect(responseHeaders.has("Settlement-Overrides")).toBe(false);
-    expect(responseHeaders.get("PAYMENT-RESPONSE")).toBe("settled");
+    expect(context.res?.headers.has("Settlement-Overrides")).toBe(false);
+    expect(context.res?.headers.get("PAYMENT-RESPONSE")).toBe("settled");
   });
 
   it("skips settlement when handler returns >= 400", async () => {
@@ -594,15 +655,8 @@ describe("paymentMiddleware", () => {
     );
     const context = createMockContext();
 
-    const responseHeaders = new Headers();
     const next = vi.fn().mockImplementation(async () => {
-      context.res = {
-        status: 200,
-        headers: responseHeaders,
-        clone: () => ({
-          arrayBuffer: async () => new ArrayBuffer(0),
-        }),
-      } as unknown as Response;
+      context.res = new Response("", { status: 200 });
     });
 
     await middleware(context, next);
@@ -739,15 +793,8 @@ describe("paymentMiddleware", () => {
     );
     const context = createMockContext();
 
-    const responseHeaders = new Headers();
     const next = vi.fn().mockImplementation(async () => {
-      context.res = {
-        status: 200,
-        headers: responseHeaders,
-        clone: () => ({
-          arrayBuffer: async () => new ArrayBuffer(0),
-        }),
-      } as unknown as Response;
+      context.res = new Response("", { status: 200 });
     });
 
     await middleware(context, next);

--- a/typescript/packages/http/hono/src/index.ts
+++ b/typescript/packages/http/hono/src/index.ts
@@ -276,18 +276,18 @@ export function paymentMiddlewareFromHTTPServer(
           return;
         }
 
-        // Get response body for extensions
-        const responseBody = Buffer.from(await res.clone().arrayBuffer());
-
-        const responseHeaders: Record<string, string> = {};
-        res.headers.forEach((value, key) => {
-          responseHeaders[key] = value;
-        });
-
         // Clear the response so we can modify headers
         c.res = undefined;
 
         try {
+          // Get response body for extensions
+          const responseBody = Buffer.from(await res.arrayBuffer());
+
+          const responseHeaders: Record<string, string> = {};
+          res.headers.forEach((value, key) => {
+            responseHeaders[key] = value;
+          });
+
           const settleResult = await httpServer.processSettlement(
             paymentPayload,
             paymentRequirements,
@@ -308,6 +308,8 @@ export function paymentMiddlewareFromHTTPServer(
               headers: response.headers,
             });
           } else {
+            res = new Response(responseBody, { status: res.status, headers: res.headers });
+            res.headers.delete("transfer-encoding");
             // Settlement succeeded - add headers to response
             Object.entries(settleResult.headers).forEach(([key, value]) => {
               res.headers.set(key, value);

--- a/typescript/packages/http/next/src/index.test.ts
+++ b/typescript/packages/http/next/src/index.test.ts
@@ -359,6 +359,7 @@ describe("paymentProxy", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("X-Settlement")).toBe("complete");
+    expect(response.headers.get("x-middleware-next")).toBe("1");
     expect(mockServer.processSettlement).toHaveBeenCalledWith(
       mockPaymentPayload,
       mockPaymentRequirements,

--- a/typescript/packages/http/next/src/utils.test.ts
+++ b/typescript/packages/http/next/src/utils.test.ts
@@ -426,6 +426,7 @@ describe("handleSettlement", () => {
     expect(result.status).toBe(200);
     expect(result.headers.get("PAYMENT-RESPONSE")).toBe("settled");
     expect(result.headers.get("Cache-Control")).toBe("private");
+    expect(await result.text()).toBe("OK");
     expect(mockHttpServer.processSettlement).toHaveBeenCalledWith(
       mockPaymentPayload,
       mockRequirements,
@@ -438,6 +439,63 @@ describe("handleSettlement", () => {
       undefined,
       undefined,
     );
+  });
+
+  it("returns the protected body after a delayed settlement", async () => {
+    vi.mocked(mockHttpServer.processSettlement).mockImplementation(
+      async () =>
+        new Promise(resolve => {
+          setTimeout(() => {
+            resolve({ success: true, headers: { "PAYMENT-RESPONSE": "settled" } });
+          }, 25);
+        }),
+    );
+    const original = new NextResponse("protected-body", { status: 200 });
+
+    const result = await handleSettlement(
+      mockHttpServer,
+      original,
+      mockPaymentPayload,
+      mockRequirements,
+      mockDeclaredExtensions,
+      mockPaymentCancellationDispatcher,
+      mockHttpContext,
+    );
+
+    expect(result).not.toBe(original);
+    expect(await result.text()).toBe("protected-body");
+    expect(result.headers.get("PAYMENT-RESPONSE")).toBe("settled");
+  });
+
+  it("fully buffers a streaming handler body before settlement", async () => {
+    const original = new NextResponse(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("chunk-1-"));
+          controller.enqueue(new TextEncoder().encode("chunk-2"));
+          controller.close();
+        },
+      }),
+      { status: 200 },
+    );
+    vi.mocked(mockHttpServer.processSettlement).mockImplementation(async () => {
+      expect(original.bodyUsed).toBe(true);
+      return { success: true, headers: { "PAYMENT-RESPONSE": "settled" } };
+    });
+
+    const result = await handleSettlement(
+      mockHttpServer,
+      original,
+      mockPaymentPayload,
+      mockRequirements,
+      mockDeclaredExtensions,
+      mockPaymentCancellationDispatcher,
+      mockHttpContext,
+    );
+
+    expect(result).not.toBe(original);
+    expect(await result.text()).toBe("chunk-1-chunk-2");
+    expect(result.headers.get("PAYMENT-RESPONSE")).toBe("settled");
   });
 
   it("merges private into existing Cache-Control on successful settlement", async () => {

--- a/typescript/packages/http/next/src/utils.ts
+++ b/typescript/packages/http/next/src/utils.ts
@@ -214,7 +214,7 @@ export async function handleSettlement(
 
   try {
     // Get response body for extensions
-    const responseBody = Buffer.from(await response.clone().arrayBuffer());
+    const responseBody = Buffer.from(await response.arrayBuffer());
 
     const responseHeaders: Record<string, string> = {};
     response.headers.forEach((value, key) => {
@@ -240,19 +240,24 @@ export async function handleSettlement(
       });
     }
 
-    // Settlement succeeded - add headers and return original response.
-    Object.entries(result.headers).forEach(([key, value]) => {
-      response.headers.set(key, value);
+    // Settlement succeeded - add headers and return the buffered response.
+    const settled = new NextResponse(responseBody, {
+      status: response.status,
+      headers: response.headers,
     });
-    response.headers.set(
+    settled.headers.delete("transfer-encoding");
+    Object.entries(result.headers).forEach(([key, value]) => {
+      settled.headers.set(key, value);
+    });
+    settled.headers.set(
       "Cache-Control",
-      withPrivateCacheControl(response.headers.get("Cache-Control")),
+      withPrivateCacheControl(settled.headers.get("Cache-Control")),
     );
 
     // Strip internal settlement override header before sending to client.
-    response.headers.delete(SETTLEMENT_OVERRIDES_HEADER);
+    settled.headers.delete(SETTLEMENT_OVERRIDES_HEADER);
 
-    return response;
+    return settled;
   } catch (error) {
     if (error instanceof FacilitatorResponseError) {
       return createFacilitatorErrorResponse(error);


### PR DESCRIPTION
## Description

Hono and Next were returning the unread Response.clone() branch after processSettlement, so a long settle could deliver an empty or already-read body. This was exposed while reviewing Cardano in [#2537](https://github.com/x402-foundation/x402/pull/2537); the adapters now consume the handler body (including streams) before settle and reply from that buffer only after confirmation. HTTPFacilitatorClient defaults to 90s so a held settle can finish (callers can still pass timeoutMs: 30_000).

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 