### PR TITLE
feat: replay-protection extension — server-side TOCTOU enforcement

### DIFF
--- a/python/x402/replay_protection.py
+++ b/python/x402/replay_protection.py
@@ -1,0 +1,115 @@
+"""Replay protection store for x402 resource servers.
+
+Provides server-side enforcement to prevent payment proof replay attacks
+during the HTTP-layer TOCTOU window (between verification and settlement).
+
+See specs/extensions/replay-protection.md for the full specification.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import threading
+import time
+from typing import Protocol, runtime_checkable
+
+# Default TTL for nonce entries (5 minutes).
+# Matches PendingSettlementStore TTL — both cover the verify→settle window.
+REPLAY_PROTECTION_TTL_SECONDS = 300.0
+
+
+@runtime_checkable
+class ReplayProtectionStore(Protocol):
+    """Protocol for a replay protection store.
+
+    Implementations must be safe for concurrent use.
+    """
+
+    def is_duplicate(self, nonce: str) -> bool:
+        """Check if nonce was already seen. If not, record it and return False.
+
+        Returns True when the nonce is a replay (already seen and not expired).
+        """
+        ...
+
+    def stats(self) -> dict:
+        """Return store stats for monitoring."""
+        ...
+
+
+class InMemoryReplayProtectionStore:
+    """Default ReplayProtectionStore implementation.
+
+    A lock-protected, per-process dict with lazy TTL pruning.
+    Never performs network I/O — suitable for single-instance resource servers.
+    Multi-instance deployments should inject a shared, network-backed
+    ReplayProtectionStore implementation (e.g. Redis).
+    """
+
+    def __init__(self, ttl: float = REPLAY_PROTECTION_TTL_SECONDS) -> None:
+        self._seen: dict[str, float] = {}  # nonce -> monotonic timestamp
+        self._lock = threading.Lock()
+        self._ttl = ttl
+
+    def is_duplicate(self, nonce: str) -> bool:
+        with self._lock:
+            self._prune()
+            if nonce in self._seen:
+                return True  # REPLAY DETECTED
+            self._seen[nonce] = time.monotonic()
+            return False
+
+    def stats(self) -> dict:
+        with self._lock:
+            self._prune()
+            return {
+                "active_nonces": len(self._seen),
+                "ttl_seconds": self._ttl,
+                "store": "in_memory",
+            }
+
+    def _prune(self) -> None:
+        """Remove entries older than TTL. Caller must hold lock."""
+        cutoff = time.monotonic() - self._ttl
+        expired = [k for k, v in self._seen.items() if v < cutoff]
+        for k in expired:
+            del self._seen[k]
+
+
+def extract_nonce(payload: dict) -> str:
+    """Extract a deterministic nonce from a payment payload.
+
+    The nonce is used as the replay protection key. For schemes where
+    the authorization nonce is directly available (EIP-3009, Permit2),
+    it is used directly. For opaque payloads, a SHA-256 hash is used.
+
+    Args:
+        payload: The payment payload dict (from PAYMENT-SIGNATURE header).
+
+    Returns:
+        A string nonce suitable for replay detection.
+    """
+    # Try EIP-3009 authorization nonce
+    if "authorization" in payload:
+        auth = payload["authorization"]
+        if isinstance(auth, dict) and "nonce" in auth:
+            return str(auth["nonce"]).strip().lower()
+
+    # Try Permit2 authorization nonce
+    if "permit2Authorization" in payload:
+        p2 = payload["permit2Authorization"]
+        if isinstance(p2, dict) and "nonce" in p2:
+            return str(p2["nonce"]).strip().lower()
+
+    # Fallback: hash the entire payload
+    import json
+    normalized = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:16]
+
+
+__all__ = [
+    "REPLAY_PROTECTION_TTL_SECONDS",
+    "ReplayProtectionStore",
+    "InMemoryReplayProtectionStore",
+    "extract_nonce",
+]

--- a/python/x402/tests/test_replay_protection.py
+++ b/python/x402/tests/test_replay_protection.py
@@ -1,0 +1,157 @@
+"""Tests for x402 replay protection."""
+
+import time
+
+from x402.replay_protection import (
+    InMemoryReplayProtectionStore,
+    extract_nonce,
+)
+
+
+class TestInMemoryReplayProtectionStore:
+    """Test the in-memory replay protection store."""
+
+    def test_first_use_returns_false(self):
+        store = InMemoryReplayProtectionStore()
+        assert store.is_duplicate("nonce-1") is False
+
+    def test_second_use_returns_true(self):
+        store = InMemoryReplayProtectionStore()
+        store.is_duplicate("nonce-1")
+        assert store.is_duplicate("nonce-1") is True
+
+    def test_different_nonces_both_pass(self):
+        store = InMemoryReplayProtectionStore()
+        assert store.is_duplicate("nonce-1") is False
+        assert store.is_duplicate("nonce-2") is False
+
+    def test_same_nonce_different_stores_pass(self):
+        store1 = InMemoryReplayProtectionStore()
+        store2 = InMemoryReplayProtectionStore()
+        store1.is_duplicate("nonce-1")
+        # Different store — not a replay
+        assert store2.is_duplicate("nonce-1") is False
+
+    def test_stats_tracks_active_nonces(self):
+        store = InMemoryReplayProtectionStore()
+        stats = store.stats()
+        assert stats["active_nonces"] == 0
+
+        store.is_duplicate("nonce-1")
+        stats = store.stats()
+        assert stats["active_nonces"] == 1
+
+        store.is_duplicate("nonce-2")
+        stats = store.stats()
+        assert stats["active_nonces"] == 2
+
+    def test_stats_includes_ttl(self):
+        store = InMemoryReplayProtectionStore(ttl=600)
+        stats = store.stats()
+        assert stats["ttl_seconds"] == 600
+
+    def test_ttl_expiry_allows_reuse(self):
+        store = InMemoryReplayProtectionStore(ttl=0.1)  # 100ms
+        store.is_duplicate("nonce-1")
+        time.sleep(0.15)
+        # Nonce expired — should pass again
+        assert store.is_duplicate("nonce-1") is False
+
+    def test_prune_removes_expired(self):
+        store = InMemoryReplayProtectionStore(ttl=0.1)
+        store.is_duplicate("nonce-1")
+        store.is_duplicate("nonce-2")
+        assert store.stats()["active_nonces"] == 2
+
+        time.sleep(0.15)
+        # Trigger prune via stats
+        stats = store.stats()
+        assert stats["active_nonces"] == 0
+
+    def test_store_type_in_stats(self):
+        store = InMemoryReplayProtectionStore()
+        assert store.stats()["store"] == "in_memory"
+
+
+class TestExtractNonce:
+    """Test nonce extraction from payment payloads."""
+
+    def test_eip3009_nonce(self):
+        payload = {
+            "authorization": {
+                "nonce": "0xf3746613c2d920b5fdabc0856f2aeb2d4f88ee6037b8cc5d04a71a4462f13480"
+            }
+        }
+        nonce = extract_nonce(payload)
+        assert nonce == "0xf3746613c2d920b5fdabc0856f2aeb2d4f88ee6037b8cc5d04a71a4462f13480"
+
+    def test_permit2_nonce(self):
+        payload = {
+            "permit2Authorization": {
+                "nonce": "33247007178036348590600198031289925668252061821958005840077069883511451257277"
+            }
+        }
+        nonce = extract_nonce(payload)
+        assert nonce == "33247007178036348590600198031289925668252061821958005840077069883511451257277"
+
+    def test_fallback_hash(self):
+        payload = {"signature": "0xabc123", "data": "some-value"}
+        nonce1 = extract_nonce(payload)
+        nonce2 = extract_nonce(payload)
+        # Same payload → same hash
+        assert nonce1 == nonce2
+        # Hash is 16 hex chars
+        assert len(nonce1) == 16
+
+    def test_different_payloads_different_hashes(self):
+        p1 = {"signature": "0xaaa"}
+        p2 = {"signature": "0xbbb"}
+        assert extract_nonce(p1) != extract_nonce(p2)
+
+    def test_nonce_normalization(self):
+        """Whitespace and case are normalized."""
+        payload1 = {"authorization": {"nonce": "  0xABC  "}}
+        payload2 = {"authorization": {"nonce": "0xabc"}}
+        assert extract_nonce(payload1) == extract_nonce(payload2)
+
+    def test_eip3009_takes_precedence(self):
+        """If both authorization and permit2Authorization exist, prefer EIP-3009."""
+        payload = {
+            "authorization": {"nonce": "0xaaa"},
+            "permit2Authorization": {"nonce": "0xbbb"},
+        }
+        nonce = extract_nonce(payload)
+        assert nonce == "0xaaa"
+
+
+class TestReplayProtectionIntegration:
+    """Integration tests combining store + nonce extraction."""
+
+    def test_full_flow_first_request(self):
+        store = InMemoryReplayProtectionStore()
+        payload = {
+            "authorization": {
+                "nonce": "0xf3746613c2d920b5fdabc0856f2aeb2d4f88ee6037b8cc5d04a71a4462f13480"
+            }
+        }
+        nonce = extract_nonce(payload)
+        assert store.is_duplicate(nonce) is False
+
+    def test_full_flow_duplicate_rejected(self):
+        store = InMemoryReplayProtectionStore()
+        payload = {
+            "authorization": {
+                "nonce": "0xf3746613c2d920b5fdabc0856f2aeb2d4f88ee6037b8cc5d04a71a4462f13480"
+            }
+        }
+        nonce = extract_nonce(payload)
+        store.is_duplicate(nonce)
+        assert store.is_duplicate(nonce) is True
+
+    def test_full_flow_different_proofs_pass(self):
+        store = InMemoryReplayProtectionStore()
+        p1 = {"authorization": {"nonce": "0xaaa"}}
+        p2 = {"authorization": {"nonce": "0xbbb"}}
+
+        assert store.is_duplicate(extract_nonce(p1)) is False
+        assert store.is_duplicate(extract_nonce(p2)) is False

--- a/specs/extensions/replay-protection.md
+++ b/specs/extensions/replay-protection.md
@@ -1,0 +1,302 @@
+# Extension: `replay-protection`
+
+## Summary
+
+The `replay-protection` extension adds server-side enforcement to prevent payment proof replay attacks during the HTTP-layer TOCTOU window — the time between payment verification and blockchain settlement.
+
+While on-chain nonces (EIP-3009, Permit2) prevent replay **after** settlement, and the `payment-identifier` extension provides client-side idempotency keys, neither prevents a malicious client from submitting the same valid payment proof to multiple endpoints or servers before settlement completes.
+
+This extension provides a server-side mechanism that:
+1. Extracts a deterministic nonce from the payment proof
+2. Tracks seen nonces in a server-side store
+3. Rejects duplicate proofs with `409 Conflict` before any processing
+
+---
+
+## Motivation
+
+### The TOCTOU Window
+
+The x402 payment flow has a window between verification and settlement:
+
+```
+Client → Resource Server: PAYMENT-SIGNATURE header
+Resource Server → Facilitator: /verify
+Facilitator → Resource Server: valid
+                              ← TOCTOU WINDOW →
+Resource Server → Facilitator: /settle
+Facilitator → Blockchain: broadcast
+```
+
+During this window (typically 100-2000ms), the same payment proof could be:
+- Submitted to the same server multiple times (replay)
+- Submitted to different servers (parallel spend attempt)
+- Intercepted and replayed by a network attacker
+
+On-chain nonces prevent double-spending **after** settlement, but during the TOCTOU window, the same proof can trigger multiple verify/settle cycles, wasting gas and potentially causing confusion.
+
+### Why `payment-identifier` Is Not Sufficient
+
+The existing `payment-identifier` extension is:
+- **Optional** — servers cannot enforce it without client cooperation
+- **Client-generated** — a malicious client can send different identifiers for the same proof
+- **Response-caching focused** — designed for idempotency, not security enforcement
+
+### What `replay-protection` Adds
+
+- **Mandatory server-side enforcement** — the server tracks seen nonces regardless of client behavior
+- **Proof-derived nonces** — extracted from the cryptographic proof itself, not client-provided
+- **Instant rejection** — `409 Conflict` before facilitator call, saving gas and processing
+
+---
+
+## Specification
+
+### Nonce Extraction
+
+The nonce is extracted deterministically from the payment proof:
+
+| Scheme | Nonce Source | Derivation |
+|--------|-------------|------------|
+| `exact` (EIP-3009) | `payload.authorization.nonce` | Direct use (32-byte hex) |
+| `exact` (Permit2) | `payload.permit2Authorization.nonce` | Direct use (uint256) |
+| `exact` (ERC-7710) | `payload.permissionContext` | SHA-256 hash (opaque bytes) |
+| `upto` | `payload.authorization.nonce` | Direct use (32-byte hex) |
+| `batch-settlement` | Voucher signature | SHA-256 of signed voucher |
+
+For schemes where the nonce is not directly available (or is opaque), the server computes:
+```
+nonce_hash = SHA-256(normalize(payload))[:16]
+```
+
+Where `normalize()` strips whitespace and lowercases hex strings.
+
+### Server-Side Store
+
+Servers maintain a `ReplayProtectionStore`:
+
+```python
+class ReplayProtectionStore(Protocol):
+    """Thread-safe store for tracking seen payment nonces."""
+
+    def is_duplicate(self, nonce: str) -> bool:
+        """Check if nonce was already seen. If not, record it and return False."""
+        ...
+
+    def stats(self) -> dict:
+        """Return store stats for monitoring."""
+        ...
+```
+
+The store must be:
+- **Thread-safe** — safe for concurrent HTTP requests
+- **TTL-based** — entries expire after a configurable period (default: 300 seconds)
+- **Per-process** for single-instance servers, or **shared** (e.g., Redis) for multi-instance
+
+### Extension Registration
+
+Servers advertise support in `PaymentRequired`:
+
+```json
+{
+  "extensions": {
+    "replay-protection": {
+      "info": {
+        "required": true,
+        "ttl_seconds": 300
+      }
+    }
+  }
+}
+```
+
+### Client Behavior
+
+Clients do NOT need to send anything special for replay-protection. The server extracts nonces from the existing `PaymentPayload` fields.
+
+However, clients that also use `payment-identifier` benefit from:
+- Client-side idempotency (same proof, same id → cached response)
+- Server-side enforcement (same proof, any id → `409 Conflict`)
+
+### Response Codes
+
+| Scenario | Response |
+|----------|----------|
+| New nonce | Process normally |
+| Duplicate nonce (same endpoint) | `409 Conflict` |
+| Duplicate nonce (different endpoint) | `409 Conflict` |
+| Duplicate nonce after TTL expiry | Process normally (nonce evicted) |
+
+### `409 Conflict` Response Body
+
+```json
+{
+  "error": "Payment proof already used",
+  "detail": "Each payment proof can only be used once. This proof was previously submitted.",
+  "nonce": "e99a18c428cb38d5f260853678922e03",
+  "hint": "Generate a new payment proof for this request."
+}
+```
+
+---
+
+## Integration with Existing Components
+
+### Relationship to `PendingSettlementStore`
+
+The `PendingSettlementStore` tracks **broadcast-but-not-confirmed** transactions for retry. The `ReplayProtectionStore` tracks **verified-but-not-settled** proofs for replay prevention. They serve different purposes:
+
+| Store | Purpose | Key | TTL |
+|-------|---------|-----|-----|
+| `PendingSettlementStore` | Retry failed settlements | tx_hash | 300s |
+| `ReplayProtectionStore` | Block replay attacks | proof_nonce | 300s |
+
+### Relationship to `payment-identifier`
+
+| Feature | `payment-identifier` | `replay-protection` |
+|---------|---------------------|---------------------|
+| Direction | Client → Server | Server-side only |
+| Enforcement | Optional | Mandatory |
+| Nonce source | Client-generated | Proof-derived |
+| Purpose | Idempotency | Security |
+| Can coexist | Yes | Yes |
+
+---
+
+## Implementation Guide
+
+### Python SDK
+
+Add to `python/x402/replay_protection.py`:
+
+```python
+import hashlib
+import threading
+import time
+
+class InMemoryReplayProtectionStore:
+    """Default replay protection store (single-instance)."""
+
+    def __init__(self, ttl: int = 300):
+        self._seen: dict[str, float] = {}
+        self._lock = threading.Lock()
+        self._ttl = ttl
+
+    def is_duplicate(self, nonce: str) -> bool:
+        with self._lock:
+            self._prune()
+            if nonce in self._seen:
+                return True
+            self._seen[nonce] = time.monotonic()
+            return False
+
+    def stats(self) -> dict:
+        with self._lock:
+            self._prune()
+            return {"active_nonces": len(self._seen), "ttl_seconds": self._ttl}
+
+    def _prune(self):
+        cutoff = time.monotonic() - self._ttl
+        expired = [k for k, v in self._seen.items() if v < cutoff]
+        for k in expired:
+            del self._seen[k]
+```
+
+### Integration Point
+
+In `x402ResourceServer.verify_payment()`, before calling the facilitator:
+
+```python
+# Check replay protection
+if self._replay_store and self._replay_store.is_duplicate(extracted_nonce):
+    return ResourceVerifyResponse(
+        is_valid=False,
+        invalid_reason="Payment proof already used",
+    )
+```
+
+---
+
+## Security Analysis
+
+### What This Prevents
+
+1. **HTTP-layer replay** — same proof submitted to same server multiple times
+2. **Parallel spend** — same proof submitted to different endpoints before settlement
+3. **Gas waste** — facilitator doesn't waste gas verifying already-seen proofs
+
+### What This Does NOT Prevent
+
+1. **Post-settlement replay** — on-chain nonces handle this
+2. **Client-side proof sharing** — if a client shares their proof, others can use it once (until first settlement)
+3. **Sybil attacks** — multiple clients creating multiple proofs (requires rate limiting)
+
+### Trust Assumptions
+
+- The server is trusted to maintain the store honestly
+- The store is per-process (or shared via Redis for multi-instance)
+- TTL-based expiry is acceptable (not permanent deduplication)
+
+---
+
+## Test Vectors
+
+### Test 1: First Request Passes
+
+```json
+// Request 1
+POST /v1/premium-data
+X-PAYMENT: {"scheme":"exact","network":"eip155:8453",...}
+
+// Response: 200 OK
+```
+
+### Test 2: Duplicate Rejected
+
+```json
+// Request 1 (same proof)
+POST /v1/premium-data
+X-PAYMENT: {"scheme":"exact","network":"eip155:8453",...}
+
+// Response: 200 OK
+
+// Request 2 (identical proof)
+POST /v1/premium-data
+X-PAYMENT: {"scheme":"exact","network":"eip155:8453",...}
+
+// Response: 409 Conflict
+```
+
+### Test 3: Different Proofs Both Pass
+
+```json
+// Request 1 (proof A)
+POST /v1/premium-data
+X-PAYMENT: {"scheme":"exact","network":"eip155:8453","payload":{"authorization":{"nonce":"0xaaa..."},...}}
+
+// Response: 200 OK
+
+// Request 2 (proof B)
+POST /v1/premium-data
+X-PAYMENT: {"scheme":"exact","network":"eip155:8453","payload":{"authorization":{"nonce":"0xbbb..."},...}}
+
+// Response: 200 OK
+```
+
+### Test 4: TTL Expiry
+
+```json
+// Request 1
+POST /v1/premium-data
+X-PAYMENT: {...}
+
+// Response: 200 OK
+
+// Wait 301 seconds (TTL = 300s)
+
+// Request 2 (same proof)
+POST /v1/premium-data
+X-PAYMENT: {...}
+
+// Response: 200 OK (nonce evicted)
+```


### PR DESCRIPTION
## Summary

Adds a  extension that provides **mandatory server-side enforcement** against payment proof replay attacks during the HTTP-layer TOCTOU window (between verification and settlement).

## Motivation

The x402 spec (§10.1) covers on-chain replay prevention via EIP-3009 nonces and blockchain protection. However, there is no protection against replay **before settlement** — the window where a valid proof could be submitted multiple times.

The existing  extension is client-side and optional. This extension provides **mandatory server-side enforcement** that works regardless of client behavior.

## What This Adds

| Layer | Protection | Status |
|-------|-----------|--------|
| On-chain (EIP-3009 nonce) | Prevents double-spend after settlement | ✅ Existing |
| Client-side () | Optional idempotency key | ✅ Existing |
| **Server-side ()** | **Blocks replay before settlement** | **🆕 This PR** |

## Files

- `specs/extensions/replay-protection.md` — Full specification
- `python/x402/replay_protection.py` — Python implementation
- `python/x402/tests/test_replay_protection.py` — Tests

## How It Works

1. Server extracts nonce from payment proof (EIP-3009 `authorization.nonce`, Permit2 `permit2Authorization.nonce`, or SHA-256 fallback)
2. Nonce is checked against a thread-safe store with TTL eviction
3. First use: passes. Duplicate: `409 Conflict` instantly (no facilitator call)

## Relationship to Existing Components

- **Complements** `PendingSettlementStore` (retry logic) with replay prevention
- **Complements** `payment-identifier` (client idempotency) with server enforcement
- **Does not conflict** with on-chain nonces — different layer of protection

## Note

This is a Draft PR for discussion. I run a production x402 resource server on Base Mainnet (120 endpoints) and implemented this protection after observing the TOCTOU window in practice. Happy to discuss the approach, adjust the spec, or split into separate spec + implementation PRs.

---

*AI-assisted: Spec and implementation drafted with AI assistance, reviewed and validated against production x402 deployment.*