### PR TITLE
feat: add generic ASGI middleware for any ASGI framework

### DIFF
--- a/python/x402/http/middleware/README.md
+++ b/python/x402/http/middleware/README.md
@@ -119,14 +119,73 @@ from x402.http.middleware import payment_middleware
 payment_middleware(app, routes, server, paywall_config={"appName": "My API"})
 ```
 
+## Generic ASGI (Any ASGI Framework)
+
+Works with Litestar, BlackSheep, Quart, or any raw ASGI app. No framework-specific dependencies.
+
+### Basic Usage
+
+```python
+from x402 import x402ResourceServerSync
+from x402.http import HTTPFacilitatorClientSync
+from x402.http.middleware.asgi import X402ASGIMiddleware
+from x402.mechanisms.evm.exact import ExactEvmServerScheme
+
+# Your ASGI app (Litestar, BlackSheep, Quart, etc.)
+async def app(scope, receive, send):
+    ...
+
+# Configure server (sync variant required for ASGI middleware)
+facilitator = HTTPFacilitatorClientSync(url="https://x402.org/facilitator")
+server = x402ResourceServerSync(facilitator)
+server.register("eip155:*", ExactEvmServerScheme())
+
+# Define routes
+routes = {
+    "GET /api/weather/*": {
+        "accepts": {
+            "scheme": "exact",
+            "payTo": "0x...",
+            "price": "$0.01",
+            "network": "eip155:84532",
+        },
+    },
+}
+
+# Wrap your ASGI app
+app = X402ASGIMiddleware(app, routes, server)
+```
+
+### Convenience Function
+
+```python
+from x402.http.middleware.asgi import payment_middleware
+
+middleware = payment_middleware(routes, server, paywall_config={"appName": "My API"})
+app = middleware(your_asgi_app)
+```
+
+### Accessing Payment Info
+
+Payment data is stored in `scope['state']` for downstream handlers:
+
+```python
+async def app(scope, receive, send):
+    state = scope.get("state", {})
+    payload = state.get("x402_payment_payload")
+    requirements = state.get("x402_payment_requirements")
+    # Use payment data...
+```
+
 ## Sync/Async Matching
 
 | Framework | Server | Facilitator Client |
 |-----------|--------|-------------------|
 | FastAPI | `x402ResourceServer` | `HTTPFacilitatorClient` |
 | Flask | `x402ResourceServerSync` | `HTTPFacilitatorClientSync` |
+| Generic ASGI | `x402ResourceServerSync` | `HTTPFacilitatorClientSync` |
 
-Using async components with Flask raises `TypeError`.
+Using async components with Flask or the generic ASGI middleware raises `TypeError`.
 
 ## Route Patterns
 
@@ -184,4 +243,13 @@ PaymentMiddleware(app, routes, server, paywall_provider=MyPaywall())
 | `payment_middleware()` | Convenience function |
 | `payment_middleware_from_config()` | Create from config dict |
 | `FlaskAdapter` | HTTPAdapter for Flask |
+
+### Generic ASGI
+
+| Export | Description |
+|--------|-------------|
+| `X402ASGIMiddleware` | ASGI middleware class |
+| `payment_middleware()` | Create middleware factory |
+| `payment_middleware_from_config()` | Create from config dict |
+| `ASGIAdapter` | HTTPAdapter for raw ASGI scope |
 

--- a/python/x402/http/middleware/__init__.py
+++ b/python/x402/http/middleware/__init__.py
@@ -1,13 +1,14 @@
 """HTTP middleware for x402 payment handling.
 
-Provides server-side middleware for FastAPI and Flask that
-protects endpoints with x402 payment requirements.
+Provides server-side middleware for FastAPI, Flask, and generic ASGI
+frameworks that protects endpoints with x402 payment requirements.
 
 Note: Import specific middleware modules directly to avoid
 requiring all framework dependencies:
 
     from x402.http.middleware.fastapi import payment_middleware
     from x402.http.middleware.flask import PaymentMiddleware
+    from x402.http.middleware.asgi import X402ASGIMiddleware
 """
 
 # Lazy imports - only import when the module is accessed to avoid
@@ -25,6 +26,11 @@ __all__ = [
     "ResponseWrapper",
     "flask_payment_middleware",
     "flask_payment_middleware_from_config",
+    # ASGI (generic)
+    "ASGIAdapter",
+    "X402ASGIMiddleware",
+    "asgi_payment_middleware",
+    "asgi_payment_middleware_from_config",
 ]
 
 
@@ -68,5 +74,23 @@ def __getattr__(name: str):
             return _flask.payment_middleware
         elif name == "flask_payment_middleware_from_config":
             return _flask.payment_middleware_from_config
+
+    # ASGI (generic) imports
+    if name in (
+        "ASGIAdapter",
+        "X402ASGIMiddleware",
+        "asgi_payment_middleware",
+        "asgi_payment_middleware_from_config",
+    ):
+        from . import asgi as _asgi
+
+        if name == "ASGIAdapter":
+            return _asgi.ASGIAdapter
+        elif name == "X402ASGIMiddleware":
+            return _asgi.X402ASGIMiddleware
+        elif name == "asgi_payment_middleware":
+            return _asgi.payment_middleware
+        elif name == "asgi_payment_middleware_from_config":
+            return _asgi.payment_middleware_from_config
 
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/python/x402/http/middleware/asgi.py
+++ b/python/x402/http/middleware/asgi.py
@@ -1,0 +1,743 @@
+"""Generic ASGI middleware for x402 payment handling.
+
+Provides payment-gated route protection for ANY ASGI framework
+(Litestar, BlackSheep, Quart, Starlette, FastAPI, etc.).
+
+This middleware operates at the raw ASGI level, requiring no framework-specific
+dependencies. Payment info is stored in ``scope['state']`` for downstream
+access.
+
+Example:
+    ```python
+    from x402.http.middleware.asgi import X402ASGIMiddleware
+
+    # Wrap any ASGI app
+    app = X402ASGIMiddleware(
+        app=some_asgi_app,
+        routes=routes,
+        server=resource_server,
+    )
+    ```
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, Any
+
+from ...schemas import SettleResponse, VerifiedPaymentCancelOptions
+from ..background_init import handle_background_init_error
+from ..constants import SETTLEMENT_OVERRIDES_HEADER
+from ..facilitator_client_base import FacilitatorResponseError
+from ..types import (
+    HTTPAdapter,
+    HTTPRequestContext,
+    HTTPTransportContext,
+    PaywallConfig,
+    RoutesConfig,
+)
+from ..x402_http_server import PaywallProvider, x402HTTPResourceServerSync
+from ..x402_http_server_base import PAYMENT_REQUIRED_CACHE_CONTROL, with_private_cache_control
+
+if TYPE_CHECKING:
+    from ...server import x402ResourceServerSync
+
+
+# ============================================================================
+# Extension Auto-Registration
+# ============================================================================
+
+from ._bazaar_utils import (
+    check_if_bazaar_needed as _check_if_bazaar_needed,
+)
+from ._bazaar_utils import (
+    register_bazaar_extension as _register_bazaar_extension,
+)
+from ._bazaar_utils import (
+    validate_bazaar_extensions as _validate_bazaar_extensions,
+)
+
+logger = logging.getLogger(__name__)
+
+# ============================================================================
+# ASGI Adapter
+# ============================================================================
+
+ASGIReceive = Callable[..., Awaitable[dict[str, Any]]]
+ASGISend = Callable[[dict[str, Any]], Awaitable[None]]
+
+
+class ASGIAdapter(HTTPAdapter):
+    """Adapter for raw ASGI scope.
+
+    Implements HTTPAdapter protocol by extracting headers, method, path,
+    and other request info from the ASGI scope dict.
+
+    ASGI headers are a list of 2-tuples ``[(name, value), ...]`` where
+    both name and value are byte strings and names are lowercase.
+    """
+
+    def __init__(
+        self,
+        scope: dict[str, Any],
+        query_params: dict[str, str | list[str]] | None = None,
+    ) -> None:
+        """Create adapter from ASGI scope.
+
+        Args:
+            scope: ASGI connection scope dict.
+            query_params: Parsed query parameters (optional).
+        """
+        self._scope = scope
+        self._query_params = query_params or {}
+        # Build a case-insensitive header lookup dict from byte tuples
+        self._headers: dict[str, str] = {}
+        for name_bytes, value_bytes in scope.get("headers", []):
+            name = name_bytes.decode("latin-1").lower()
+            value = value_bytes.decode("latin-1")
+            self._headers[name] = value
+
+    def get_header(self, name: str) -> str | None:
+        """Get header value (case-insensitive).
+
+        Args:
+            name: Header name.
+
+        Returns:
+            Header value or None.
+        """
+        return self._headers.get(name.lower())
+
+    def get_method(self) -> str:
+        """Get HTTP method.
+
+        Returns:
+            HTTP method (GET, POST, etc.).
+        """
+        return self._scope.get("method", "GET")
+
+    def get_path(self) -> str:
+        """Get request path.
+
+        Returns:
+            Request path.
+        """
+        return self._scope.get("path", "/")
+
+    def get_url(self) -> str:
+        """Get full request URL.
+
+        Reconstructed from ASGI scope fields.
+
+        Returns:
+            Full URL string.
+        """
+        scheme = self._scope.get("scheme", "http")
+        server = self._scope.get("server")
+        host = server[0] if server else "localhost"
+        port = server[1] if server and len(server) > 1 else 80
+
+        # Omit default port for scheme
+        if (scheme == "https" and port == 443) or (scheme == "http" and port == 80):
+            authority = host
+        else:
+            authority = f"{host}:{port}"
+
+        path = self._scope.get("path", "/")
+        query_string = self._scope.get("query_string", b"")
+        if query_string:
+            qs = query_string.decode("latin-1") if isinstance(query_string, bytes) else query_string
+            return f"{scheme}://{authority}{path}?{qs}"
+        return f"{scheme}://{authority}{path}"
+
+    def get_accept_header(self) -> str:
+        """Get Accept header.
+
+        Returns:
+            Accept header value.
+        """
+        return self._headers.get("accept", "")
+
+    def get_user_agent(self) -> str:
+        """Get User-Agent header.
+
+        Returns:
+            User-Agent header value.
+        """
+        return self._headers.get("user-agent", "")
+
+    def get_query_params(self) -> dict[str, str | list[str]]:
+        """Get query parameters.
+
+        Returns:
+            Dict of query parameters.
+        """
+        return dict(self._query_params)
+
+    def get_query_param(self, name: str) -> str | list[str] | None:
+        """Get single query parameter.
+
+        Args:
+            name: Parameter name.
+
+        Returns:
+            Parameter value or None.
+        """
+        return self._query_params.get(name)
+
+    def get_body(self) -> Any:
+        """Get request body.
+
+        Returns:
+            None (body requires async access via receive).
+        """
+        return None
+
+
+# ============================================================================
+# ASGI Response Helpers
+# ============================================================================
+
+
+async def _send_asgi_response(
+    send: ASGISend,
+    status_code: int,
+    headers: list[tuple[str, str]],
+    body: bytes,
+) -> None:
+    """Send a complete ASGI HTTP response asynchronously.
+
+    Args:
+        send: ASGI send callable.
+        status_code: HTTP status code.
+        headers: Response headers as list of (name, value) tuples.
+        body: Response body bytes.
+    """
+    asgi_headers = [
+        (name.encode("latin-1"), value.encode("latin-1")) for name, value in headers
+    ]
+
+    await send({
+        "type": "http.response.start",
+        "status": status_code,
+        "headers": asgi_headers,
+    })
+    await send({
+        "type": "http.response.body",
+        "body": body,
+    })
+
+
+def _json_bytes(data: Any) -> bytes:
+    """Serialize data to JSON bytes."""
+    return json.dumps(data).encode("utf-8")
+
+
+def _parse_query_string(query_string: bytes | str) -> dict[str, str | list[str]]:
+    """Parse ASGI query string into a dict.
+
+    Args:
+        query_string: Raw query string bytes or string.
+
+    Returns:
+        Parsed query parameters.
+    """
+    from urllib.parse import parse_qs
+
+    if isinstance(query_string, bytes):
+        query_string = query_string.decode("latin-1")
+
+    if not query_string:
+        return {}
+
+    parsed = parse_qs(query_string, keep_blank_values=True)
+    # Flatten single-value lists
+    result: dict[str, str | list[str]] = {}
+    for key, values in parsed.items():
+        result[key] = values[0] if len(values) == 1 else values
+    return result
+
+
+# ============================================================================
+# ASGI Middleware Class
+# ============================================================================
+
+
+class X402ASGIMiddleware:
+    """Generic ASGI middleware for x402 payment handling.
+
+    Works with ANY ASGI framework (Litestar, BlackSheep, Quart, Starlette,
+    FastAPI, etc.). No framework-specific dependencies required.
+
+    Payment info is stored in ``scope['state']['x402_payment_payload']`` and
+    ``scope['state']['x402_payment_requirements']`` for downstream handlers.
+
+    Example:
+        ```python
+        from x402.http.middleware.asgi import X402ASGIMiddleware
+
+        app = X402ASGIMiddleware(
+            app=your_asgi_app,
+            routes=routes,
+            server=resource_server,
+        )
+        ```
+    """
+
+    def __init__(
+        self,
+        app: Callable[..., Awaitable[None]],
+        routes: RoutesConfig,
+        server: x402ResourceServerSync,
+        paywall_config: PaywallConfig | None = None,
+        paywall_provider: PaywallProvider | None = None,
+        sync_facilitator_on_start: bool = True,
+    ) -> None:
+        """Initialize ASGI middleware.
+
+        Args:
+            app: ASGI application callable.
+            routes: Route configuration for protected endpoints.
+            server: Pre-configured x402ResourceServerSync.
+            paywall_config: Optional paywall UI configuration.
+            paywall_provider: Optional custom paywall provider.
+            sync_facilitator_on_start: Fetch facilitator support when created.
+        """
+        # Auto-register bazaar extension if routes declare it
+        if _check_if_bazaar_needed(routes):
+            _register_bazaar_extension(server)
+            _validate_bazaar_extensions(routes)
+
+        self._app = app
+        self._http_server = x402HTTPResourceServerSync(server, routes)
+        self._paywall_config = paywall_config
+        self._sync_on_start = sync_facilitator_on_start
+        self._init_done = False
+        self._init_lock = threading.Lock()
+
+        if paywall_provider:
+            self._http_server.register_paywall_provider(paywall_provider)
+
+        if self._sync_on_start:
+            try:
+                self._http_server.initialize()
+                self._init_done = True
+            except Exception as error:
+                handle_background_init_error(error)
+
+    async def __call__(
+        self,
+        scope: dict[str, Any],
+        receive: ASGIReceive,
+        send: ASGISend,
+    ) -> None:
+        """ASGI entry point.
+
+        Intercepts HTTP requests on payment-protected routes and processes
+        x402 payments before forwarding to the downstream ASGI app.
+
+        Lifespan and WebSocket scope types are passed through directly.
+
+        Args:
+            scope: ASGI connection scope.
+            receive: ASGI receive callable.
+            send: ASGI send callable.
+        """
+        # Only intercept HTTP requests
+        if scope.get("type") == "lifespan":
+            await self._app(scope, receive, send)
+            return
+
+        if scope.get("type") != "http":
+            await self._app(scope, receive, send)
+            return
+
+        # Parse query string
+        query_params = _parse_query_string(scope.get("query_string", b""))
+
+        # Create adapter and context
+        adapter = ASGIAdapter(scope, query_params)
+        context = HTTPRequestContext(
+            adapter=adapter,
+            path=adapter.get_path(),
+            method=adapter.get_method(),
+            payment_header=(
+                adapter.get_header("payment-signature")
+                or adapter.get_header("x-payment")
+            ),
+        )
+
+        # Check if route requires payment
+        if not self._http_server.requires_payment(context):
+            await self._app(scope, receive, send)
+            return
+
+        # Initialize on first protected request (double-checked locking)
+        if self._sync_on_start and not self._init_done:
+            with self._init_lock:
+                if not self._init_done:
+                    try:
+                        self._http_server.initialize()
+                    except FacilitatorResponseError as error:
+                        await _send_asgi_response(
+                            send,
+                            502,
+                            [("Content-Type", "application/json")],
+                            _json_bytes({"error": str(error)}),
+                        )
+                        return
+                    self._init_done = True
+
+        # Process payment request synchronously
+        try:
+            result = self._http_server.process_http_request(context, self._paywall_config)
+        except FacilitatorResponseError as error:
+            await _send_asgi_response(
+                send,
+                502,
+                [("Content-Type", "application/json")],
+                _json_bytes({"error": str(error)}),
+            )
+            return
+        except Exception:
+            logger.exception("x402: unexpected error while processing an HTTP payment request")
+            await _send_asgi_response(
+                send,
+                500,
+                [("Content-Type", "application/json")],
+                _json_bytes({"error": "Internal Server Error"}),
+            )
+            return
+
+        if result.type == "no-payment-required":
+            await self._app(scope, receive, send)
+            return
+
+        if result.type == "payment-error":
+            response = result.response
+            if response is None:
+                await _send_asgi_response(
+                    send,
+                    402,
+                    [("Content-Type", "application/json")],
+                    _json_bytes({"error": "Payment required"}),
+                )
+                return
+
+            headers = list(response.headers.items())
+            if response.is_html:
+                headers.append(("Content-Type", "text/html; charset=utf-8"))
+                body = (
+                    response.body.encode("utf-8")
+                    if isinstance(response.body, str)
+                    else response.body if isinstance(response.body, bytes) else _json_bytes(response.body)
+                )
+            else:
+                headers.append(("Content-Type", "application/json"))
+                body = _json_bytes(response.body or {})
+
+            await _send_asgi_response(send, response.status, headers, body)
+            return
+
+        if result.type == "payment-verified":
+            # Store payment info in ASGI scope['state'] for downstream access
+            state = scope.setdefault("state", {})
+            state["x402_payment_payload"] = result.payment_payload
+            state["x402_payment_requirements"] = result.payment_requirements
+
+            dispatcher = result.cancellation_dispatcher
+            transport_context = HTTPTransportContext(request=context)
+
+            # Capture the downstream response
+            captured_status = 200
+            captured_headers: list[tuple[bytes, bytes]] = []
+            captured_body = b""
+
+            async def capture_send(message: dict[str, Any]) -> None:
+                nonlocal captured_status, captured_headers, captured_body
+                if message["type"] == "http.response.start":
+                    captured_status = message.get("status", 200)
+                    captured_headers = list(message.get("headers", []))
+                elif message["type"] == "http.response.body":
+                    captured_body += message.get("body", b"")
+
+            # Call downstream
+            try:
+                await self._app(scope, receive, capture_send)
+            except Exception as error:
+                cancel_settlement = None
+                if dispatcher is not None:
+                    cancel_settlement = await dispatcher.cancel(
+                        VerifiedPaymentCancelOptions(reason="handler_threw", error=error)
+                    )
+                failure_headers = self._http_server.create_failure_path_settlement_headers(
+                    cancel_settlement,
+                    result.before_handler_settlement,
+                    result.payment_payload,
+                )
+                if not isinstance(failure_headers, dict) or not failure_headers:
+                    raise
+                await _send_asgi_response(
+                    send,
+                    500,
+                    [("Content-Type", "application/json"), *failure_headers.items()],
+                    _json_bytes({"error": "Internal Server Error"}),
+                )
+                return
+
+            # Don't settle on error responses
+            if captured_status >= 400:
+                cancel_settlement = None
+                if dispatcher is not None:
+                    cancel_settlement = await dispatcher.cancel(
+                        VerifiedPaymentCancelOptions(
+                            reason="handler_failed",
+                            response_status=captured_status,
+                        )
+                    )
+                existing_cc = None
+                for name_bytes, value_bytes in captured_headers:
+                    if name_bytes.lower() == b"cache-control":
+                        existing_cc = value_bytes.decode("latin-1")
+                        break
+                failure_headers = self._http_server.create_failure_path_settlement_headers(
+                    cancel_settlement,
+                    result.before_handler_settlement,
+                    result.payment_payload,
+                    existing_cc,
+                )
+                if isinstance(failure_headers, dict):
+                    for key, value in failure_headers.items():
+                        captured_headers.append((key.encode("latin-1"), value.encode("latin-1")))
+                await _send_asgi_response(
+                    send,
+                    captured_status,
+                    [(n.decode("latin-1"), v.decode("latin-1")) for n, v in captured_headers],
+                    captured_body,
+                )
+                return
+
+            # Convert captured headers to dict for processing
+            response_headers_dict: dict[str, str] = {}
+            for name_bytes, value_bytes in captured_headers:
+                name = name_bytes.decode("latin-1")
+                value = value_bytes.decode("latin-1")
+                response_headers_dict[name] = value
+
+            # Extract and strip settlement overrides
+            overrides = self._http_server._extract_settlement_overrides(response_headers_dict)
+            if overrides is not None:
+                captured_headers = [
+                    (n, v)
+                    for n, v in captured_headers
+                    if n.lower() != SETTLEMENT_OVERRIDES_HEADER.lower().encode("latin-1")
+                ]
+
+            transport_context.response_headers = response_headers_dict
+
+            # Process settlement (sync)
+            try:
+                settle_result = self._http_server.process_settlement(
+                    result.payment_payload,
+                    result.payment_requirements,
+                    context=context,
+                    settlement_overrides=overrides,
+                    declared_extensions=result.declared_extensions,
+                    transport_context=transport_context,
+                    before_handler_settlement=result.before_handler_settlement,
+                )
+
+                if not settle_result.success:
+                    settle_response = settle_result.response
+                    if settle_response is None:
+                        await _send_asgi_response(
+                            send, 402, [("Content-Type", "application/json")], b"{}"
+                        )
+                        return
+                    if settle_response.is_html:
+                        resp_headers = list(settle_response.headers.items())
+                        resp_headers.append(("Content-Type", "text/html; charset=utf-8"))
+                        body = (
+                            settle_response.body.encode("utf-8")
+                            if isinstance(settle_response.body, str)
+                            else settle_response.body if isinstance(settle_response.body, bytes)
+                            else _json_bytes(settle_response.body)
+                        )
+                    else:
+                        resp_headers = list(settle_response.headers.items())
+                        resp_headers.append(("Content-Type", "application/json"))
+                        body = _json_bytes(settle_response.body or {})
+                    await _send_asgi_response(send, settle_response.status, resp_headers, body)
+                    return
+
+                # Build final response with settlement headers
+                final_headers = list(captured_headers)
+                for key, value in settle_result.headers.items():
+                    final_headers.append((key.encode("latin-1"), value.encode("latin-1")))
+
+                # Update Cache-Control to include 'private'
+                cache_control_updated = False
+                for i, (name_bytes, _) in enumerate(final_headers):
+                    if name_bytes.lower() == b"cache-control":
+                        existing_cc = name_bytes.decode("latin-1")
+                        # Get the value
+                        val = final_headers[i][1].decode("latin-1")
+                        final_headers[i] = (
+                            b"cache-control",
+                            with_private_cache_control(val).encode("latin-1"),
+                        )
+                        cache_control_updated = True
+                        break
+                if not cache_control_updated:
+                    final_headers.append((b"cache-control", b"private"))
+
+                await _send_asgi_response(
+                    send,
+                    captured_status,
+                    [(n.decode("latin-1"), v.decode("latin-1")) for n, v in final_headers],
+                    captured_body,
+                )
+
+            except FacilitatorResponseError as error:
+                await _send_asgi_response(
+                    send,
+                    502,
+                    [("Content-Type", "application/json")],
+                    _json_bytes({"error": str(error)}),
+                )
+            except Exception:
+                logger.exception("x402: unexpected error while settling a verified payment")
+                settle_response = SettleResponse(
+                    success=False,
+                    error_reason="unexpected_settle_error",
+                    error_message="unexpected error while settling the verified payment",
+                    transaction="",
+                    network=result.payment_requirements.network,
+                )
+                settle_headers = self._http_server._create_settlement_headers(
+                    settle_response, result.payment_requirements
+                )
+                await _send_asgi_response(
+                    send,
+                    402,
+                    [
+                        ("Content-Type", "application/json"),
+                        ("Cache-Control", PAYMENT_REQUIRED_CACHE_CONTROL),
+                        *settle_headers.items(),
+                    ],
+                    b"{}",
+                )
+            return
+
+        # Fallthrough — pass through to downstream app
+        await self._app(scope, receive, send)
+
+
+# ============================================================================
+# Convenience Functions
+# ============================================================================
+
+
+def payment_middleware(
+    routes: RoutesConfig,
+    server: x402ResourceServerSync,
+    paywall_config: PaywallConfig | None = None,
+    paywall_provider: PaywallProvider | None = None,
+    sync_facilitator_on_start: bool = True,
+) -> Callable[
+    [Callable[..., Awaitable[None]]],
+    X402ASGIMiddleware,
+]:
+    """Create a middleware factory for any ASGI framework.
+
+    Returns a callable that wraps an ASGI app with x402 payment protection.
+
+    Args:
+        routes: Route configuration for protected endpoints.
+        server: Pre-configured x402ResourceServerSync.
+        paywall_config: Optional paywall UI configuration.
+        paywall_provider: Optional custom paywall provider.
+        sync_facilitator_on_start: Fetch facilitator support when created.
+
+    Returns:
+        Callable that wraps an ASGI app.
+
+    Example:
+        ```python
+        from x402.http.middleware.asgi import payment_middleware
+
+        middleware = payment_middleware(routes, server)
+        app = middleware(your_asgi_app)
+        ```
+    """
+    def _wrap(app: Callable[..., Awaitable[None]]) -> X402ASGIMiddleware:
+        return X402ASGIMiddleware(
+            app=app,
+            routes=routes,
+            server=server,
+            paywall_config=paywall_config,
+            paywall_provider=paywall_provider,
+            sync_facilitator_on_start=sync_facilitator_on_start,
+        )
+    return _wrap
+
+
+def payment_middleware_from_config(
+    routes: RoutesConfig,
+    facilitator_client: Any = None,
+    schemes: list[dict[str, Any]] | None = None,
+    paywall_config: PaywallConfig | None = None,
+    paywall_provider: PaywallProvider | None = None,
+    sync_facilitator_on_start: bool = True,
+) -> Callable[
+    [Callable[..., Awaitable[None]]],
+    X402ASGIMiddleware,
+]:
+    """Create ASGI payment middleware from configuration.
+
+    Convenience function that creates x402ResourceServerSync internally.
+
+    Args:
+        routes: Route configuration for protected endpoints.
+        facilitator_client: Facilitator client(s) for payment processing.
+        schemes: Scheme registrations for server-side processing.
+        paywall_config: Optional paywall UI configuration.
+        paywall_provider: Optional custom paywall provider.
+        sync_facilitator_on_start: Fetch facilitator support when created.
+
+    Returns:
+        Callable that wraps an ASGI app.
+    """
+    from ...server import x402ResourceServerSync as _x402ResourceServerSync
+
+    server = _x402ResourceServerSync(facilitator_client)
+
+    if schemes:
+        for registration in schemes:
+            server.register(registration["network"], registration["server"])
+
+    return payment_middleware(
+        routes,
+        server,
+        paywall_config,
+        paywall_provider,
+        sync_facilitator_on_start,
+    )
+
+
+def set_settlement_overrides(scope: dict[str, Any], overrides: dict[str, Any]) -> None:
+    """Settlement overrides are not applicable to raw ASGI middleware.
+
+    In raw ASGI, the downstream app sends the response directly. Use
+    ``X402ASGIMiddleware`` which handles settlement transparently.
+
+    Raises:
+        NotImplementedError: Always, as raw ASGI has no response object to annotate.
+    """
+    raise NotImplementedError(
+        "set_settlement_overrides is not supported in raw ASGI middleware. "
+        "The middleware handles settlement transparently."
+    )

--- a/python/x402/tests/unit/http/middleware/test_asgi.py
+++ b/python/x402/tests/unit/http/middleware/test_asgi.py
@@ -1,0 +1,972 @@
+"""Unit tests for x402.http.middleware.asgi - Generic ASGI middleware."""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from x402.http.middleware.asgi import (
+    ASGIAdapter,
+    X402ASGIMiddleware,
+    _parse_query_string,
+    payment_middleware,
+)
+from x402.http.types import (
+    HTTPProcessResult,
+    HTTPResponseInstructions,
+    PaymentOption,
+    ProcessSettleResult,
+    RouteConfig,
+)
+from x402.schemas import PaymentPayload, PaymentRequirements
+from x402.http.facilitator_client_base import FacilitatorResponseError
+from x402.schemas.hooks import PaymentCancellationDispatcher
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def make_payment_requirements() -> PaymentRequirements:
+    """Helper to create valid PaymentRequirements."""
+    return PaymentRequirements(
+        scheme="exact",
+        network="eip155:8453",
+        asset="0x0000000000000000000000000000000000000000",
+        amount="1000000",
+        pay_to="0x1234567890123456789012345678901234567890",
+        max_timeout_seconds=300,
+    )
+
+
+def make_v2_payload(signature: str = "0xmock") -> PaymentPayload:
+    """Helper to create valid V2 PaymentPayload."""
+    return PaymentPayload(
+        x402_version=2,
+        payload={"signature": signature},
+        accepted=make_payment_requirements(),
+    )
+
+
+def make_asgi_scope(
+    method: str = "GET",
+    path: str = "/api/test",
+    headers: list[tuple[bytes, bytes]] | None = None,
+    query_string: bytes = b"",
+    state: dict | None = None,
+) -> dict:
+    """Create a minimal ASGI scope dict."""
+    if headers is None:
+        headers = [
+            (b"host", b"example.com"),
+            (b"user-agent", b"TestClient/1.0"),
+            (b"accept", b"application/json"),
+        ]
+    scope: dict = {
+        "type": "http",
+        "method": method,
+        "path": path,
+        "headers": headers,
+        "query_string": query_string,
+        "server": ("example.com", 80),
+        "scheme": "http",
+    }
+    if state:
+        scope["state"] = state
+    return scope
+
+
+async def default_send(message: dict) -> None:
+    """Default no-op send callable for tests."""
+    pass
+
+
+# =============================================================================
+# ASGIAdapter Tests
+# =============================================================================
+
+
+class TestASGIAdapter:
+    """Tests for ASGIAdapter."""
+
+    def test_get_header(self):
+        """Test getting header value from ASGI scope."""
+        scope = make_asgi_scope(
+            headers=[(b"x-custom", b"test-value"), (b"host", b"example.com")]
+        )
+        adapter = ASGIAdapter(scope)
+
+        assert adapter.get_header("x-custom") == "test-value"
+
+    def test_get_header_case_insensitive(self):
+        """Test headers are matched case-insensitively."""
+        scope = make_asgi_scope(
+            headers=[(b"Payment-Signature", b"sig123")]
+        )
+        adapter = ASGIAdapter(scope)
+
+        assert adapter.get_header("payment-signature") == "sig123"
+        assert adapter.get_header("Payment-Signature") == "sig123"
+        assert adapter.get_header("PAYMENT-SIGNATURE") == "sig123"
+
+    def test_get_header_missing(self):
+        """Test getting missing header returns None."""
+        scope = make_asgi_scope()
+        adapter = ASGIAdapter(scope)
+
+        assert adapter.get_header("x-missing") is None
+
+    def test_get_method(self):
+        """Test getting HTTP method."""
+        scope = make_asgi_scope(method="POST")
+        adapter = ASGIAdapter(scope)
+
+        assert adapter.get_method() == "POST"
+
+    def test_get_path(self):
+        """Test getting request path."""
+        scope = make_asgi_scope(path="/api/weather/london")
+        adapter = ASGIAdapter(scope)
+
+        assert adapter.get_path() == "/api/weather/london"
+
+    def test_get_url(self):
+        """Test getting full URL reconstructed from scope."""
+        scope = make_asgi_scope(path="/api/test", query_string=b"key=value")
+        adapter = ASGIAdapter(scope)
+
+        assert adapter.get_url() == "http://example.com/api/test?key=value"
+
+    def test_get_url_https(self):
+        """Test URL with HTTPS scheme."""
+        scope = make_asgi_scope(path="/secure")
+        scope["scheme"] = "https"
+        scope["server"] = ("example.com", 443)
+        adapter = ASGIAdapter(scope)
+
+        assert adapter.get_url() == "https://example.com/secure"
+
+    def test_get_url_custom_port(self):
+        """Test URL with non-default port."""
+        scope = make_asgi_scope(path="/api")
+        scope["server"] = ("example.com", 8080)
+        adapter = ASGIAdapter(scope)
+
+        assert adapter.get_url() == "http://example.com:8080/api"
+
+    def test_get_accept_header(self):
+        """Test getting Accept header."""
+        scope = make_asgi_scope(
+            headers=[(b"accept", b"text/html")]
+        )
+        adapter = ASGIAdapter(scope)
+
+        assert adapter.get_accept_header() == "text/html"
+
+    def test_get_accept_header_missing(self):
+        """Test missing Accept returns empty string."""
+        scope = make_asgi_scope(headers=[])
+        adapter = ASGIAdapter(scope)
+
+        assert adapter.get_accept_header() == ""
+
+    def test_get_user_agent(self):
+        """Test getting User-Agent header."""
+        scope = make_asgi_scope(
+            headers=[(b"user-agent", b"Mozilla/5.0")]
+        )
+        adapter = ASGIAdapter(scope)
+
+        assert adapter.get_user_agent() == "Mozilla/5.0"
+
+    def test_get_user_agent_missing(self):
+        """Test missing User-Agent returns empty string."""
+        scope = make_asgi_scope(headers=[])
+        adapter = ASGIAdapter(scope)
+
+        assert adapter.get_user_agent() == ""
+
+    def test_get_query_params(self):
+        """Test getting query parameters."""
+        scope = make_asgi_scope(query_string=b"city=london&units=metric")
+        adapter = ASGIAdapter(scope)
+
+        params = adapter.get_query_params()
+        assert params["city"] == "london"
+        assert params["units"] == "metric"
+
+    def test_get_query_param(self):
+        """Test getting single query parameter."""
+        scope = make_asgi_scope(query_string=b"city=london")
+        adapter = ASGIAdapter(scope)
+
+        assert adapter.get_query_param("city") == "london"
+
+    def test_get_query_param_missing(self):
+        """Test missing query parameter returns None."""
+        scope = make_asgi_scope()
+        adapter = ASGIAdapter(scope)
+
+        assert adapter.get_query_param("missing") is None
+
+    def test_get_body_returns_none(self):
+        """Test that get_body returns None."""
+        scope = make_asgi_scope()
+        adapter = ASGIAdapter(scope)
+
+        assert adapter.get_body() is None
+
+
+# =============================================================================
+# Query String Parsing Tests
+# =============================================================================
+
+
+class TestParseQueryString:
+    """Tests for _parse_query_string helper."""
+
+    def test_empty_string(self):
+        assert _parse_query_string(b"") == {}
+
+    def test_single_param(self):
+        result = _parse_query_string(b"key=value")
+        assert result == {"key": "value"}
+
+    def test_multiple_params(self):
+        result = _parse_query_string(b"a=1&b=2&c=3")
+        assert result == {"a": "1", "b": "2", "c": "3"}
+
+    def test_string_input(self):
+        result = _parse_query_string("key=value")
+        assert result == {"key": "value"}
+
+    def test_repeated_param_returns_list(self):
+        result = _parse_query_string(b"a=1&a=2")
+        assert result == {"a": ["1", "2"]}
+
+
+# =============================================================================
+# X402ASGIMiddleware Tests
+# =============================================================================
+
+
+class TestX402ASGIMiddleware:
+    """Tests for X402ASGIMiddleware."""
+
+    def test_creates_middleware(self):
+        """Test that middleware can be instantiated."""
+        mock_app = AsyncMock()
+        mock_server = MagicMock()
+        routes = {
+            "GET /api/test": RouteConfig(
+                accepts=PaymentOption(
+                    scheme="exact",
+                    pay_to="0x1234567890123456789012345678901234567890",
+                    price="$0.01",
+                    network="eip155:8453",
+                ),
+            )
+        }
+
+        middleware = X402ASGIMiddleware(mock_app, routes, mock_server, sync_facilitator_on_start=False)
+
+        assert middleware._app is mock_app
+        assert callable(middleware)
+
+    def test_non_http_scope_passes_through(self):
+        """Test that non-HTTP scope types are passed through."""
+        mock_app = AsyncMock()
+        mock_server = MagicMock()
+
+        middleware = X402ASGIMiddleware(mock_app, {}, mock_server, sync_facilitator_on_start=False)
+
+        lifespan_scope = {"type": "lifespan"}
+        import asyncio
+
+        asyncio.get_event_loop().run_until_complete(
+            middleware(lifespan_scope, AsyncMock(), AsyncMock())
+        )
+        mock_app.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_lifespan_scope_passes_through(self):
+        """Test that lifespan scope passes through."""
+        mock_app = AsyncMock()
+        mock_server = MagicMock()
+
+        middleware = X402ASGIMiddleware(mock_app, {}, mock_server, sync_facilitator_on_start=False)
+
+        scope = {"type": "lifespan"}
+        receive = AsyncMock()
+        send = AsyncMock()
+
+        await middleware(scope, receive, send)
+        mock_app.assert_awaited_once_with(scope, receive, send)
+
+    @pytest.mark.asyncio
+    async def test_websocket_scope_passes_through(self):
+        """Test that WebSocket scope passes through."""
+        mock_app = AsyncMock()
+        mock_server = MagicMock()
+
+        middleware = X402ASGIMiddleware(mock_app, {}, mock_server, sync_facilitator_on_start=False)
+
+        scope = {"type": "websocket"}
+        receive = AsyncMock()
+        send = AsyncMock()
+
+        await middleware(scope, receive, send)
+        mock_app.assert_awaited_once_with(scope, receive, send)
+
+    @pytest.mark.asyncio
+    async def test_non_protected_route_passes_through(self):
+        """Test that non-protected routes pass through."""
+        mock_app = AsyncMock()
+        mock_server = MagicMock()
+
+        with patch("x402.http.middleware.asgi.x402HTTPResourceServerSync") as mock_http_class:
+            mock_http_instance = MagicMock()
+            mock_http_instance.requires_payment.return_value = False
+            mock_http_class.return_value = mock_http_instance
+
+            routes = {
+                "GET /api/protected": RouteConfig(
+                    accepts=PaymentOption(
+                        scheme="exact",
+                        pay_to="0x1234567890123456789012345678901234567890",
+                        price="$0.01",
+                        network="eip155:8453",
+                    ),
+                )
+            }
+
+            middleware = X402ASGIMiddleware(
+                mock_app, routes, mock_server, sync_facilitator_on_start=False
+            )
+
+            scope = make_asgi_scope(path="/api/public")
+            receive = AsyncMock()
+            send = AsyncMock()
+
+            await middleware(scope, receive, send)
+            mock_app.assert_awaited_once_with(scope, receive, send)
+
+    @pytest.mark.asyncio
+    async def test_facilitator_error_returns_502(self):
+        """Test that FacilitatorResponseError returns 502."""
+        mock_app = AsyncMock()
+        mock_server = MagicMock()
+
+        with patch("x402.http.middleware.asgi.x402HTTPResourceServerSync") as mock_http_class:
+            mock_http_instance = MagicMock()
+            mock_http_instance.requires_payment.return_value = True
+            mock_http_instance.process_http_request.side_effect = FacilitatorResponseError(
+                "verify failed"
+            )
+            mock_http_class.return_value = mock_http_instance
+
+            routes = {
+                "GET /api/test": RouteConfig(
+                    accepts=PaymentOption(
+                        scheme="exact",
+                        pay_to="0x1234567890123456789012345678901234567890",
+                        price="$0.01",
+                        network="eip155:8453",
+                    ),
+                )
+            }
+
+            middleware = X402ASGIMiddleware(
+                mock_app, routes, mock_server, sync_facilitator_on_start=False
+            )
+
+            scope = make_asgi_scope(path="/api/test")
+            receive = AsyncMock()
+            messages = []
+
+            async def capture_send(message):
+                messages.append(message)
+
+            await middleware(scope, receive, capture_send)
+
+            assert len(messages) == 2
+            assert messages[0]["type"] == "http.response.start"
+            assert messages[0]["status"] == 502
+            assert messages[1]["type"] == "http.response.body"
+            import json
+            body = json.loads(messages[1]["body"])
+            assert "verify failed" in body["error"]
+
+    @pytest.mark.asyncio
+    async def test_unexpected_error_returns_500(self):
+        """Test that unexpected errors return 500."""
+        mock_app = AsyncMock()
+        mock_server = MagicMock()
+
+        with patch("x402.http.middleware.asgi.x402HTTPResourceServerSync") as mock_http_class:
+            mock_http_instance = MagicMock()
+            mock_http_instance.requires_payment.return_value = True
+            mock_http_instance.process_http_request.side_effect = RuntimeError("boom")
+            mock_http_class.return_value = mock_http_instance
+
+            routes = {
+                "GET /api/test": RouteConfig(
+                    accepts=PaymentOption(
+                        scheme="exact",
+                        pay_to="0x1234567890123456789012345678901234567890",
+                        price="$0.01",
+                        network="eip155:8453",
+                    ),
+                )
+            }
+
+            middleware = X402ASGIMiddleware(
+                mock_app, routes, mock_server, sync_facilitator_on_start=False
+            )
+
+            scope = make_asgi_scope(path="/api/test")
+            receive = AsyncMock()
+            messages = []
+
+            async def capture_send(message):
+                messages.append(message)
+
+            await middleware(scope, receive, capture_send)
+
+            assert len(messages) == 2
+            assert messages[0]["status"] == 500
+            import json
+            body = json.loads(messages[1]["body"])
+            assert body["error"] == "Internal Server Error"
+
+    @pytest.mark.asyncio
+    async def test_payment_error_returns_402(self):
+        """Test that payment-error result returns 402 with paywall content."""
+        mock_app = AsyncMock()
+        mock_server = MagicMock()
+
+        with patch("x402.http.middleware.asgi.x402HTTPResourceServerSync") as mock_http_class:
+            mock_http_instance = MagicMock()
+            mock_http_instance.requires_payment.return_value = True
+            mock_http_instance.process_http_request.return_value = HTTPProcessResult(
+                type="payment-error",
+                response=HTTPResponseInstructions(
+                    status=402,
+                    headers={"Content-Type": "application/json"},
+                    body={"error": "Payment required"},
+                ),
+            )
+            mock_http_class.return_value = mock_http_instance
+
+            routes = {
+                "GET /api/test": RouteConfig(
+                    accepts=PaymentOption(
+                        scheme="exact",
+                        pay_to="0x1234567890123456789012345678901234567890",
+                        price="$0.01",
+                        network="eip155:8453",
+                    ),
+                )
+            }
+
+            middleware = X402ASGIMiddleware(
+                mock_app, routes, mock_server, sync_facilitator_on_start=False
+            )
+
+            scope = make_asgi_scope(path="/api/test")
+            receive = AsyncMock()
+            messages = []
+
+            async def capture_send(message):
+                messages.append(message)
+
+            await middleware(scope, receive, capture_send)
+
+            assert messages[0]["status"] == 402
+            import json
+            body = json.loads(messages[1]["body"])
+            assert body["error"] == "Payment required"
+
+    @pytest.mark.asyncio
+    async def test_payment_verified_stores_in_scope_state(self):
+        """Test that payment-verified stores payment info in scope['state']."""
+        mock_app = AsyncMock()
+        mock_server = MagicMock()
+
+        payment_payload = make_v2_payload()
+        payment_requirements = make_payment_requirements()
+
+        with patch("x402.http.middleware.asgi.x402HTTPResourceServerSync") as mock_http_class:
+            mock_http_instance = MagicMock()
+            mock_http_instance.requires_payment.return_value = True
+            mock_http_instance.process_http_request.return_value = HTTPProcessResult(
+                type="payment-verified",
+                payment_payload=payment_payload,
+                payment_requirements=payment_requirements,
+            )
+            mock_http_instance.process_settlement.return_value = ProcessSettleResult(
+                success=True,
+                headers={"PAYMENT-RESPONSE": "settlement_encoded"},
+            )
+            mock_http_class.return_value = mock_http_instance
+
+            routes = {
+                "GET /api/test": RouteConfig(
+                    accepts=PaymentOption(
+                        scheme="exact",
+                        pay_to="0x1234567890123456789012345678901234567890",
+                        price="$0.01",
+                        network="eip155:8453",
+                    ),
+                )
+            }
+
+            middleware = X402ASGIMiddleware(
+                mock_app, routes, mock_server, sync_facilitator_on_start=False
+            )
+
+            scope = make_asgi_scope(path="/api/test")
+            receive = AsyncMock()
+            messages = []
+
+            async def capture_send(message):
+                messages.append(message)
+
+            # Downstream app should send a response
+            async def mock_downstream(s, r, snd):
+                # Verify payment info is in scope
+                assert "x402_payment_payload" in s.get("state", {})
+                assert "x402_payment_requirements" in s.get("state", {})
+                await snd({
+                    "type": "http.response.start",
+                    "status": 200,
+                    "headers": [(b"content-type", b"application/json")],
+                })
+                await snd({
+                    "type": "http.response.body",
+                    "body": b'{"data": "ok"}',
+                })
+
+            middleware._app = mock_downstream
+
+            await middleware(scope, receive, capture_send)
+
+            # Should have response.start and response.body from settlement
+            assert messages[0]["type"] == "http.response.start"
+            assert messages[0]["status"] == 200
+
+    @pytest.mark.asyncio
+    async def test_payment_verified_settlement_failure_returns_402(self):
+        """Test that settlement failure returns 402."""
+        mock_app = AsyncMock()
+        mock_server = MagicMock()
+
+        payment_payload = make_v2_payload()
+        payment_requirements = make_payment_requirements()
+
+        with patch("x402.http.middleware.asgi.x402HTTPResourceServerSync") as mock_http_class:
+            mock_http_instance = MagicMock()
+            mock_http_instance.requires_payment.return_value = True
+            mock_http_instance.process_http_request.return_value = HTTPProcessResult(
+                type="payment-verified",
+                payment_payload=payment_payload,
+                payment_requirements=payment_requirements,
+            )
+            mock_http_instance.process_settlement.return_value = ProcessSettleResult(
+                success=False,
+                error_reason="insufficient_funds",
+                response=HTTPResponseInstructions(
+                    status=402,
+                    headers={"PAYMENT-RESPONSE": "failure_data"},
+                    body={},
+                ),
+            )
+            mock_http_class.return_value = mock_http_instance
+
+            routes = {
+                "GET /api/test": RouteConfig(
+                    accepts=PaymentOption(
+                        scheme="exact",
+                        pay_to="0x1234567890123456789012345678901234567890",
+                        price="$0.01",
+                        network="eip155:8453",
+                    ),
+                )
+            }
+
+            middleware = X402ASGIMiddleware(
+                mock_app, routes, mock_server, sync_facilitator_on_start=False
+            )
+
+            scope = make_asgi_scope(path="/api/test")
+            receive = AsyncMock()
+            messages = []
+
+            async def capture_send(message):
+                messages.append(message)
+
+            async def mock_downstream(s, r, snd):
+                await snd({
+                    "type": "http.response.start",
+                    "status": 200,
+                    "headers": [],
+                })
+                await snd({
+                    "type": "http.response.body",
+                    "body": b'{"data": "ok"}',
+                })
+
+            middleware._app = mock_downstream
+
+            await middleware(scope, receive, capture_send)
+
+            # Settlement failure should return 402
+            assert messages[0]["status"] == 402
+
+    @pytest.mark.asyncio
+    async def test_handler_error_status_cancels_settlement(self):
+        """Test that handler 4xx/5xx triggers cancellation."""
+        mock_app = AsyncMock()
+        mock_server = MagicMock()
+
+        payment_payload = make_v2_payload()
+        payment_requirements = make_payment_requirements()
+        dispatcher = MagicMock(spec=PaymentCancellationDispatcher)
+        dispatcher.cancel = AsyncMock()
+
+        with patch("x402.http.middleware.asgi.x402HTTPResourceServerSync") as mock_http_class:
+            mock_http_instance = MagicMock()
+            mock_http_instance.requires_payment.return_value = True
+            mock_http_instance.process_http_request.return_value = HTTPProcessResult(
+                type="payment-verified",
+                payment_payload=payment_payload,
+                payment_requirements=payment_requirements,
+                cancellation_dispatcher=dispatcher,
+            )
+            mock_http_instance.create_failure_path_settlement_headers.return_value = {
+                "PAYMENT-RESPONSE": "cancel_receipt"
+            }
+            mock_http_class.return_value = mock_http_instance
+
+            routes = {
+                "GET /api/test": RouteConfig(
+                    accepts=PaymentOption(
+                        scheme="exact",
+                        pay_to="0x1234567890123456789012345678901234567890",
+                        price="$0.01",
+                        network="eip155:8453",
+                    ),
+                )
+            }
+
+            middleware = X402ASGIMiddleware(
+                mock_app, routes, mock_server, sync_facilitator_on_start=False
+            )
+
+            scope = make_asgi_scope(path="/api/test")
+            receive = AsyncMock()
+            messages = []
+
+            async def capture_send(message):
+                messages.append(message)
+
+            async def mock_downstream_error(s, r, snd):
+                await snd({
+                    "type": "http.response.start",
+                    "status": 500,
+                    "headers": [],
+                })
+                await snd({
+                    "type": "http.response.body",
+                    "body": b'{"error": "failed"}',
+                })
+
+            middleware._app = mock_downstream_error
+
+            await middleware(scope, receive, capture_send)
+
+            # Should return error status with cancellation receipt
+            assert messages[0]["status"] == 500
+            dispatcher.cancel.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_handler_exception_cancels_settlement(self):
+        """Test that handler exceptions trigger cancellation."""
+        mock_app = AsyncMock()
+        mock_server = MagicMock()
+
+        payment_payload = make_v2_payload()
+        payment_requirements = make_payment_requirements()
+        dispatcher = MagicMock(spec=PaymentCancellationDispatcher)
+        dispatcher.cancel = AsyncMock()
+
+        with patch("x402.http.middleware.asgi.x402HTTPResourceServerSync") as mock_http_class:
+            mock_http_instance = MagicMock()
+            mock_http_instance.requires_payment.return_value = True
+            mock_http_instance.process_http_request.return_value = HTTPProcessResult(
+                type="payment-verified",
+                payment_payload=payment_payload,
+                payment_requirements=payment_requirements,
+                cancellation_dispatcher=dispatcher,
+            )
+            mock_http_instance.create_failure_path_settlement_headers.return_value = {
+                "PAYMENT-RESPONSE": "cancel_receipt"
+            }
+            mock_http_class.return_value = mock_http_instance
+
+            routes = {
+                "GET /api/test": RouteConfig(
+                    accepts=PaymentOption(
+                        scheme="exact",
+                        pay_to="0x1234567890123456789012345678901234567890",
+                        price="$0.01",
+                        network="eip155:8453",
+                    ),
+                )
+            }
+
+            middleware = X402ASGIMiddleware(
+                mock_app, routes, mock_server, sync_facilitator_on_start=False
+            )
+
+            scope = make_asgi_scope(path="/api/test")
+            receive = AsyncMock()
+            messages = []
+
+            async def capture_send(message):
+                messages.append(message)
+
+            async def mock_downstream_exception(s, r, snd):
+                raise RuntimeError("handler crashed")
+
+            middleware._app = mock_downstream_exception
+
+            await middleware(scope, receive, capture_send)
+
+            assert messages[0]["status"] == 500
+            dispatcher.cancel.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_facilitator_error_during_settlement_returns_502(self):
+        """Test FacilitatorResponseError during settlement returns 502."""
+        mock_app = AsyncMock()
+        mock_server = MagicMock()
+
+        payment_payload = make_v2_payload()
+        payment_requirements = make_payment_requirements()
+
+        with patch("x402.http.middleware.asgi.x402HTTPResourceServerSync") as mock_http_class:
+            mock_http_instance = MagicMock()
+            mock_http_instance.requires_payment.return_value = True
+            mock_http_instance.process_http_request.return_value = HTTPProcessResult(
+                type="payment-verified",
+                payment_payload=payment_payload,
+                payment_requirements=payment_requirements,
+            )
+            mock_http_instance.process_settlement.side_effect = FacilitatorResponseError(
+                "settle verify failed"
+            )
+            mock_http_class.return_value = mock_http_instance
+
+            routes = {
+                "GET /api/test": RouteConfig(
+                    accepts=PaymentOption(
+                        scheme="exact",
+                        pay_to="0x1234567890123456789012345678901234567890",
+                        price="$0.01",
+                        network="eip155:8453",
+                    ),
+                )
+            }
+
+            middleware = X402ASGIMiddleware(
+                mock_app, routes, mock_server, sync_facilitator_on_start=False
+            )
+
+            scope = make_asgi_scope(path="/api/test")
+            receive = AsyncMock()
+            messages = []
+
+            async def capture_send(message):
+                messages.append(message)
+
+            async def mock_downstream(s, r, snd):
+                await snd({
+                    "type": "http.response.start",
+                    "status": 200,
+                    "headers": [],
+                })
+                await snd({
+                    "type": "http.response.body",
+                    "body": b"ok",
+                })
+
+            middleware._app = mock_downstream
+
+            await middleware(scope, receive, capture_send)
+
+            assert messages[0]["status"] == 502
+
+    @pytest.mark.asyncio
+    async def test_unexpected_settlement_error_logs_and_returns_402(self, caplog):
+        """Test unexpected settlement error is logged and returns 402."""
+        mock_app = AsyncMock()
+        mock_server = MagicMock()
+
+        payment_payload = make_v2_payload()
+        payment_requirements = make_payment_requirements()
+
+        with patch("x402.http.middleware.asgi.x402HTTPResourceServerSync") as mock_http_class:
+            mock_http_instance = MagicMock()
+            mock_http_instance.requires_payment.return_value = True
+            mock_http_instance.process_http_request.return_value = HTTPProcessResult(
+                type="payment-verified",
+                payment_payload=payment_payload,
+                payment_requirements=payment_requirements,
+            )
+            mock_http_instance.process_settlement.side_effect = RuntimeError("RPC timeout")
+            mock_http_instance._create_settlement_headers.return_value = {
+                "PAYMENT-RESPONSE": "error_receipt"
+            }
+            mock_http_class.return_value = mock_http_instance
+
+            routes = {
+                "GET /api/test": RouteConfig(
+                    accepts=PaymentOption(
+                        scheme="exact",
+                        pay_to="0x1234567890123456789012345678901234567890",
+                        price="$0.01",
+                        network="eip155:8453",
+                    ),
+                )
+            }
+
+            middleware = X402ASGIMiddleware(
+                mock_app, routes, mock_server, sync_facilitator_on_start=False
+            )
+
+            scope = make_asgi_scope(path="/api/test")
+            receive = AsyncMock()
+            messages = []
+
+            async def capture_send(message):
+                messages.append(message)
+
+            async def mock_downstream(s, r, snd):
+                await snd({
+                    "type": "http.response.start",
+                    "status": 200,
+                    "headers": [],
+                })
+                await snd({
+                    "type": "http.response.body",
+                    "body": b"ok",
+                })
+
+            middleware._app = mock_downstream
+
+            with caplog.at_level(logging.ERROR):
+                await middleware(scope, receive, capture_send)
+
+            assert messages[0]["status"] == 402
+            assert any("unexpected error while settling" in r.getMessage() for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_payment_verified_stores_in_existing_state(self):
+        """Test that payment info is stored when scope['state'] already exists."""
+        mock_app = AsyncMock()
+        mock_server = MagicMock()
+
+        payment_payload = make_v2_payload()
+        payment_requirements = make_payment_requirements()
+
+        with patch("x402.http.middleware.asgi.x402HTTPResourceServerSync") as mock_http_class:
+            mock_http_instance = MagicMock()
+            mock_http_instance.requires_payment.return_value = True
+            mock_http_instance.process_http_request.return_value = HTTPProcessResult(
+                type="payment-verified",
+                payment_payload=payment_payload,
+                payment_requirements=payment_requirements,
+            )
+            mock_http_instance.process_settlement.return_value = ProcessSettleResult(
+                success=True,
+                headers={},
+            )
+            mock_http_class.return_value = mock_http_instance
+
+            routes = {
+                "GET /api/test": RouteConfig(
+                    accepts=PaymentOption(
+                        scheme="exact",
+                        pay_to="0x1234567890123456789012345678901234567890",
+                        price="$0.01",
+                        network="eip155:8453",
+                    ),
+                )
+            }
+
+            middleware = X402ASGIMiddleware(
+                mock_app, routes, mock_server, sync_facilitator_on_start=False
+            )
+
+            scope = make_asgi_scope(
+                path="/api/test",
+                state={"existing_key": "existing_value"},
+            )
+            receive = AsyncMock()
+            messages = []
+
+            async def capture_send(message):
+                messages.append(message)
+
+            async def mock_downstream(s, r, snd):
+                state = s.get("state", {})
+                assert state["existing_key"] == "existing_value"
+                assert "x402_payment_payload" in state
+                await snd({
+                    "type": "http.response.start",
+                    "status": 200,
+                    "headers": [],
+                })
+                await snd({
+                    "type": "http.response.body",
+                    "body": b"ok",
+                })
+
+            middleware._app = mock_downstream
+
+            await middleware(scope, receive, capture_send)
+            assert messages[0]["status"] == 200
+
+
+# =============================================================================
+# Convenience Function Tests
+# =============================================================================
+
+
+class TestPaymentMiddlewareFactory:
+    """Tests for payment_middleware factory function."""
+
+    def test_returns_callable(self):
+        """Test that factory returns a callable."""
+        mock_server = MagicMock()
+        routes = {}
+
+        factory = payment_middleware(routes, mock_server, sync_facilitator_on_start=False)
+
+        assert callable(factory)
+
+    def test_factory_wraps_app(self):
+        """Test that factory creates middleware wrapping the app."""
+        mock_app = AsyncMock()
+        mock_server = MagicMock()
+        routes = {}
+
+        factory = payment_middleware(routes, mock_server, sync_facilitator_on_start=False)
+        middleware = factory(mock_app)
+
+        assert isinstance(middleware, X402ASGIMiddleware)
+        assert middleware._app is mock_app


### PR DESCRIPTION
## Summary

Adds `x402.http.middleware.asgi` — a generic ASGI middleware that provides x402 payment-gated route protection for **any** ASGI framework without framework-specific dependencies.

Currently x402 has middleware for FastAPI (Starlette-based), Flask (WSGI), and Django, but no support for non-Starlette ASGI frameworks like Litestar, BlackSheep, Quart, or raw ASGI apps. This PR fills that gap.

## What was built

### `python/x402/http/middleware/asgi.py`

- **`ASGIAdapter`** — `HTTPAdapter` implementation that extracts headers, method, path, and query params from raw ASGI scope dicts (byte-encoded header tuples)
- **`X402ASGIMiddleware`** — Pure ASGI middleware class (`scope/receive/send`) that:
  - Intercepts HTTP requests on payment-protected routes
  - Passes through lifespan and WebSocket scope types transparently
  - Stores payment info in `scope['state']` for downstream handler access
  - Uses `x402HTTPResourceServerSync` (sync variant) since settlement is synchronous
  - Implements double-checked locking for lazy facilitator initialization
- **`payment_middleware()`** — Factory function returning a callable that wraps any ASGI app
- **`payment_middleware_from_config()`** — Convenience factory creating server from facilitator client + scheme registrations

### `python/x402/tests/unit/http/middleware/test_asgi.py`

Comprehensive test coverage including:
- ASGIAdapter header extraction (case-insensitive), method, path, URL reconstruction, query params
- Query string parsing edge cases
- Middleware passthrough for non-HTTP scopes (lifespan, WebSocket)
- Payment-free route passthrough
- Facilitator error → 502 response
- Unexpected error → 500 response (no details leaked)
- Payment error → 402 with response body
- Payment verified → stores in `scope['state']`, settlement success
- Settlement failure → 402 with settlement headers
- Handler error status triggers cancellation
- Handler exception triggers cancellation
- Facilitator error during settlement → 502
- Unexpected settlement error → logged + 402 with PAYMENT-RESPONSE
- Factory function returns callable wrapper

### Updated files

- `__init__.py` — Added lazy imports for `ASGIAdapter`, `X402ASGIMiddleware`, `asgi_payment_middleware`, `asgi_payment_middleware_from_config`
- `README.md` — Added Generic ASGI section with usage examples, convenience function, `scope['state']` access pattern, and exports table

## Design decisions

1. **No framework dependencies** — Works with any ASGI app; no need for Starlette, FastAPI, etc.
2. **Sync settlement** — Uses `x402HTTPResourceServerSync` because ASGI middleware runs async but settlement is sync (same pattern as Flask/Django middleware)
3. **`scope['state']`** — Payment info stored in ASGI scope state dict for downstream access, following ASGI conventions
4. **Response capture** — Downstream response intercepted via `capture_send` wrapper, enabling settlement processing before forwarding to client
5. **Lifespan/WebSocket passthrough** — Only HTTP scope type is intercepted; other scope types pass through directly

## Usage

```python
from x402.http.middleware.asgi import X402ASGIMiddleware

# Works with ANY ASGI framework
app = X402ASGIMiddleware(
    app=your_asgi_app,
    routes=routes,
    server=resource_server,
)

# Or via factory
from x402.http.middleware.asgi import payment_middleware
middleware = payment_middleware(routes, server)
app = middleware(your_asgi_app)
```

## Sync/Async matching

| Framework | Server | Facilitator Client |
|-----------|--------|-------------------|
| FastAPI | `x402ResourceServer` | `HTTPFacilitatorClient` |
| Flask | `x402ResourceServerSync` | `HTTPFacilitatorClientSync` |
| Generic ASGI | `x402ResourceServerSync` | `HTTPFacilitatorClientSync` |