### PR TITLE
fix(stellar): allow informational simulation events

### DIFF
--- a/typescript/.changeset/flat-humans-pick.md
+++ b/typescript/.changeset/flat-humans-pick.md
@@ -1,0 +1,5 @@
+---
+"@x402/stellar": patch
+---
+
+Fixed Stellar payment verification rejecting informational smart-account events while continuing to reject additional token balance changes.

--- a/typescript/.changeset/flat-humans-pick.md
+++ b/typescript/.changeset/flat-humans-pick.md
@@ -2,4 +2,4 @@
 "@x402/stellar": patch
 ---
 
-Fixed Stellar payment verification rejecting informational smart-account events while continuing to reject additional token balance changes.
+Fixed Stellar payment verification rejecting informational smart-account events while continuing to reject additional payment-token balance changes.

--- a/typescript/packages/mechanisms/stellar/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/stellar/src/exact/facilitator/scheme.ts
@@ -646,24 +646,20 @@ export class ExactStellarScheme implements SchemeNetworkFacilitator {
         const body = event.body().v0();
         const topics = body.topics();
 
-        // Check if this is a transfer event (first topic is "transfer" symbol)
-        if (topics.length < 3) {
-          return invalidVerifyResponse(
-            "invalid_exact_stellar_payload_event_not_transfer",
-            fromAddress,
-          );
-        }
-
-        const topicType = topics[0].switch().name;
-        if (topicType !== "scvSymbol") {
-          return invalidVerifyResponse(
-            "invalid_exact_stellar_payload_event_not_transfer",
-            fromAddress,
-          );
-        }
-
-        const symbol = topics[0].sym().toString();
+        const symbol =
+          topics[0]?.switch().name === "scvSymbol" ? topics[0].sym().toString() : undefined;
         if (symbol !== "transfer") {
+          // Ignore informational events, but reject additional token balance changes.
+          if (symbol === "mint" || symbol === "burn" || symbol === "clawback") {
+            return invalidVerifyResponse(
+              "invalid_exact_stellar_payload_event_not_transfer",
+              fromAddress,
+            );
+          }
+          continue;
+        }
+
+        if (topics.length < 3) {
           return invalidVerifyResponse(
             "invalid_exact_stellar_payload_event_not_transfer",
             fromAddress,

--- a/typescript/packages/mechanisms/stellar/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/stellar/src/exact/facilitator/scheme.ts
@@ -607,7 +607,7 @@ export class ExactStellarScheme implements SchemeNetworkFacilitator {
 
   /**
    * Validates simulation events for transfer correctness.
-   * Ensures there is exactly one token transfer event, the transfer matches the
+   * Ensures there is exactly one payment-token transfer event, the transfer matches the
    * expected sender, recipient, amount, and asset (contract address), and the
    * facilitator address is not involved in the transfer.
    *
@@ -643,13 +643,27 @@ export class ExactStellarScheme implements SchemeNetworkFacilitator {
           continue;
         }
 
+        const contractIdHash = event.contractId();
+        if (!contractIdHash)
+          return invalidVerifyResponse(
+            "invalid_exact_stellar_payload_event_missing_contract_id",
+            fromAddress,
+          );
+        const eventContractAddress = Address.fromScAddress(
+          xdr.ScAddress.scAddressTypeContract(contractIdHash),
+        ).toString();
+        // Event topics are contract-defined; only interpret the payment token's events.
+        if (eventContractAddress !== expectedAsset) {
+          continue;
+        }
+
         const body = event.body().v0();
         const topics = body.topics();
 
         const symbol =
           topics[0]?.switch().name === "scvSymbol" ? topics[0].sym().toString() : undefined;
         if (symbol !== "transfer") {
-          // Ignore informational events, but reject additional token balance changes.
+          // Ignore informational events, but reject additional payment-token balance changes.
           if (symbol === "mint" || symbol === "burn" || symbol === "clawback") {
             return invalidVerifyResponse(
               "invalid_exact_stellar_payload_event_not_transfer",
@@ -662,22 +676,6 @@ export class ExactStellarScheme implements SchemeNetworkFacilitator {
         if (topics.length < 3) {
           return invalidVerifyResponse(
             "invalid_exact_stellar_payload_event_not_transfer",
-            fromAddress,
-          );
-        }
-
-        const contractIdHash = event.contractId();
-        if (!contractIdHash)
-          return invalidVerifyResponse(
-            "invalid_exact_stellar_payload_event_missing_contract_id",
-            fromAddress,
-          );
-        const eventContractAddress = Address.fromScAddress(
-          xdr.ScAddress.scAddressTypeContract(contractIdHash),
-        ).toString();
-        if (eventContractAddress !== expectedAsset) {
-          return invalidVerifyResponse(
-            "invalid_exact_stellar_payload_event_wrong_asset",
             fromAddress,
           );
         }

--- a/typescript/packages/mechanisms/stellar/test/unit/facilitator-verify.test.ts
+++ b/typescript/packages/mechanisms/stellar/test/unit/facilitator-verify.test.ts
@@ -13,6 +13,7 @@ import {
   xdr,
   Keypair,
   Asset,
+  nativeToScVal,
 } from "@stellar/stellar-sdk";
 import { Api } from "@stellar/stellar-sdk/rpc";
 import { beforeEach, beforeAll, describe, expect, it, vi } from "vitest";
@@ -1106,7 +1107,7 @@ describe("ExactStellarScheme#Verify (randomly using 1-2 facilitator signers)", (
         expect(result.invalidReason).toBe("invalid_exact_stellar_payload_no_transfer_events");
       });
 
-      it("should reject when a contract event is not a transfer", async () => {
+      it("should reject mint events", async () => {
         const mockNonTransferEvent = createMockContractEvent({
           from: CLIENT_PUBLIC,
           to: FACILITATOR_PUBLIC,
@@ -1128,6 +1129,103 @@ describe("ExactStellarScheme#Verify (randomly using 1-2 facilitator signers)", (
         const result = await facilitator.verify(validPayload, validRequirements);
         expect(result.isValid).toBe(false);
         expect(result.invalidReason).toBe("invalid_exact_stellar_payload_event_not_transfer");
+      });
+
+      describe("informational contract events", () => {
+        const payer = new Address(CLIENT_PUBLIC).toScVal();
+        const recipient = new Address(TRANSACTION_RECIPIENT).toScVal();
+        const policyContract = Address.contract(Buffer.alloc(32, 1)).toScAddress().contractId();
+
+        const verifyEvents = (
+          topics: xdr.ScVal[],
+          contractId = policyContract,
+          transferPosition: "first" | "last" | "none" = "last",
+        ) => {
+          const extraEvent = createMockDiagnosticEvent(
+            new xdr.ContractEventV0({ topics, data: nativeToScVal(1n) }),
+            xdr.ContractEventType.contract(),
+            contractId,
+          );
+          const transferEvent = createMockContractEvent({
+            from: CLIENT_PUBLIC,
+            to: TRANSACTION_RECIPIENT,
+            amount: BigInt(validRequirements.amount),
+            contractId: expectedAssetHash(),
+          });
+          const events = [extraEvent];
+          if (transferPosition === "first") events.unshift(transferEvent);
+          if (transferPosition === "last") events.push(transferEvent);
+          vi.mocked(mockServer.simulateTransaction).mockResolvedValueOnce({
+            id: "test",
+            latestLedger: 123,
+            events,
+            _parsed: true,
+            transactionData: new SorobanDataBuilder(),
+            minResourceFee: "100",
+            cost: { cpuInsns: "0", memBytes: "0" },
+            results: [],
+          } as Api.SimulateTransactionSuccessResponse);
+          return facilitator.verify(validPayload, validRequirements);
+        };
+
+        it.each([
+          ["spending limit", [xdr.ScVal.scvSymbol("spending_limit_enforced"), payer, recipient]],
+          ["short topics", [xdr.ScVal.scvSymbol("spending_limit_enforced")]],
+          ["non-symbol topic", [xdr.ScVal.scvString("policy"), payer, recipient]],
+          ["empty topics", []],
+        ] satisfies [string, xdr.ScVal[]][])(
+          "should accept %s events before and after the transfer",
+          async (_, topics) => {
+            for (const position of ["first", "last"] as const) {
+              expect(await verifyEvents(topics, policyContract, position)).toEqual(
+                validVerifyResponse(CLIENT_PUBLIC),
+              );
+            }
+          },
+        );
+
+        it("should reject informational events without a transfer", async () => {
+          const result = await verifyEvents(
+            [xdr.ScVal.scvSymbol("spending_limit_enforced")],
+            policyContract,
+            "none",
+          );
+          expect(result).toEqual(
+            invalidVerifyResponse(
+              "invalid_exact_stellar_payload_no_transfer_events",
+              CLIENT_PUBLIC,
+            ),
+          );
+        });
+
+        it.each(["mint", "burn", "clawback"])(
+          "should reject an additional %s from any contract",
+          async symbol => {
+            const topics = [xdr.ScVal.scvSymbol(symbol), payer];
+            if (symbol === "mint") topics.push(recipient);
+
+            for (const contractId of [expectedAssetHash(), policyContract]) {
+              for (const position of ["first", "last"] as const) {
+                expect(await verifyEvents(topics, contractId, position)).toEqual(
+                  invalidVerifyResponse(
+                    "invalid_exact_stellar_payload_event_not_transfer",
+                    CLIENT_PUBLIC,
+                  ),
+                );
+              }
+            }
+          },
+        );
+
+        it.each([1, 2])("should reject a transfer event with only %i topics", async topicCount => {
+          const topics = [xdr.ScVal.scvSymbol("transfer"), payer].slice(0, topicCount);
+          expect(await verifyEvents(topics)).toEqual(
+            invalidVerifyResponse(
+              "invalid_exact_stellar_payload_event_not_transfer",
+              CLIENT_PUBLIC,
+            ),
+          );
+        });
       });
 
       it("should ignore non-contract events and still accept valid transfer", async () => {

--- a/typescript/packages/mechanisms/stellar/test/unit/facilitator-verify.test.ts
+++ b/typescript/packages/mechanisms/stellar/test/unit/facilitator-verify.test.ts
@@ -1065,7 +1065,7 @@ describe("ExactStellarScheme#Verify (randomly using 1-2 facilitator signers)", (
         );
       });
 
-      it("should reject when transfer event has wrong asset (contract address)", async () => {
+      it("should reject when no transfer comes from the expected asset", async () => {
         const wrongAsset = "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC";
         const mockTransferEvent = createMockContractEvent({
           from: CLIENT_PUBLIC,
@@ -1087,7 +1087,7 @@ describe("ExactStellarScheme#Verify (randomly using 1-2 facilitator signers)", (
 
         const result = await facilitator.verify(validPayload, validRequirements);
         expect(result.isValid).toBe(false);
-        expect(result.invalidReason).toBe("invalid_exact_stellar_payload_event_wrong_asset");
+        expect(result.invalidReason).toBe("invalid_exact_stellar_payload_no_transfer_events");
       });
 
       it("should reject when no transfer events are present", async () => {
@@ -1113,6 +1113,7 @@ describe("ExactStellarScheme#Verify (randomly using 1-2 facilitator signers)", (
           to: FACILITATOR_PUBLIC,
           amount: BigInt(10000),
           fnName: "mint", // ❌ event is not "transfer"
+          contractId: expectedAssetHash(),
         });
 
         vi.mocked(mockServer.simulateTransaction).mockResolvedValueOnce({
@@ -1138,7 +1139,7 @@ describe("ExactStellarScheme#Verify (randomly using 1-2 facilitator signers)", (
 
         const verifyEvents = (
           topics: xdr.ScVal[],
-          contractId = policyContract,
+          contractId: xdr.Hash | null = policyContract,
           transferPosition: "first" | "last" | "none" = "last",
         ) => {
           const extraEvent = createMockDiagnosticEvent(
@@ -1176,10 +1177,12 @@ describe("ExactStellarScheme#Verify (randomly using 1-2 facilitator signers)", (
         ] satisfies [string, xdr.ScVal[]][])(
           "should accept %s events before and after the transfer",
           async (_, topics) => {
-            for (const position of ["first", "last"] as const) {
-              expect(await verifyEvents(topics, policyContract, position)).toEqual(
-                validVerifyResponse(CLIENT_PUBLIC),
-              );
+            for (const contractId of [expectedAssetHash(), policyContract]) {
+              for (const position of ["first", "last"] as const) {
+                expect(await verifyEvents(topics, contractId, position)).toEqual(
+                  validVerifyResponse(CLIENT_PUBLIC),
+                );
+              }
             }
           },
         );
@@ -1198,28 +1201,64 @@ describe("ExactStellarScheme#Verify (randomly using 1-2 facilitator signers)", (
           );
         });
 
-        it.each(["mint", "burn", "clawback"])(
-          "should reject an additional %s from any contract",
+        it.each(["mint", "burn", "clawback", "transfer"])(
+          "should accept a custom %s from another contract before and after the transfer",
           async symbol => {
             const topics = [xdr.ScVal.scvSymbol(symbol), payer];
-            if (symbol === "mint") topics.push(recipient);
+            if (symbol === "mint" || symbol === "transfer") topics.push(recipient);
 
-            for (const contractId of [expectedAssetHash(), policyContract]) {
-              for (const position of ["first", "last"] as const) {
-                expect(await verifyEvents(topics, contractId, position)).toEqual(
-                  invalidVerifyResponse(
-                    "invalid_exact_stellar_payload_event_not_transfer",
-                    CLIENT_PUBLIC,
-                  ),
-                );
-              }
+            for (const position of ["first", "last"] as const) {
+              expect(await verifyEvents(topics, policyContract, position)).toEqual(
+                validVerifyResponse(CLIENT_PUBLIC),
+              );
             }
           },
         );
 
+        it.each(["mint", "burn", "clawback", "transfer"])(
+          "should reject a custom %s without a payment-asset transfer",
+          async symbol => {
+            const topics = [xdr.ScVal.scvSymbol(symbol), payer, recipient];
+            expect(await verifyEvents(topics, policyContract, "none")).toEqual(
+              invalidVerifyResponse(
+                "invalid_exact_stellar_payload_no_transfer_events",
+                CLIENT_PUBLIC,
+              ),
+            );
+          },
+        );
+
+        it.each(["mint", "burn", "clawback"])(
+          "should reject an additional %s from the payment asset before and after the transfer",
+          async symbol => {
+            const topics = [xdr.ScVal.scvSymbol(symbol), payer];
+            if (symbol === "mint") topics.push(recipient);
+
+            for (const position of ["first", "last"] as const) {
+              expect(await verifyEvents(topics, expectedAssetHash(), position)).toEqual(
+                invalidVerifyResponse(
+                  "invalid_exact_stellar_payload_event_not_transfer",
+                  CLIENT_PUBLIC,
+                ),
+              );
+            }
+          },
+        );
+
+        it("should reject an informational contract event without an emitter", async () => {
+          expect(
+            await verifyEvents([xdr.ScVal.scvSymbol("spending_limit_enforced")], null),
+          ).toEqual(
+            invalidVerifyResponse(
+              "invalid_exact_stellar_payload_event_missing_contract_id",
+              CLIENT_PUBLIC,
+            ),
+          );
+        });
+
         it.each([1, 2])("should reject a transfer event with only %i topics", async topicCount => {
           const topics = [xdr.ScVal.scvSymbol("transfer"), payer].slice(0, topicCount);
-          expect(await verifyEvents(topics)).toEqual(
+          expect(await verifyEvents(topics, expectedAssetHash())).toEqual(
             invalidVerifyResponse(
               "invalid_exact_stellar_payload_event_not_transfer",
               CLIENT_PUBLIC,


### PR DESCRIPTION
## Description

Allow Stellar verification to accept informational smart-account events, including custom events named `mint`, `burn`, `clawback`, or `transfer`. Soroban event symbols are contract-defined: check the emitting contract ID before interpreting token topics.

Only events from `requirements.asset` participate in payment validation. Require exactly one transfer with the expected sender, recipient, and amount; reject that asset's additional `mint`, `burn`, or `clawback` events and malformed transfers. Reject contract events without an emitter ID. Foreign events alone cannot prove payment.

Closes #3352

**Review scope:** this enforces movement of the payment asset. The [Stellar exact specification](https://github.com/x402-foundation/x402/blob/4e15690028cf6d66b35e44a8128da47da9b92a4d/specs/schemes/exact/scheme_exact_stellar.md#4--facilitator-safety) also prohibits all other balance changes. Ignoring foreign emitters cannot prove that broader condition: a foreign token event and a custom event can have the same shape. Soroban contract-invoker authorization also means that rejecting signed auth sub-invocations does not exclude every other-token mutation. This interpretation needs maintainer review before merge; the PR does not claim that other assets were untouched.

## Tests

- GitHub Actions passed, including the full TypeScript unit workflows on Node 22 and 24. Vercel deployment separately requires maintainer authorization.

- Stellar unit tests: 194 passed across 10 files; coverage thresholds passed.
- Stellar testnet integration: 11 passed, none skipped, on Protocol 28 using temporary Friendbot-funded accounts.
- Regression coverage uses distinct XDR contract IDs: foreign symbol collisions before/after the valid transfer, actual payment-token balance events rejected in both orders, foreign-only events rejected, duplicate payment-token transfers rejected, informational events from either emitter accepted, missing emitter and malformed payment-token topics rejected. The revised suite exposes 10 failing assertions/cases on the previous PR implementation; all pass after the fix.
- Core/Stellar build, Stellar lint/format, and strict typecheck of the changed source/test file passed.
- Package-wide `tsc --noEmit` reports the same 8 existing mock-type errors in untouched `facilitator-settle.test.ts` as pristine current main `4e156900`.
- Hono comparison, with the same full package test command: original base `241df660` and previous PR head `aff89612` each reproduce 71 passed / 2 failed; current main `4e156900` passes 73/73. Both old failures are response mocks missing `arrayBuffer()`, already corrected by [#3402](https://github.com/x402-foundation/x402/pull/3402). Hono production code is identical across those trees; this PR makes no Hono changes.

The live suite validates existing payment flows; the custom policy-event scenarios use unit-level simulation fixtures, not a newly deployed policy contract.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing Stellar tests pass
- [x] My commits are signed (required for merge)
- [x] I added a changelog fragment for user-facing changes

AI assistance: Codex developed the implementation and tests.
