### PR TITLE
fix(ts): bound HTTP response body reads

### DIFF
--- a/typescript/.changeset/bound-response-body-reads.md
+++ b/typescript/.changeset/bound-response-body-reads.md
@@ -1,0 +1,6 @@
+---
+"@x402/core": patch
+"@x402/extensions": patch
+---
+
+Bound the response bodies buffered by facilitator and Bazaar discovery clients: 1 MiB for control-plane responses (verify, settle, supported) and 4 MiB for discovery pages. A larger body throws `ResponseBodyTooLargeError` and cancels the stream instead of buffering the rest. Ports the Go behavior from #2973 to TypeScript.

--- a/typescript/packages/core/src/http/httpFacilitatorClient.ts
+++ b/typescript/packages/core/src/http/httpFacilitatorClient.ts
@@ -10,6 +10,7 @@ import {
 } from "../types/facilitator";
 import { z } from "../schemas";
 import { safeBase64Decode } from "../utils";
+import { MAX_CONTROL_PLANE_RESPONSE_BYTES, readLimitedText } from "./responseBody";
 
 const DEFAULT_FACILITATOR_URL = "https://x402.org/facilitator";
 /** Default per-request timeout for facilitator HTTP calls, in milliseconds */
@@ -337,7 +338,7 @@ async function parseSuccessResponse<T>(
   schema: z.ZodType<T, z.ZodTypeDef, unknown>,
   operation: string,
 ): Promise<T> {
-  const text = await response.text();
+  const text = await readLimitedText(response, MAX_CONTROL_PLANE_RESPONSE_BYTES);
 
   let data: unknown;
   try {
@@ -421,7 +422,7 @@ export class HTTPFacilitatorClient implements FacilitatorClient {
       });
 
       if (!response.ok) {
-        const text = await response.text();
+        const text = await readLimitedText(response, MAX_CONTROL_PLANE_RESPONSE_BYTES);
         let data: unknown;
         try {
           data = JSON.parse(text);
@@ -479,7 +480,7 @@ export class HTTPFacilitatorClient implements FacilitatorClient {
       });
 
       if (!response.ok) {
-        const text = await response.text();
+        const text = await readLimitedText(response, MAX_CONTROL_PLANE_RESPONSE_BYTES);
         let data: unknown;
         try {
           data = JSON.parse(text);
@@ -536,15 +537,17 @@ export class HTTPFacilitatorClient implements FacilitatorClient {
           };
         }
 
-        const errorText = await response.text().catch((cause: unknown) => {
-          // A deadline abort during the error-body read must surface as a
-          // timeout, not be masked as a generic HTTP failure (which would be
-          // retried for 429). statusText covers other body-read failures.
-          if (isAbortOrTimeoutError(cause)) {
-            throw cause;
-          }
-          return response.statusText;
-        });
+        const errorText = await readLimitedText(response, MAX_CONTROL_PLANE_RESPONSE_BYTES).catch(
+          (cause: unknown) => {
+            // A deadline abort during the error-body read must surface as a
+            // timeout, not be masked as a generic HTTP failure (which would be
+            // retried for 429). statusText covers other body-read failures.
+            if (isAbortOrTimeoutError(cause)) {
+              throw cause;
+            }
+            return response.statusText;
+          },
+        );
         return {
           kind: "http-error" as const,
           status: response.status,

--- a/typescript/packages/core/src/http/index.ts
+++ b/typescript/packages/core/src/http/index.ts
@@ -123,6 +123,11 @@ export {
 } from "../types";
 export { attachBackgroundInitHandler, isFatalStartupInitError } from "./backgroundInit";
 export {
+  MAX_CONTROL_PLANE_RESPONSE_BYTES,
+  ResponseBodyTooLargeError,
+  readLimitedText,
+} from "./responseBody";
+export {
   x402HTTPClient,
   PaymentRequiredContext,
   PaymentRequiredHook,

--- a/typescript/packages/core/src/http/responseBody.ts
+++ b/typescript/packages/core/src/http/responseBody.ts
@@ -1,0 +1,59 @@
+/**
+ * Bounds the facilitator responses buffered by x402 clients. Control-plane JSON
+ * is small, so a tight limit is enough.
+ */
+export const MAX_CONTROL_PLANE_RESPONSE_BYTES = 1 << 20;
+
+/** Raised when a response body exceeds the buffering limit applied by x402 clients. */
+export class ResponseBodyTooLargeError extends Error {
+  /**
+   * Builds the error for a body that exceeded the client's buffering limit.
+   *
+   * @param limit - The byte limit the body exceeded
+   */
+  constructor(limit: number) {
+    super(`http response body too large: limit ${limit} bytes`);
+    this.name = "ResponseBodyTooLargeError";
+  }
+}
+
+/**
+ * Reads a response body as text, stopping once it exceeds `limit` bytes.
+ *
+ * A body over the limit throws ResponseBodyTooLargeError and cancels the stream
+ * rather than buffering the rest. Bodyless responses have nothing to bound.
+ *
+ * @param response - The response whose body is read
+ * @param limit - Maximum number of bytes to buffer
+ * @returns The decoded body text
+ */
+export async function readLimitedText(response: Response, limit: number): Promise<string> {
+  if (!response.body) {
+    return response.text();
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    total += value.byteLength;
+    if (total > limit) {
+      await reader.cancel();
+      throw new ResponseBodyTooLargeError(limit);
+    }
+    chunks.push(value);
+  }
+
+  const buffer = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    buffer.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(buffer);
+}

--- a/typescript/packages/core/test/unit/http/httpFacilitatorClient.test.ts
+++ b/typescript/packages/core/test/unit/http/httpFacilitatorClient.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { HTTPFacilitatorClient, computeRetryDelay } from "../../../src/http/httpFacilitatorClient";
+import { ResponseBodyTooLargeError } from "../../../src/http/responseBody";
 import {
   FacilitatorResponseError,
   FacilitatorTimeoutError,
@@ -322,6 +323,26 @@ describe("HTTPFacilitatorClient", () => {
       expect(mockFetch).toHaveBeenCalledWith(
         "https://facilitator.test/supported",
         expect.objectContaining({ redirect: "follow" }),
+      );
+    });
+
+    it("rejects a verify success body over the control-plane limit", async () => {
+      const oversized = JSON.stringify({ isValid: true, pad: "a".repeat(1024 * 1024) });
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(oversized, { status: 200 })));
+
+      const client = new HTTPFacilitatorClient({ url: "https://facilitator.test" });
+      await expect(client.verify(paymentPayload, paymentRequirements)).rejects.toThrow(
+        ResponseBodyTooLargeError,
+      );
+    });
+
+    it("rejects a verify error body over the control-plane limit", async () => {
+      const oversized = JSON.stringify({ isValid: false, pad: "a".repeat(1024 * 1024) });
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(oversized, { status: 400 })));
+
+      const client = new HTTPFacilitatorClient({ url: "https://facilitator.test" });
+      await expect(client.verify(paymentPayload, paymentRequirements)).rejects.toThrow(
+        ResponseBodyTooLargeError,
       );
     });
 

--- a/typescript/packages/core/test/unit/http/responseBody.test.ts
+++ b/typescript/packages/core/test/unit/http/responseBody.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import {
+  MAX_CONTROL_PLANE_RESPONSE_BYTES,
+  ResponseBodyTooLargeError,
+  readLimitedText,
+} from "../../../src/http/responseBody";
+
+/**
+ * Builds a response whose body arrives in chunks, so the reader cannot rely on
+ * Content-Length.
+ *
+ * @param chunks - Byte chunks delivered in order
+ * @returns A response streaming those chunks
+ */
+function streamed(chunks: Uint8Array[]): Response {
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(chunk);
+      }
+      controller.close();
+    },
+  });
+  return new Response(stream);
+}
+
+describe("readLimitedText", () => {
+  it("returns a body under the limit", async () => {
+    await expect(readLimitedText(new Response("payload"), 32)).resolves.toBe("payload");
+  });
+
+  it("returns a body exactly at the limit", async () => {
+    const body = "a".repeat(64);
+    await expect(readLimitedText(new Response(body), 64)).resolves.toBe(body);
+  });
+
+  it("rejects a body one byte over the limit", async () => {
+    await expect(readLimitedText(new Response("a".repeat(65)), 64)).rejects.toThrow(
+      ResponseBodyTooLargeError,
+    );
+  });
+
+  it("rejects an oversized chunked body that declares no Content-Length", async () => {
+    const chunk = new Uint8Array(32).fill(97);
+    const response = streamed([chunk, chunk, chunk]);
+    expect(response.headers.get("content-length")).toBeNull();
+    await expect(readLimitedText(response, 64)).rejects.toThrow(ResponseBodyTooLargeError);
+  });
+
+  it("decodes a multi-byte character split across chunks", async () => {
+    const euro = new TextEncoder().encode("€");
+    const response = streamed([euro.slice(0, 1), euro.slice(1)]);
+    await expect(readLimitedText(response, 64)).resolves.toBe("€");
+  });
+
+  it("returns an empty string for a bodyless response", async () => {
+    const response = new Response(null, { status: 204 });
+    expect(response.body).toBeNull();
+    await expect(readLimitedText(response, 64)).resolves.toBe("");
+  });
+
+  it("bounds control-plane responses at 1 MiB", () => {
+    expect(MAX_CONTROL_PLANE_RESPONSE_BYTES).toBe(1024 * 1024);
+  });
+});

--- a/typescript/packages/extensions/src/bazaar/facilitatorClient.ts
+++ b/typescript/packages/extensions/src/bazaar/facilitatorClient.ts
@@ -2,9 +2,15 @@
  * Client extensions for querying Bazaar discovery resources
  */
 
-import { HTTPFacilitatorClient } from "@x402/core/http";
+import { HTTPFacilitatorClient, readLimitedText } from "@x402/core/http";
 import type { PaymentRequirements } from "@x402/core/types";
 import { WithExtensions } from "../types";
+
+/**
+ * Bounds discovery responses. Catalog pages carry resource extensions and MCP
+ * JSON schemas, so they need more room than control-plane JSON.
+ */
+const MAX_DISCOVERY_RESPONSE_BYTES = 4 << 20;
 
 /**
  * Parameters for listing discovery resources.
@@ -260,13 +266,17 @@ export function withBazaar<T extends HTTPFacilitatorClient>(
         });
 
         if (!response.ok) {
-          const errorText = await response.text().catch(() => response.statusText);
+          const errorText = await readLimitedText(response, MAX_DISCOVERY_RESPONSE_BYTES).catch(
+            () => response.statusText,
+          );
           throw new Error(
             `Facilitator listDiscoveryResources failed (${response.status}): ${errorText}`,
           );
         }
 
-        return (await response.json()) as DiscoveryResourcesResponse;
+        return JSON.parse(
+          await readLimitedText(response, MAX_DISCOVERY_RESPONSE_BYTES),
+        ) as DiscoveryResourcesResponse;
       },
 
       async search(
@@ -311,13 +321,17 @@ export function withBazaar<T extends HTTPFacilitatorClient>(
         });
 
         if (!response.ok) {
-          const errorText = await response.text().catch(() => response.statusText);
+          const errorText = await readLimitedText(response, MAX_DISCOVERY_RESPONSE_BYTES).catch(
+            () => response.statusText,
+          );
           throw new Error(
             `Facilitator searchDiscoveryResources failed (${response.status}): ${errorText}`,
           );
         }
 
-        return (await response.json()) as SearchDiscoveryResourcesResponse;
+        return JSON.parse(
+          await readLimitedText(response, MAX_DISCOVERY_RESPONSE_BYTES),
+        ) as SearchDiscoveryResourcesResponse;
       },
     },
   } as WithExtensions<T, BazaarClientExtension>["extensions"];

--- a/typescript/packages/extensions/test/facilitatorClient.test.ts
+++ b/typescript/packages/extensions/test/facilitatorClient.test.ts
@@ -227,10 +227,7 @@ describe("Bazaar Client Extension - facilitatorClient", () => {
           pagination: { limit: 20, offset: 0, total: 0 },
         };
 
-        mockFetch.mockResolvedValue({
-          ok: true,
-          json: () => Promise.resolve(mockResponse),
-        });
+        mockFetch.mockResolvedValue(new Response(JSON.stringify(mockResponse), { status: 200 }));
 
         const facilitatorClient = new HTTPFacilitatorClient({
           url: "https://x402.org/facilitator",
@@ -253,10 +250,7 @@ describe("Bazaar Client Extension - facilitatorClient", () => {
           pagination: { limit: 10, offset: 5, total: 100 },
         };
 
-        mockFetch.mockResolvedValue({
-          ok: true,
-          json: () => Promise.resolve(mockResponse),
-        });
+        mockFetch.mockResolvedValue(new Response(JSON.stringify(mockResponse), { status: 200 }));
 
         const facilitatorClient = new HTTPFacilitatorClient({
           url: "https://x402.org/facilitator",
@@ -331,10 +325,7 @@ describe("Bazaar Client Extension - facilitatorClient", () => {
           },
         };
 
-        mockFetch.mockResolvedValue({
-          ok: true,
-          json: () => Promise.resolve(mockResponse),
-        });
+        mockFetch.mockResolvedValue(new Response(JSON.stringify(mockResponse), { status: 200 }));
 
         const facilitatorClient = new HTTPFacilitatorClient({
           url: "https://x402.org/facilitator",
@@ -354,6 +345,19 @@ describe("Bazaar Client Extension - facilitatorClient", () => {
       });
     });
 
+    it("rejects a discovery body over the 4 MiB limit", async () => {
+      const oversized = JSON.stringify({ items: "a".repeat(4 * 1024 * 1024) });
+      mockFetch.mockResolvedValue(new Response(oversized, { status: 200 }));
+
+      const extendedClient = withBazaar(
+        new HTTPFacilitatorClient({ url: "https://x402.org/facilitator" }),
+      );
+
+      await expect(extendedClient.extensions.bazaar.listResources()).rejects.toThrow(
+        /http response body too large/,
+      );
+    });
+
     describe("search", () => {
       it("should call correct endpoint with required query param", async () => {
         const mockResponse: SearchDiscoveryResourcesResponse = {
@@ -361,10 +365,7 @@ describe("Bazaar Client Extension - facilitatorClient", () => {
           resources: [],
         };
 
-        mockFetch.mockResolvedValue({
-          ok: true,
-          json: () => Promise.resolve(mockResponse),
-        });
+        mockFetch.mockResolvedValue(new Response(JSON.stringify(mockResponse), { status: 200 }));
 
         const facilitatorClient = new HTTPFacilitatorClient({
           url: "https://x402.org/facilitator",
@@ -390,10 +391,7 @@ describe("Bazaar Client Extension - facilitatorClient", () => {
           pagination: { limit: 10, cursor: "eyJwYWdlIjoyfQ==" },
         };
 
-        mockFetch.mockResolvedValue({
-          ok: true,
-          json: () => Promise.resolve(mockResponse),
-        });
+        mockFetch.mockResolvedValue(new Response(JSON.stringify(mockResponse), { status: 200 }));
 
         const facilitatorClient = new HTTPFacilitatorClient({
           url: "https://x402.org/facilitator",
@@ -454,10 +452,7 @@ describe("Bazaar Client Extension - facilitatorClient", () => {
           pagination: { limit: 10, cursor: "nextPageToken" },
         };
 
-        mockFetch.mockResolvedValue({
-          ok: true,
-          json: () => Promise.resolve(mockResponse),
-        });
+        mockFetch.mockResolvedValue(new Response(JSON.stringify(mockResponse), { status: 200 }));
 
         const facilitatorClient = new HTTPFacilitatorClient({
           url: "https://x402.org/facilitator",


### PR DESCRIPTION
## Description

Ports the bounded response-body reads from #2973 (Go) to the TypeScript SDK. Addresses the first unchecked item in #3361.

Root cause: `typescript/packages/core/src/http/httpFacilitatorClient.ts:340` (and the error paths at 424, 482, 539) buffer the entire facilitator reply with `response.text()`, and `typescript/packages/extensions/src/bazaar/facilitatorClient.ts:269,320` do the same with `response.json()`. A facilitator returning an oversized body holds the client's memory for as long as it keeps writing. Go bounded these reads on 2026-09-03; TypeScript was never ported.

Same tiered limits as Go: 1 MiB for control-plane responses (verify, settle, supported), 4 MiB for Bazaar discovery pages. `readLimitedText` streams the body and cancels at the limit rather than buffering the rest, so the bound holds for chunked replies that declare no `Content-Length`.

Two deliberate differences from the Go change:

- Go reads each body once and then branches, so bounding the success path bounded the error path with it. In TypeScript the error paths issue their own `response.text()`, so they are bounded explicitly.
- `x402HTTPClient.processResponse` is left unbounded. It reads the resource's own payload, not control-plane JSON, and a 1 MiB cap there would truncate paid content.

Six Bazaar tests mocked `fetch` with objects carrying only `json()`. A real `Response` always has `text()` and a body stream, so those mocks are now real `Response` objects.

Python is not included here; it has the same gap and is better as a separate PR.

## Tests

`test/unit/http/responseBody.test.ts` (new) covers under-limit, exactly-at-limit, one-byte-over, an oversized chunked body with no `Content-Length`, a multi-byte character split across chunks, and a bodyless response. Integration cases in `httpFacilitatorClient.test.ts` and `facilitatorClient.test.ts` drive oversized verify success, verify error, and Bazaar discovery replies through the clients.

Each new test was checked against five deliberately wrong implementations, and each wrong one turns tests red: the unbounded pre-fix read, an off-by-one at the boundary (`>=`), trusting `Content-Length` instead of counting bytes, decoding each chunk separately, and bounding only the success path.

```
pnpm -C packages/core test         25 files, 742 tests, all passing
pnpm -C packages/extensions test    9 files, 535 tests, all passing
pnpm -C packages/core format:check && pnpm -C packages/core lint:check       clean
pnpm -C packages/extensions format:check && pnpm -C packages/extensions lint:check   clean
```

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed
- [x] I added a changelog fragment (`typescript/.changeset/bound-response-body-reads.md`)

AI-assisted per CONTRIBUTING.md: the implementation and tests were drafted with an AI coding agent and reviewed by me before opening this PR.
