### PR TITLE
fix(hono): settlement-failure tests construct a real Response

### DIFF
--- a/typescript/packages/http/hono/src/index.test.ts
+++ b/typescript/packages/http/hono/src/index.test.ts
@@ -871,13 +871,11 @@ describe("paymentMiddleware", () => {
     );
     const context = createMockContext();
     const next = vi.fn().mockImplementation(async () => {
-      context.res = {
-        status: 200,
-        headers: new Headers(),
-        clone: () => ({
-          arrayBuffer: async () => new ArrayBuffer(0),
-        }),
-      } as unknown as Response;
+      // A real Response: the middleware buffers it via res.arrayBuffer()
+      // (settlement-reply buffering, #3392), so a hand-rolled object without
+      // that method throws and falls into the generic JSON-402 catch instead
+      // of exercising the settlement-failure path under test.
+      context.res = new Response(null, { status: 200 });
     });
 
     await middleware(context, next);
@@ -906,13 +904,11 @@ describe("paymentMiddleware", () => {
     );
     const context = createMockContext();
     const next = vi.fn().mockImplementation(async () => {
-      context.res = {
-        status: 200,
-        headers: new Headers(),
-        clone: () => ({
-          arrayBuffer: async () => new ArrayBuffer(0),
-        }),
-      } as unknown as Response;
+      // A real Response: the middleware buffers it via res.arrayBuffer()
+      // (settlement-reply buffering, #3392), so a hand-rolled object without
+      // that method throws and falls into the generic JSON-402 catch instead
+      // of exercising the settlement-failure path under test.
+      context.res = new Response(null, { status: 200 });
     });
 
     await middleware(context, next);


### PR DESCRIPTION
## Summary

Two Hono settlement-failure tests added in #3393 fail on pristine `main` at `241df66`:

- `returns HTML when settlement fails with isHtml`
- `returns 502 when settlement surfaces FacilitatorResponseError`

The fixtures provide `arrayBuffer()` only on the object returned by `clone()`, but #3392 changed [index.ts#L284](https://github.com/x402-foundation/x402/blob/241df66/typescript/packages/http/hono/src/index.ts#L284) to call `res.arrayBuffer()` directly. Instrumentation captured `TypeError: res.arrayBuffer is not a function`; the generic catch returns the JSON 402 fallback before `processSettlement()` runs.

## Fix

Both fixtures now construct a real `Response`, with comments explaining the required method. The existing HTML and 502 assertions pass against the unchanged middleware and exercise the intended settlement-failure paths.

## Verification

- `pnpm test` in `typescript/packages/http/hono`: 71 passed / 2 failed on pristine `main` at `241df66`; 73/73 passed after the fix.
- Prettier clean.
- Test-only: 1 file changed, +10/−14.
