### PR TITLE
test(mcp): add comprehensive edge case tests for MCP client module

### DIFF
--- a/python/x402/http/middleware/README.md
+++ b/python/x402/http/middleware/README.md
@@ -119,14 +119,82 @@ from x402.http.middleware import payment_middleware
 payment_middleware(app, routes, server, paywall_config={"appName": "My API"})
 ```
 
+## Django (Sync)
+
+```bash
+uv add x402[django]
+```
+
+### Basic Usage
+
+```python
+# settings.py
+MIDDLEWARE = [
+    "x402.http.middleware.django.X402PaymentMiddleware",
+    # ... other middleware
+]
+
+X402_ROUTES = {
+    "GET /api/weather/*": {
+        "accepts": {
+            "scheme": "exact",
+            "payTo": "0x...",
+            "price": "$0.01",
+            "network": "eip155:84532",
+        },
+    },
+}
+X402_FACILITATOR_URL = "https://x402.org/facilitator"
+```
+
+### Accessing Payment Info
+
+```python
+# views.py
+from django.http import JsonResponse
+
+def weather(request):
+    payload = request.x402_payment_payload
+    requirements = request.x402_payment_requirements
+    return JsonResponse({"weather": "sunny", "payer": payload.accepted.payTo})
+```
+
+### Factory Function
+
+```python
+# For custom server configuration outside of settings
+from x402 import x402ResourceServerSync
+from x402.http import HTTPFacilitatorClientSync
+from x402.http.middleware.django import payment_middleware
+
+facilitator = HTTPFacilitatorClientSync(url="https://x402.org/facilitator")
+server = x402ResourceServerSync(facilitator)
+server.register("eip155:*", ExactEvmServerScheme())
+
+X402PaymentMiddleware = payment_middleware(routes, server)
+# Add to MIDDLEWARE in settings.py
+```
+
+### Django Settings
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `X402_ROUTES` | dict | `{}` | Route configuration for protected endpoints |
+| `X402_FACILITATOR_URL` | str | `"https://x402.org/facilitator"` | Facilitator service URL |
+| `X402_FACILITATOR_CLIENT` | FacilitatorClient | `None` | Custom facilitator client (overrides URL) |
+| `X402_SCHEMES` | list | `[]` | Scheme registrations for server-side processing |
+| `X402_PAYWALL_CONFIG` | dict | `None` | Paywall UI configuration |
+| `X402_SYNC_FACILITATOR_ON_START` | bool | `True` | Fetch facilitator support when middleware is created |
+
 ## Sync/Async Matching
 
 | Framework | Server | Facilitator Client |
 |-----------|--------|-------------------|
 | FastAPI | `x402ResourceServer` | `HTTPFacilitatorClient` |
 | Flask | `x402ResourceServerSync` | `HTTPFacilitatorClientSync` |
+| Django | `x402ResourceServerSync` | `HTTPFacilitatorClientSync` |
 
-Using async components with Flask raises `TypeError`.
+Using async components with Flask or Django raises `TypeError`.
 
 ## Route Patterns
 
@@ -184,4 +252,13 @@ PaymentMiddleware(app, routes, server, paywall_provider=MyPaywall())
 | `payment_middleware()` | Convenience function |
 | `payment_middleware_from_config()` | Create from config dict |
 | `FlaskAdapter` | HTTPAdapter for Flask |
+
+### Django
+
+| Export | Description |
+|--------|-------------|
+| `X402PaymentMiddleware` | Django middleware class |
+| `payment_middleware()` | Factory function for custom server |
+| `DjangoAdapter` | HTTPAdapter for Django |
+| `set_settlement_overrides()` | Set settlement overrides on response |
 

--- a/python/x402/http/middleware/__init__.py
+++ b/python/x402/http/middleware/__init__.py
@@ -1,6 +1,6 @@
 """HTTP middleware for x402 payment handling.
 
-Provides server-side middleware for FastAPI and Flask that
+Provides server-side middleware for FastAPI, Flask, and Django that
 protects endpoints with x402 payment requirements.
 
 Note: Import specific middleware modules directly to avoid
@@ -8,6 +8,7 @@ requiring all framework dependencies:
 
     from x402.http.middleware.fastapi import payment_middleware
     from x402.http.middleware.flask import PaymentMiddleware
+    from x402.http.middleware.django import X402PaymentMiddleware
 """
 
 # Lazy imports - only import when the module is accessed to avoid
@@ -25,6 +26,11 @@ __all__ = [
     "ResponseWrapper",
     "flask_payment_middleware",
     "flask_payment_middleware_from_config",
+    # Django
+    "DjangoAdapter",
+    "X402PaymentMiddleware",
+    "django_payment_middleware",
+    "django_set_settlement_overrides",
 ]
 
 
@@ -68,5 +74,23 @@ def __getattr__(name: str):
             return _flask.payment_middleware
         elif name == "flask_payment_middleware_from_config":
             return _flask.payment_middleware_from_config
+
+    # Django imports
+    if name in (
+        "DjangoAdapter",
+        "X402PaymentMiddleware",
+        "django_payment_middleware",
+        "django_set_settlement_overrides",
+    ):
+        from . import django as _django
+
+        if name == "DjangoAdapter":
+            return _django.DjangoAdapter
+        elif name == "X402PaymentMiddleware":
+            return _django.X402PaymentMiddleware
+        elif name == "django_payment_middleware":
+            return _django.payment_middleware
+        elif name == "django_set_settlement_overrides":
+            return _django.set_settlement_overrides
 
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/python/x402/http/middleware/django.py
+++ b/python/x402/http/middleware/django.py
@@ -1,0 +1,785 @@
+"""Django middleware for x402 payment handling.
+
+Provides payment-gated route protection for Django applications.
+Uses x402HTTPResourceServerSync for synchronous request processing.
+
+Example:
+    ```python
+    # settings.py
+    MIDDLEWARE = [
+        "x402.http.middleware.django.X402PaymentMiddleware",
+        # ... other middleware
+    ]
+
+    X402_ROUTES = {
+        "GET /api/weather/*": {
+            "accepts": {
+                "scheme": "exact",
+                "payTo": "0x...",
+                "price": "$0.01",
+                "network": "eip155:84532",
+            },
+            "description": "Weather API",
+        },
+    }
+    X402_FACILITATOR_URL = "https://x402.org/facilitator"
+    ```
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from typing import TYPE_CHECKING, Any
+
+try:
+    from django.conf import settings
+    from django.http import HttpRequest, JsonResponse, HttpResponse
+except ImportError as e:
+    raise ImportError(
+        "Django middleware requires django. Install with: uv add x402[django]"
+    ) from e
+
+from ...schemas import SettleResponse, VerifiedPaymentCancelOptions
+from ..background_init import handle_background_init_error
+from ..constants import SETTLEMENT_OVERRIDES_HEADER
+from ..facilitator_client_base import FacilitatorResponseError
+from ..types import (
+    HTTPAdapter,
+    HTTPRequestContext,
+    HTTPTransportContext,
+    PaywallConfig,
+    RoutesConfig,
+)
+from ..x402_http_server import PaywallProvider, x402HTTPResourceServerSync
+from ..x402_http_server_base import PAYMENT_REQUIRED_CACHE_CONTROL, with_private_cache_control
+
+if TYPE_CHECKING:
+    from ...server import x402ResourceServerSync
+
+# ============================================================================
+# Extension Auto-Registration
+# ============================================================================
+
+from ._bazaar_utils import (
+    check_if_bazaar_needed as _check_if_bazaar_needed,
+)
+from ._bazaar_utils import (
+    register_bazaar_extension as _register_bazaar_extension,
+)
+from ._bazaar_utils import (
+    validate_bazaar_extensions as _validate_bazaar_extensions,
+)
+
+logger = logging.getLogger(__name__)
+
+# ============================================================================
+# Django Adapter
+# ============================================================================
+
+
+class DjangoAdapter(HTTPAdapter):
+    """Adapter for Django HttpRequest.
+
+    Implements HTTPAdapter protocol for Django framework.
+    """
+
+    def __init__(self, request: HttpRequest) -> None:
+        """Create adapter from Django request.
+
+        Args:
+            request: Django HttpRequest object.
+        """
+        self._request = request
+
+    def get_header(self, name: str) -> str | None:
+        """Get header value (case-insensitive).
+
+        Django stores headers in META with HTTP_ prefix and uppercased.
+        Also handles Content-Type and Content-Length which lack the prefix.
+
+        Args:
+            name: Header name.
+
+        Returns:
+            Header value or None.
+        """
+        # Django normalizes headers to META: "Content-Type" -> "CONTENT_TYPE",
+        # "X-Custom" -> "HTTP_X_CUSTOM"
+        meta_key = name.replace("-", "_").upper()
+        if meta_key in ("CONTENT_TYPE", "CONTENT_LENGTH"):
+            return self._request.META.get(meta_key)
+        return self._request.META.get(f"HTTP_{meta_key}")
+
+    def get_method(self) -> str:
+        """Get HTTP method.
+
+        Returns:
+            HTTP method (GET, POST, etc.).
+        """
+        return self._request.method
+
+    def get_path(self) -> str:
+        """Get request path.
+
+        Returns:
+            Request path.
+        """
+        return self._request.path
+
+    def get_url(self) -> str:
+        """Get full request URL.
+
+        Returns:
+            Full URL string.
+        """
+        return self._request.build_absolute_uri()
+
+    def get_accept_header(self) -> str:
+        """Get Accept header.
+
+        Returns:
+            Accept header value.
+        """
+        return self._request.META.get("HTTP_ACCEPT", "")
+
+    def get_user_agent(self) -> str:
+        """Get User-Agent header.
+
+        Returns:
+            User-Agent header value.
+        """
+        return self._request.META.get("HTTP_USER_AGENT", "")
+
+    def get_query_params(self) -> dict[str, str | list[str]]:
+        """Get query parameters.
+
+        Returns:
+            Dict of query parameters.
+        """
+        return dict(self._request.GET)
+
+    def get_query_param(self, name: str) -> str | None:
+        """Get single query parameter.
+
+        Args:
+            name: Parameter name.
+
+        Returns:
+            Parameter value or None.
+        """
+        return self._request.GET.get(name)
+
+    def get_body(self) -> Any:
+        """Get request body.
+
+        Returns:
+            Parsed JSON body or None.
+        """
+        if not self._request.body:
+            return None
+        try:
+            return json.loads(self._request.body)
+        except (json.JSONDecodeError, TypeError):
+            return None
+
+
+# ============================================================================
+# Response Helpers
+# ============================================================================
+
+
+def _json_error_response(
+    status: int,
+    detail: str,
+    headers: dict[str, str] | None = None,
+) -> JsonResponse:
+    """Build a JSON error response.
+
+    Args:
+        status: HTTP status code.
+        detail: Error detail message.
+        headers: Optional extra headers.
+
+    Returns:
+        Django JsonResponse.
+    """
+    resp = JsonResponse({"error": detail}, status=status)
+    if headers:
+        for key, value in headers.items():
+            resp[key] = value
+    return resp
+
+
+# ============================================================================
+# Django Middleware Class
+# ============================================================================
+
+
+class X402PaymentMiddleware:
+    """Django middleware for x402 payment handling.
+
+    Django processes WSGI requests synchronously. This middleware wraps the
+    Django WSGI application and intercepts requests to protected routes,
+    verifying x402 payments before forwarding to the view.
+
+    Payment info is attached to ``request.x402_payment_payload`` and
+    ``request.x402_payment_requirements`` for downstream views.
+
+    Example:
+        ```python
+        # settings.py
+        MIDDLEWARE = [
+            "x402.http.middleware.django.X402PaymentMiddleware",
+            # ... other middleware
+        ]
+
+        X402_ROUTES = {
+            "GET /api/weather/*": {
+                "accepts": {
+                    "scheme": "exact",
+                    "payTo": "0x...",
+                    "price": "$0.01",
+                    "network": "eip155:84532",
+                },
+            },
+        }
+        ```
+    """
+
+    def __init__(self, get_response: Any = None) -> None:
+        """Initialize Django payment middleware.
+
+        Supports both Django new-style middleware (get_response parameter)
+        and legacy WSGI-style initialization via Django settings.
+
+        Args:
+            get_response: Next middleware in the chain (Django new-style).
+        """
+        self._get_response = get_response
+
+        # Load configuration from Django settings
+        routes = getattr(settings, "X402_ROUTES", {})
+        facilitator_url = getattr(settings, "X402_FACILITATOR_URL", "https://x402.org/facilitator")
+        paywall_config_dict = getattr(settings, "X402_PAYWALL_CONFIG", None)
+
+        # Build paywall config
+        paywall_config = None
+        if paywall_config_dict:
+            paywall_config = PaywallConfig(
+                app_name=paywall_config_dict.get("app_name"),
+                app_logo=paywall_config_dict.get("app_logo"),
+                testnet=paywall_config_dict.get("testnet", False),
+                faucet_urls=paywall_config_dict.get("faucet_urls"),
+            )
+
+        # Create server
+        from ...server import x402ResourceServerSync
+
+        facilitator = getattr(settings, "X402_FACILITATOR_CLIENT", None)
+        if facilitator is None:
+            from ..facilitator_client import HTTPFacilitatorClientSync
+
+            facilitator = HTTPFacilitatorClientSync(url=facilitator_url)
+
+        server = x402ResourceServerSync(facilitator)
+
+        # Register schemes from settings
+        schemes = getattr(settings, "X402_SCHEMES", [])
+        for registration in schemes:
+            server.register(registration["network"], registration["server"])
+
+        # Auto-register bazaar extension if routes declare it
+        if _check_if_bazaar_needed(routes):
+            _register_bazaar_extension(server)
+            _validate_bazaar_extensions(routes)
+
+        self._http_server = x402HTTPResourceServerSync(server, routes)
+        self._paywall_config = paywall_config
+
+        # Lazy initialization state
+        self._sync_on_start = getattr(settings, "X402_SYNC_FACILITATOR_ON_START", True)
+        self._init_done = False
+        self._init_lock = threading.Lock()
+
+        if self._sync_on_start:
+            try:
+                self._http_server.initialize()
+                self._init_done = True
+            except Exception as error:
+                handle_background_init_error(error)
+
+    def __call__(self, request: HttpRequest) -> Any:
+        """Process request through x402 payment middleware.
+
+        Args:
+            request: Django HttpRequest.
+
+        Returns:
+            Django HttpResponse.
+        """
+        # Create adapter and context
+        adapter = DjangoAdapter(request)
+        context = HTTPRequestContext(
+            adapter=adapter,
+            path=request.path,
+            method=request.method,
+            payment_header=(
+                adapter.get_header("payment-signature")
+                or adapter.get_header("x-payment")
+            ),
+        )
+
+        # Check if route requires payment
+        if not self._http_server.requires_payment(context):
+            return self._get_response(request)
+
+        # Initialize on first protected request (double-checked locking)
+        if self._sync_on_start and not self._init_done:
+            with self._init_lock:
+                if not self._init_done:
+                    try:
+                        self._http_server.initialize()
+                    except FacilitatorResponseError as error:
+                        return _json_error_response(502, str(error))
+                    self._init_done = True
+
+        # Process payment request synchronously
+        try:
+            result = self._http_server.process_http_request(context, self._paywall_config)
+        except FacilitatorResponseError as error:
+            return _json_error_response(502, str(error))
+        except Exception:
+            logger.exception("x402: unexpected error while processing an HTTP payment request")
+            return _json_error_response(500, "Internal Server Error")
+
+        if result.type == "no-payment-required":
+            return self._get_response(request)
+
+        if result.type == "payment-error":
+            response = result.response
+            if response is None:
+                return _json_error_response(402, "Payment required")
+
+            if response.is_html:
+                return HttpResponse(
+                    content=response.body,
+                    status=response.status,
+                    content_type="text/html; charset=utf-8",
+                    headers=response.headers,
+                )
+            return JsonResponse(
+                content=response.body or {},
+                status=response.status,
+                headers=response.headers,
+            )
+
+        if result.type == "payment-verified":
+            # Store payment info on request for downstream views
+            request.x402_payment_payload = result.payment_payload
+            request.x402_payment_requirements = result.payment_requirements
+
+            dispatcher = result.cancellation_dispatcher
+            transport_context = HTTPTransportContext(request=context)
+
+            # Call downstream
+            try:
+                response = self._get_response(request)
+            except Exception as error:
+                cancel_settlement = None
+                if dispatcher is not None:
+                    cancel_settlement = dispatcher.cancel_sync(
+                        VerifiedPaymentCancelOptions(reason="handler_threw", error=error)
+                    )
+                failure_headers = self._http_server.create_failure_path_settlement_headers(
+                    cancel_settlement,
+                    result.before_handler_settlement,
+                    result.payment_payload,
+                )
+                if not isinstance(failure_headers, dict) or not failure_headers:
+                    raise
+                return _json_error_response(500, "Internal Server Error", failure_headers)
+
+            # Don't settle on error responses
+            if response.status_code >= 400:
+                cancel_settlement = None
+                if dispatcher is not None:
+                    cancel_settlement = dispatcher.cancel_sync(
+                        VerifiedPaymentCancelOptions(
+                            reason="handler_failed",
+                            response_status=response.status_code,
+                        )
+                    )
+                failure_headers = self._http_server.create_failure_path_settlement_headers(
+                    cancel_settlement,
+                    result.before_handler_settlement,
+                    result.payment_payload,
+                    response.get("Cache-Control"),
+                )
+                if isinstance(failure_headers, dict):
+                    for key, value in failure_headers.items():
+                        response[key] = value
+                return response
+
+            # Extract response body for buffering
+            body = b""
+            if hasattr(response, "content"):
+                body = response.content
+            elif hasattr(response, "streaming_content"):
+                for chunk in response.streaming_content:
+                    body += chunk
+
+            # Extract and strip settlement overrides
+            response_headers = dict(response.items())
+            overrides = self._http_server._extract_settlement_overrides(response_headers)
+            if overrides is not None:
+                for key in list(response.keys()):
+                    if key.lower() == SETTLEMENT_OVERRIDES_HEADER.lower():
+                        del response[key]
+                response_headers = {k: v for k, v in response_headers.items()
+                                   if k.lower() != SETTLEMENT_OVERRIDES_HEADER.lower()}
+
+            transport_context.response_headers = response_headers
+
+            # Process settlement
+            try:
+                settle_result = self._http_server.process_settlement(
+                    result.payment_payload,
+                    result.payment_requirements,
+                    context=context,
+                    settlement_overrides=overrides,
+                    declared_extensions=result.declared_extensions,
+                    transport_context=transport_context,
+                    before_handler_settlement=result.before_handler_settlement,
+                )
+
+                if not settle_result.success:
+                    settle_response = settle_result.response
+                    if settle_response is None:
+                        return JsonResponse({}, status=402)
+                    if settle_response.is_html:
+                        return HttpResponse(
+                            content=settle_response.body,
+                            status=settle_response.status,
+                            content_type="text/html; charset=utf-8",
+                            headers=settle_response.headers,
+                        )
+                    return JsonResponse(
+                        content=settle_response.body or {},
+                        status=settle_response.status,
+                        headers=settle_response.headers,
+                    )
+
+                # Add settlement headers
+                headers = dict(response.items())
+                headers.update(settle_result.headers)
+                existing_cc = headers.get("Cache-Control")
+                headers["Cache-Control"] = with_private_cache_control(existing_cc)
+
+                return HttpResponse(
+                    content=body,
+                    status=response.status_code,
+                    headers=headers,
+                    content_type=response.get("Content-Type", "application/octet-stream"),
+                )
+
+            except FacilitatorResponseError as error:
+                return _json_error_response(502, str(error))
+            except Exception:
+                logger.exception("x402: unexpected error while settling a verified payment")
+                settle_response = SettleResponse(
+                    success=False,
+                    error_reason="unexpected_settle_error",
+                    error_message="unexpected error while settling the verified payment",
+                    transaction="",
+                    network=result.payment_requirements.network,
+                )
+                settle_headers = self._http_server._create_settlement_headers(
+                    settle_response, result.payment_requirements
+                )
+                return JsonResponse(
+                    {},
+                    status=402,
+                    headers={
+                        "Cache-Control": PAYMENT_REQUIRED_CACHE_CONTROL,
+                        **settle_headers,
+                    },
+                )
+
+        # Fallthrough
+        return self._get_response(request)
+
+
+# ============================================================================
+# Convenience Functions
+# ============================================================================
+
+
+def set_settlement_overrides(response: HttpResponse, overrides: dict[str, Any]) -> None:
+    """Set settlement overrides on a Django response for partial settlement.
+
+    The middleware extracts these before settlement and strips the header
+    from the client response.
+
+    Args:
+        response: Django ``HttpResponse`` object.
+        overrides: Settlement overrides, e.g. ``{"amount": "500"}``.
+    """
+    response[SETTLEMENT_OVERRIDES_HEADER] = json.dumps(overrides)
+
+
+def payment_middleware(
+    routes: RoutesConfig,
+    server: x402ResourceServerSync,
+    paywall_config: PaywallConfig | None = None,
+    paywall_provider: PaywallProvider | None = None,
+    sync_facilitator_on_start: bool = True,
+) -> type:
+    """Create a Django middleware class with pre-configured server.
+
+    This is a factory function for cases where you want to pass the server
+    directly instead of configuring via Django settings.
+
+    Args:
+        routes: Route configuration for protected endpoints.
+        server: Pre-configured x402ResourceServerSync.
+        paywall_config: Optional paywall UI configuration.
+        paywall_provider: Optional custom paywall provider.
+        sync_facilitator_on_start: Fetch facilitator support when middleware is created.
+
+    Returns:
+        Django middleware class.
+
+    Example:
+        ```python
+        # urls.py or custom settings
+        from x402 import x402ResourceServerSync
+        from x402.http import HTTPFacilitatorClientSync
+        from x402.http.middleware.django import payment_middleware
+
+        facilitator = HTTPFacilitatorClientSync()
+        server = x402ResourceServerSync(facilitator)
+
+        routes = {
+            "GET /api/weather/*": {
+                "accepts": {
+                    "scheme": "exact",
+                    "payTo": "0x...",
+                    "price": "$0.01",
+                    "network": "eip155:84532",
+                }
+            }
+        }
+
+        X402PaymentMiddleware = payment_middleware(routes, server)
+        # Add to MIDDLEWARE in settings.py
+        ```
+    """
+    # Auto-register bazaar extension if routes declare it
+    if _check_if_bazaar_needed(routes):
+        _register_bazaar_extension(server)
+        _validate_bazaar_extensions(routes)
+
+    http_server = x402HTTPResourceServerSync(server, routes)
+
+    if paywall_provider:
+        http_server.register_paywall_provider(paywall_provider)
+
+    init_done = False
+    init_lock = threading.Lock()
+
+    if sync_facilitator_on_start:
+        try:
+            http_server.initialize()
+            init_done = True
+        except Exception as error:
+            handle_background_init_error(error)
+
+    class ConfiguredX402Middleware:
+        """Django middleware with pre-configured x402 server."""
+
+        def __init__(self, get_response: Any = None) -> None:
+            self._get_response = get_response
+
+        def __call__(self, request: HttpRequest) -> Any:
+            nonlocal init_done
+
+            adapter = DjangoAdapter(request)
+            context = HTTPRequestContext(
+                adapter=adapter,
+                path=request.path,
+                method=request.method,
+                payment_header=(
+                    adapter.get_header("payment-signature")
+                    or adapter.get_header("x-payment")
+                ),
+            )
+
+            if not http_server.requires_payment(context):
+                return self._get_response(request)
+
+            if sync_facilitator_on_start and not init_done:
+                with init_lock:
+                    if not init_done:
+                        try:
+                            http_server.initialize()
+                        except FacilitatorResponseError as error:
+                            return _json_error_response(502, str(error))
+                        init_done = True
+
+            try:
+                result = http_server.process_http_request(context, paywall_config)
+            except FacilitatorResponseError as error:
+                return _json_error_response(502, str(error))
+            except Exception:
+                logger.exception("x402: unexpected error while processing an HTTP payment request")
+                return _json_error_response(500, "Internal Server Error")
+
+            if result.type == "no-payment-required":
+                return self._get_response(request)
+
+            if result.type == "payment-error":
+                response = result.response
+                if response is None:
+                    return _json_error_response(402, "Payment required")
+                if response.is_html:
+                    return HttpResponse(
+                        content=response.body,
+                        status=response.status,
+                        content_type="text/html; charset=utf-8",
+                        headers=response.headers,
+                    )
+                return JsonResponse(
+                    content=response.body or {},
+                    status=response.status,
+                    headers=response.headers,
+                )
+
+            if result.type == "payment-verified":
+                request.x402_payment_payload = result.payment_payload
+                request.x402_payment_requirements = result.payment_requirements
+                dispatcher = result.cancellation_dispatcher
+                transport_context = HTTPTransportContext(request=context)
+
+                try:
+                    response = self._get_response(request)
+                except Exception as error:
+                    cancel_settlement = None
+                    if dispatcher is not None:
+                        cancel_settlement = dispatcher.cancel_sync(
+                            VerifiedPaymentCancelOptions(reason="handler_threw", error=error)
+                        )
+                    failure_headers = http_server.create_failure_path_settlement_headers(
+                        cancel_settlement,
+                        result.before_handler_settlement,
+                        result.payment_payload,
+                    )
+                    if not isinstance(failure_headers, dict) or not failure_headers:
+                        raise
+                    return _json_error_response(500, "Internal Server Error", failure_headers)
+
+                if response.status_code >= 400:
+                    cancel_settlement = None
+                    if dispatcher is not None:
+                        cancel_settlement = dispatcher.cancel_sync(
+                            VerifiedPaymentCancelOptions(
+                                reason="handler_failed",
+                                response_status=response.status_code,
+                            )
+                        )
+                    failure_headers = http_server.create_failure_path_settlement_headers(
+                        cancel_settlement,
+                        result.before_handler_settlement,
+                        result.payment_payload,
+                        response.get("Cache-Control"),
+                    )
+                    if isinstance(failure_headers, dict):
+                        for key, value in failure_headers.items():
+                            response[key] = value
+                    return response
+
+                body = b""
+                if hasattr(response, "content"):
+                    body = response.content
+                elif hasattr(response, "streaming_content"):
+                    for chunk in response.streaming_content:
+                        body += chunk
+
+                response_headers = dict(response.items())
+                overrides = http_server._extract_settlement_overrides(response_headers)
+                if overrides is not None:
+                    for key in list(response.keys()):
+                        if key.lower() == SETTLEMENT_OVERRIDES_HEADER.lower():
+                            del response[key]
+                    response_headers = {k: v for k, v in response_headers.items()
+                                       if k.lower() != SETTLEMENT_OVERRIDES_HEADER.lower()}
+
+                transport_context.response_headers = response_headers
+
+                try:
+                    settle_result = http_server.process_settlement(
+                        result.payment_payload,
+                        result.payment_requirements,
+                        context=context,
+                        settlement_overrides=overrides,
+                        declared_extensions=result.declared_extensions,
+                        transport_context=transport_context,
+                        before_handler_settlement=result.before_handler_settlement,
+                    )
+
+                    if not settle_result.success:
+                        settle_response = settle_result.response
+                        if settle_response is None:
+                            return JsonResponse({}, status=402)
+                        if settle_response.is_html:
+                            return HttpResponse(
+                                content=settle_response.body,
+                                status=settle_response.status,
+                                content_type="text/html; charset=utf-8",
+                                headers=settle_response.headers,
+                            )
+                        return JsonResponse(
+                            content=settle_response.body or {},
+                            status=settle_response.status,
+                            headers=settle_response.headers,
+                        )
+
+                    headers = dict(response.items())
+                    headers.update(settle_result.headers)
+                    existing_cc = headers.get("Cache-Control")
+                    headers["Cache-Control"] = with_private_cache_control(existing_cc)
+
+                    return HttpResponse(
+                        content=body,
+                        status=response.status_code,
+                        headers=headers,
+                        content_type=response.get("Content-Type", "application/octet-stream"),
+                    )
+
+                except FacilitatorResponseError as error:
+                    return _json_error_response(502, str(error))
+                except Exception:
+                    logger.exception("x402: unexpected error while settling a verified payment")
+                    settle_response = SettleResponse(
+                        success=False,
+                        error_reason="unexpected_settle_error",
+                        error_message="unexpected error while settling the verified payment",
+                        transaction="",
+                        network=result.payment_requirements.network,
+                    )
+                    settle_headers = http_server._create_settlement_headers(
+                        settle_response, result.payment_requirements
+                    )
+                    return JsonResponse(
+                        {},
+                        status=402,
+                        headers={
+                            "Cache-Control": PAYMENT_REQUIRED_CACHE_CONTROL,
+                            **settle_headers,
+                        },
+                    )
+
+            return self._get_response(request)
+
+    return ConfiguredX402Middleware

--- a/python/x402/mcp/tests/test_client_edge_cases.py
+++ b/python/x402/mcp/tests/test_client_edge_cases.py
@@ -1,0 +1,1790 @@
+"""Edge case tests for MCP client module.
+
+Covers error handling, timeouts, retries, malformed responses, and unusual
+scenarios for both sync (x402MCPClientSync) and async (x402MCPClient) clients.
+
+The sync client (x402MCPClientSync from client.py) has a simpler API:
+  call_tool, call_tool_with_payment, client, payment_client.
+The async client (x402MCPClient from client_async.py) adds hooks and probing:
+  on_payment_required, on_before_payment, on_after_payment,
+  get_tool_payment_requirements, call_tool_with_payment.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from x402.mcp import PaymentRequiredError, x402MCPClient, x402MCPClientSync
+from x402.mcp.types import (
+    MCPToolCallResult,
+    MCPToolResult,
+    PaymentRequiredHookResult,
+)
+from x402.mcp.utils import (
+    _extract_payment_required_from_object,
+    convert_mcp_result,
+    extract_payment_required_from_error,
+    extract_payment_required_from_result,
+)
+from x402.schemas import PaymentPayload, PaymentRequired
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+VALID_PAYMENT_REQUIRED_JSON = (
+    '{"x402Version":2,"accepts":[{"scheme":"exact","network":"eip155:84532",'
+    '"amount":"1000","asset":"USDC","payTo":"0xrecipient","maxTimeoutSeconds":300}]}'
+)
+
+VALID_PAYMENT_REQUIRED_DICT = {
+    "x402Version": 2,
+    "accepts": [
+        {
+            "scheme": "exact",
+            "network": "eip155:84532",
+            "amount": "1000",
+            "asset": "USDC",
+            "payTo": "0xrecipient",
+            "maxTimeoutSeconds": 300,
+        }
+    ],
+}
+
+
+class MockMCPResult:
+    """Mock raw MCP result (has isError, matching real MCP SDK shape)."""
+
+    def __init__(self, content=None, is_error=False, meta=None, structured_content=None):
+        self.content = content or [{"type": "text", "text": "pong"}]
+        self.isError = is_error
+        self._meta = meta or {}
+        self.structuredContent = structured_content
+
+
+class MockMCPClient:
+    """Mock MCP client (sync)."""
+
+    def __init__(self):
+        self.call_tool = Mock()
+        self.connect = Mock()
+        self.close = Mock()
+        self.list_tools = Mock(return_value={"tools": []})
+
+
+class MockPaymentClient:
+    """Mock payment client (sync)."""
+
+    def __init__(self):
+        self.create_payment_payload = Mock()
+
+
+class MockAsyncMCPClient:
+    """Mock async MCP client."""
+
+    def __init__(self):
+        self.call_tool = AsyncMock()
+        self.connect = AsyncMock()
+        self.close = AsyncMock()
+        self.list_tools = AsyncMock(return_value={"tools": []})
+
+
+class MockAsyncPaymentClient:
+    """Mock async payment client."""
+
+    def __init__(self):
+        self.create_payment_payload = AsyncMock()
+
+
+def _mcp_tool_result(content=None, is_error=False, meta=None, structured_content=None):
+    """Build an MCPToolResult (used by extract_payment_required_from_result)."""
+    return MCPToolResult(
+        content=content or [{"type": "text", "text": "pong"}],
+        is_error=is_error,
+        meta=meta or {},
+        structured_content=structured_content,
+    )
+
+
+def _make_payment_required_result(text=None):
+    """Build a raw MCP result with payment required data (for client call_tool)."""
+    return MockMCPResult(
+        content=[{"type": "text", "text": text or VALID_PAYMENT_REQUIRED_JSON}],
+        is_error=True,
+    )
+
+
+def _make_paid_success_result():
+    """Build a raw MCP result for a successful paid tool call."""
+    return MockMCPResult(
+        content=[{"type": "text", "text": "success"}],
+        meta={
+            "x402/payment-response": {
+                "success": True,
+                "transaction": "0xtx123",
+                "network": "eip155:84532",
+            }
+        },
+    )
+
+
+PAYLOAD = PaymentPayload(
+    x402_version=2,
+    accepted={
+        "scheme": "exact",
+        "network": "eip155:84532",
+        "amount": "1000",
+        "asset": "USDC",
+        "pay_to": "0xrecipient",
+        "max_timeout_seconds": 300,
+    },
+    payload={"signature": "0x123"},
+)
+
+
+# ============================================================================
+# 1. Malformed payment required responses
+# ============================================================================
+
+
+class TestMalformedPaymentRequiredResponses:
+    """Tests for malformed isError=True responses that are not valid payment requests."""
+
+    def test_is_error_with_invalid_json_text(self):
+        """Tool returns isError=True but content text is not valid JSON."""
+        result = _mcp_tool_result(
+            content=[{"type": "text", "text": "not valid json at all {"}],
+            is_error=True,
+        )
+        extracted = extract_payment_required_from_result(result)
+        assert extracted is None
+
+    def test_is_error_with_valid_json_no_accepts_key(self):
+        """Tool returns isError=True with JSON but no 'accepts' key."""
+        result = _mcp_tool_result(
+            content=[{"type": "text", "text": '{"x402Version":2,"error":"insufficient funds"}'}],
+            is_error=True,
+        )
+        extracted = extract_payment_required_from_result(result)
+        assert extracted is None
+
+    def test_is_error_with_empty_content_array(self):
+        """Tool returns isError=True with empty content array."""
+        result = _mcp_tool_result(content=[], is_error=True)
+        extracted = extract_payment_required_from_result(result)
+        assert extracted is None
+
+    def test_is_error_with_content_no_text_field(self):
+        """Tool returns isError=True with content items that lack 'text' field."""
+        result = _mcp_tool_result(
+            content=[{"type": "image", "data": "base64data"}],
+            is_error=True,
+        )
+        extracted = extract_payment_required_from_result(result)
+        assert extracted is None
+
+    def test_is_error_with_text_field_not_dict(self):
+        """Content text parses to a list instead of a dict."""
+        result = _mcp_tool_result(
+            content=[{"type": "text", "text": "[1,2,3]"}],
+            is_error=True,
+        )
+        extracted = extract_payment_required_from_result(result)
+        assert extracted is None
+
+    def test_is_error_with_empty_accepts_list(self):
+        """JSON has accepts key but the list is empty."""
+        data = {"x402Version": 2, "accepts": []}
+        result = _mcp_tool_result(
+            content=[{"type": "text", "text": json.dumps(data)}],
+            is_error=True,
+        )
+        extracted = extract_payment_required_from_result(result)
+        assert extracted is None
+
+    def test_is_error_with_accepts_not_a_list(self):
+        """JSON has accepts key but value is a string, not a list."""
+        data = {"x402Version": 2, "accepts": "not_a_list"}
+        result = _mcp_tool_result(
+            content=[{"type": "text", "text": json.dumps(data)}],
+            is_error=True,
+        )
+        extracted = extract_payment_required_from_result(result)
+        assert extracted is None
+
+    def test_structured_content_with_no_accepts(self):
+        """structuredContent is present but lacks 'accepts' key."""
+        result = _mcp_tool_result(
+            content=[{"type": "text", "text": "error"}],
+            is_error=True,
+            structured_content={"x402Version": 2, "error": "no accepts"},
+        )
+        extracted = extract_payment_required_from_result(result)
+        assert extracted is None
+
+    def test_structured_content_empty_dict(self):
+        """structuredContent is an empty dict."""
+        result = _mcp_tool_result(
+            content=[],
+            is_error=True,
+            structured_content={},
+        )
+        extracted = extract_payment_required_from_result(result)
+        assert extracted is None
+
+    def test_not_is_error_returns_none(self):
+        """When is_error is False, extract_payment_required always returns None."""
+        result = _mcp_tool_result(
+            content=[{"type": "text", "text": VALID_PAYMENT_REQUIRED_JSON}],
+            is_error=False,
+        )
+        extracted = extract_payment_required_from_result(result)
+        assert extracted is None
+
+    def test_sync_client_ignores_malformed_error_and_returns_raw(self):
+        """Sync client returns isError result when payment JSON is malformed."""
+        mock_mcp = MockMCPClient()
+        mock_payment = MockPaymentClient()
+
+        mock_mcp.call_tool.return_value = MockMCPResult(
+            content=[{"type": "text", "text": "Server error: internal failure"}],
+            is_error=True,
+        )
+
+        client = x402MCPClientSync(mock_mcp, mock_payment, auto_payment=True)
+        result = client.call_tool("tool", {})
+
+        assert result.payment_made is False
+        assert result.is_error is True
+        mock_payment.create_payment_payload.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_async_client_ignores_malformed_error_and_returns_raw(self):
+        """Async client returns isError result when payment JSON is malformed."""
+        mock_mcp = MockAsyncMCPClient()
+        mock_payment = MockAsyncPaymentClient()
+
+        mock_mcp.call_tool.return_value = MockMCPResult(
+            content=[{"type": "text", "text": "Server error: internal failure"}],
+            is_error=True,
+        )
+
+        client = x402MCPClient(mock_mcp, mock_payment, auto_payment=True)
+        result = await client.call_tool("tool", {})
+
+        assert result.payment_made is False
+        assert result.is_error is True
+        mock_payment.create_payment_payload.assert_not_called()
+
+    def test_fastmcp_wrapped_error_without_json(self):
+        """FastMCP error wrapper text that doesn't contain JSON."""
+        result = _mcp_tool_result(
+            content=[{"type": "text", "text": "Error executing tool get_weather: something went wrong"}],
+            is_error=True,
+        )
+        extracted = extract_payment_required_from_result(result)
+        assert extracted is None
+
+
+# ============================================================================
+# 2. Network / connection errors
+# ============================================================================
+
+
+class TestNetworkConnectionErrors:
+    """Tests for network and connection error scenarios."""
+
+    @pytest.mark.asyncio
+    async def test_async_client_connection_error_propagates(self):
+        """Async client propagates ConnectionError from underlying MCP call."""
+        mock_mcp = MockAsyncMCPClient()
+        mock_payment = MockAsyncPaymentClient()
+        mock_mcp.call_tool.side_effect = ConnectionError("Connection refused")
+
+        client = x402MCPClient(mock_mcp, mock_payment, auto_payment=True)
+        with pytest.raises(ConnectionError, match="Connection refused"):
+            await client.call_tool("tool", {})
+
+    @pytest.mark.asyncio
+    async def test_async_client_timeout_error_propagates(self):
+        """Async client propagates TimeoutError from underlying MCP call."""
+        mock_mcp = MockAsyncMCPClient()
+        mock_payment = MockAsyncPaymentClient()
+        mock_mcp.call_tool.side_effect = TimeoutError("Request timed out")
+
+        client = x402MCPClient(mock_mcp, mock_payment, auto_payment=True)
+        with pytest.raises(TimeoutError, match="Request timed out"):
+            await client.call_tool("tool", {})
+
+    @pytest.mark.asyncio
+    async def test_async_client_os_error_propagates(self):
+        """Async client propagates OSError from underlying MCP call."""
+        mock_mcp = MockAsyncMCPClient()
+        mock_payment = MockAsyncPaymentClient()
+        mock_mcp.call_tool.side_effect = OSError("Network unreachable")
+
+        client = x402MCPClient(mock_mcp, mock_payment, auto_payment=True)
+        with pytest.raises(OSError, match="Network unreachable"):
+            await client.call_tool("tool", {})
+
+    def test_sync_client_connection_error_propagates(self):
+        """Sync client propagates ConnectionError from underlying MCP call."""
+        mock_mcp = MockMCPClient()
+        mock_payment = MockPaymentClient()
+        mock_mcp.call_tool.side_effect = ConnectionError("Connection refused")
+
+        client = x402MCPClientSync(mock_mcp, mock_payment, auto_payment=True)
+        with pytest.raises(ConnectionError, match="Connection refused"):
+            client.call_tool("tool", {})
+
+    def test_sync_client_timeout_error_propagates(self):
+        """Sync client propagates TimeoutError from underlying MCP call."""
+        mock_mcp = MockMCPClient()
+        mock_payment = MockPaymentClient()
+        mock_mcp.call_tool.side_effect = TimeoutError("Request timed out")
+
+        client = x402MCPClientSync(mock_mcp, mock_payment, auto_payment=True)
+        with pytest.raises(TimeoutError, match="Request timed out"):
+            client.call_tool("tool", {})
+
+    def test_sync_client_os_error_propagates(self):
+        """Sync client propagates OSError from underlying MCP call."""
+        mock_mcp = MockMCPClient()
+        mock_payment = MockPaymentClient()
+        mock_mcp.call_tool.side_effect = OSError("Network unreachable")
+
+        client = x402MCPClientSync(mock_mcp, mock_payment, auto_payment=True)
+        with pytest.raises(OSError, match="Network unreachable"):
+            client.call_tool("tool", {})
+
+    @pytest.mark.asyncio
+    async def test_async_client_generic_exception_propagates(self):
+        """Async client propagates unexpected generic exceptions."""
+        mock_mcp = MockAsyncMCPClient()
+        mock_payment = MockAsyncPaymentClient()
+        mock_mcp.call_tool.side_effect = RuntimeError("Something unexpected")
+
+        client = x402MCPClient(mock_mcp, mock_payment, auto_payment=True)
+        with pytest.raises(RuntimeError, match="Something unexpected"):
+            await client.call_tool("tool", {})
+
+    @pytest.mark.asyncio
+    async def test_async_connection_error_during_retry(self):
+        """Connection error occurs during the retry call (after payment creation)."""
+        mock_mcp = MockAsyncMCPClient()
+        mock_payment = MockAsyncPaymentClient()
+
+        mock_mcp.call_tool.side_effect = [
+            _make_payment_required_result(),
+            ConnectionError("Lost during retry"),
+        ]
+        mock_payment.create_payment_payload.return_value = PAYLOAD
+
+        client = x402MCPClient(mock_mcp, mock_payment, auto_payment=True)
+        with pytest.raises(ConnectionError, match="Lost during retry"):
+            await client.call_tool("tool", {})
+
+    def test_sync_connection_error_during_retry(self):
+        """Connection error occurs during the retry call (sync)."""
+        mock_mcp = MockMCPClient()
+        mock_payment = MockPaymentClient()
+
+        mock_mcp.call_tool.side_effect = [
+            _make_payment_required_result(),
+            ConnectionError("Lost during retry"),
+        ]
+        mock_payment.create_payment_payload.return_value = PAYLOAD
+
+        client = x402MCPClientSync(mock_mcp, mock_payment, auto_payment=True)
+        with pytest.raises(ConnectionError, match="Lost during retry"):
+            client.call_tool("tool", {})
+
+
+# ============================================================================
+# 3. Payment creation failures
+# ============================================================================
+
+
+class TestPaymentCreationFailures:
+    """Tests for when payment payload creation fails."""
+
+    @pytest.mark.asyncio
+    async def test_async_create_payment_raises_exception(self):
+        """Async client: create_payment_payload raises an exception."""
+        mock_mcp = MockAsyncMCPClient()
+        mock_payment = MockAsyncPaymentClient()
+
+        mock_mcp.call_tool.return_value = _make_payment_required_result()
+        mock_payment.create_payment_payload.side_effect = RuntimeError("Insufficient balance")
+
+        client = x402MCPClient(mock_mcp, mock_payment, auto_payment=True)
+        with pytest.raises(RuntimeError, match="Insufficient balance"):
+            await client.call_tool("tool", {})
+
+    def test_sync_create_payment_raises_exception(self):
+        """Sync client: create_payment_payload raises an exception."""
+        mock_mcp = MockMCPClient()
+        mock_payment = MockPaymentClient()
+
+        mock_mcp.call_tool.return_value = _make_payment_required_result()
+        mock_payment.create_payment_payload.side_effect = RuntimeError("Insufficient balance")
+
+        client = x402MCPClientSync(mock_mcp, mock_payment, auto_payment=True)
+        with pytest.raises(RuntimeError, match="Insufficient balance"):
+            client.call_tool("tool", {})
+
+    @pytest.mark.asyncio
+    async def test_async_create_payment_returns_none(self):
+        """Async client: create_payment_payload returns None.
+
+        When payment is required and create_payment_payload returns None,
+        the code calls call_tool_with_payment which calls attach_payment_to_meta
+        (which stores None as payload since it lacks model_dump), then retries.
+        The retry MCP call returns the same payment-required result again since
+        it's still isError=True, so extract_payment_required_from_result returns
+        non-None and the flow enters the payment_required branch again with a
+        different MCP result — but since there's no more side_effect, the mock
+        reuses return_value. Since isError=True in the retry result, the client
+        sees it as another payment-required and returns payment_made=False.
+        """
+        mock_mcp = MockAsyncMCPClient()
+        mock_payment = MockAsyncPaymentClient()
+
+        mock_mcp.call_tool.side_effect = [
+            _make_payment_required_result(),
+            MockMCPResult(
+                content=[{"type": "text", "text": "retry result"}],
+                is_error=False,
+            ),
+        ]
+        mock_payment.create_payment_payload.return_value = None
+
+        client = x402MCPClient(mock_mcp, mock_payment, auto_payment=True)
+        result = await client.call_tool("tool", {})
+
+        # The retry completes; result depends on mock response
+        assert isinstance(result, MCPToolCallResult)
+        mock_payment.create_payment_payload.assert_called_once()
+
+    def test_sync_create_payment_returns_none(self):
+        """Sync client: create_payment_payload returns None.
+
+        Sync client calls payload.model_dump() directly on the return value.
+        None has no model_dump, so it stores None as the meta payload, then
+        the retry MCP call proceeds. If mock returns non-error, payment_made=True.
+        """
+        mock_mcp = MockMCPClient()
+        mock_payment = MockPaymentClient()
+
+        mock_mcp.call_tool.side_effect = [
+            _make_payment_required_result(),
+            MockMCPResult(
+                content=[{"type": "text", "text": "retry result"}],
+                is_error=False,
+            ),
+        ]
+        mock_payment.create_payment_payload.return_value = None
+
+        client = x402MCPClientSync(mock_mcp, mock_payment, auto_payment=True)
+        # Sync client calls payload.model_dump() — None has no model_dump → AttributeError
+        with pytest.raises(AttributeError):
+            client.call_tool("tool", {})
+
+    @pytest.mark.asyncio
+    async def test_async_create_payment_returns_invalid_payload(self):
+        """Async client: create_payment_payload returns a plain string.
+
+        String has no __await__ so it's not awaited. attach_payment_to_meta
+        stores it as-is (hasattr(str, 'model_dump') is False). The retry MCP
+        call proceeds with the string in meta.
+        """
+        mock_mcp = MockAsyncMCPClient()
+        mock_payment = MockAsyncPaymentClient()
+
+        mock_mcp.call_tool.side_effect = [
+            _make_payment_required_result(),
+            MockMCPResult(
+                content=[{"type": "text", "text": "retry result"}],
+                is_error=False,
+            ),
+        ]
+        mock_payment.create_payment_payload.return_value = "not a payment payload"
+
+        client = x402MCPClient(mock_mcp, mock_payment, auto_payment=True)
+        result = await client.call_tool("tool", {})
+
+        # Retry proceeds with string payload in meta
+        assert isinstance(result, MCPToolCallResult)
+        mock_payment.create_payment_payload.assert_called_once()
+
+    def test_sync_create_payment_returns_invalid_payload(self):
+        """Sync client: create_payment_payload returns a plain string.
+
+        Sync client calls payload.model_dump() — string has no model_dump → AttributeError.
+        """
+        mock_mcp = MockMCPClient()
+        mock_payment = MockPaymentClient()
+
+        mock_mcp.call_tool.side_effect = [
+            _make_payment_required_result(),
+            MockMCPResult(content=[{"type": "text", "text": "retry"}], is_error=False),
+        ]
+        mock_payment.create_payment_payload.return_value = "not a payment payload"
+
+        client = x402MCPClientSync(mock_mcp, mock_payment, auto_payment=True)
+        with pytest.raises(AttributeError):
+            client.call_tool("tool", {})
+
+    @pytest.mark.asyncio
+    async def test_async_create_payment_timeout(self):
+        """Async client: create_payment_payload times out."""
+        mock_mcp = MockAsyncMCPClient()
+        mock_payment = MockAsyncPaymentClient()
+
+        mock_mcp.call_tool.return_value = _make_payment_required_result()
+        mock_payment.create_payment_payload.side_effect = TimeoutError("Payment signing timed out")
+
+        client = x402MCPClient(mock_mcp, mock_payment, auto_payment=True)
+        with pytest.raises(TimeoutError, match="Payment signing timed out"):
+            await client.call_tool("tool", {})
+
+    def test_sync_create_payment_timeout(self):
+        """Sync client: create_payment_payload times out."""
+        mock_mcp = MockMCPClient()
+        mock_payment = MockPaymentClient()
+
+        mock_mcp.call_tool.return_value = _make_payment_required_result()
+        mock_payment.create_payment_payload.side_effect = TimeoutError("Signing timed out")
+
+        client = x402MCPClientSync(mock_mcp, mock_payment, auto_payment=True)
+        with pytest.raises(TimeoutError, match="Signing timed out"):
+            client.call_tool("tool", {})
+
+
+# ============================================================================
+# 4. Settlement failures
+# ============================================================================
+
+
+class TestSettlementFailures:
+    """Tests for settlement failure scenarios."""
+
+    def test_sync_server_returns_success_false(self):
+        """Server returns success=False in payment response."""
+        mock_mcp = MockMCPClient()
+        mock_payment = MockPaymentClient()
+
+        settle_response = {
+            "success": False,
+            "error_reason": "insufficient_funds",
+            "error_message": "Not enough funds to settle",
+            "transaction": "0xfailtx",
+            "network": "eip155:84532",
+        }
+
+        mock_mcp.call_tool.side_effect = [
+            _make_payment_required_result(),
+            MockMCPResult(
+                content=[{"type": "text", "text": "settlement failed"}],
+                meta={"x402/payment-response": settle_response},
+            ),
+        ]
+        mock_payment.create_payment_payload.return_value = PAYLOAD
+
+        client = x402MCPClientSync(mock_mcp, mock_payment, auto_payment=True)
+        result = client.call_tool("tool", {})
+
+        assert result.payment_made is True
+        assert result.payment_response is not None
+        assert result.payment_response.success is False
+        assert result.payment_response.error_reason == "insufficient_funds"
+
+    @pytest.mark.asyncio
+    async def test_async_server_returns_success_false(self):
+        """Async: server returns success=False in payment response."""
+        mock_mcp = MockAsyncMCPClient()
+        mock_payment = MockAsyncPaymentClient()
+
+        settle_response = {
+            "success": False,
+            "error_reason": "network_congestion",
+            "error_message": "Try again later",
+            "transaction": "0xfailtx",
+            "network": "eip155:84532",
+        }
+
+        mock_mcp.call_tool.side_effect = [
+            _make_payment_required_result(),
+            MockMCPResult(
+                content=[{"type": "text", "text": "settlement failed"}],
+                meta={"x402/payment-response": settle_response},
+            ),
+        ]
+        mock_payment.create_payment_payload.return_value = PAYLOAD
+
+        client = x402MCPClient(mock_mcp, mock_payment, auto_payment=True)
+        result = await client.call_tool("tool", {})
+
+        assert result.payment_made is True
+        assert result.payment_response is not None
+        assert result.payment_response.success is False
+        assert result.payment_response.error_reason == "network_congestion"
+
+    def test_sync_server_returns_empty_payment_response(self):
+        """Server returns empty dict in payment-response meta (validation fails → None)."""
+        mock_mcp = MockMCPClient()
+        mock_payment = MockPaymentClient()
+
+        mock_mcp.call_tool.side_effect = [
+            _make_payment_required_result(),
+            MockMCPResult(
+                content=[{"type": "text", "text": "ok"}],
+                meta={"x402/payment-response": {}},
+            ),
+        ]
+        mock_payment.create_payment_payload.return_value = PAYLOAD
+
+        client = x402MCPClientSync(mock_mcp, mock_payment, auto_payment=True)
+        result = client.call_tool("tool", {})
+
+        assert result.payment_made is True
+        # Empty dict fails SettleResponse validation → payment_response is None
+        assert result.payment_response is None
+
+    @pytest.mark.asyncio
+    async def test_async_server_returns_empty_payment_response(self):
+        """Async: server returns empty dict in payment-response meta."""
+        mock_mcp = MockAsyncMCPClient()
+        mock_payment = MockAsyncPaymentClient()
+
+        mock_mcp.call_tool.side_effect = [
+            _make_payment_required_result(),
+            MockMCPResult(
+                content=[{"type": "text", "text": "ok"}],
+                meta={"x402/payment-response": {}},
+            ),
+        ]
+        mock_payment.create_payment_payload.return_value = PAYLOAD
+
+        client = x402MCPClient(mock_mcp, mock_payment, auto_payment=True)
+        result = await client.call_tool("tool", {})
+
+        assert result.payment_made is True
+        assert result.payment_response is None
+
+    def test_sync_server_returns_missing_fields_in_response(self):
+        """Server returns payment response with missing required fields (→ None)."""
+        mock_mcp = MockMCPClient()
+        mock_payment = MockPaymentClient()
+
+        mock_mcp.call_tool.side_effect = [
+            _make_payment_required_result(),
+            MockMCPResult(
+                content=[{"type": "text", "text": "ok"}],
+                meta={"x402/payment-response": {"success": True}},
+            ),
+        ]
+        mock_payment.create_payment_payload.return_value = PAYLOAD
+
+        client = x402MCPClientSync(mock_mcp, mock_payment, auto_payment=True)
+        result = client.call_tool("tool", {})
+
+        assert result.payment_made is True
+        # Missing transaction/network fails SettleResponse validation → None
+        assert result.payment_response is None
+
+    @pytest.mark.asyncio
+    async def test_async_server_returns_missing_fields_in_response(self):
+        """Async: server returns payment response with missing required fields."""
+        mock_mcp = MockAsyncMCPClient()
+        mock_payment = MockAsyncPaymentClient()
+
+        mock_mcp.call_tool.side_effect = [
+            _make_payment_required_result(),
+            MockMCPResult(
+                content=[{"type": "text", "text": "ok"}],
+                meta={"x402/payment-response": {"success": True}},
+            ),
+        ]
+        mock_payment.create_payment_payload.return_value = PAYLOAD
+
+        client = x402MCPClient(mock_mcp, mock_payment, auto_payment=True)
+        result = await client.call_tool("tool", {})
+
+        assert result.payment_made is True
+        assert result.payment_response is None
+
+    def test_sync_no_payment_response_meta(self):
+        """Retry succeeds but meta contains no payment-response key."""
+        mock_mcp = MockMCPClient()
+        mock_payment = MockPaymentClient()
+
+        mock_mcp.call_tool.side_effect = [
+            _make_payment_required_result(),
+            MockMCPResult(
+                content=[{"type": "text", "text": "ok"}],
+                meta={"some_other_key": "value"},
+            ),
+        ]
+        mock_payment.create_payment_payload.return_value = PAYLOAD
+
+        client = x402MCPClientSync(mock_mcp, mock_payment, auto_payment=True)
+        result = client.call_tool("tool", {})
+
+        assert result.payment_made is True
+        assert result.payment_response is None
+
+    @pytest.mark.asyncio
+    async def test_async_no_payment_response_meta(self):
+        """Async: retry succeeds but meta contains no payment-response key."""
+        mock_mcp = MockAsyncMCPClient()
+        mock_payment = MockAsyncPaymentClient()
+
+        mock_mcp.call_tool.side_effect = [
+            _make_payment_required_result(),
+            MockMCPResult(
+                content=[{"type": "text", "text": "ok"}],
+                meta={"some_other_key": "value"},
+            ),
+        ]
+        mock_payment.create_payment_payload.return_value = PAYLOAD
+
+        client = x402MCPClient(mock_mcp, mock_payment, auto_payment=True)
+        result = await client.call_tool("tool", {})
+
+        assert result.payment_made is True
+        assert result.payment_response is None
+
+
+# ============================================================================
+# 5. Concurrent access
+# ============================================================================
+
+
+class TestConcurrentAccess:
+    """Tests for concurrent access and thread safety."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_async_calls_same_payment_required(self):
+        """Multiple concurrent async calls with the same payment required."""
+        mock_mcp = MockAsyncMCPClient()
+        mock_payment = MockAsyncPaymentClient()
+
+        payment_required_result = _make_payment_required_result()
+        success_result = MockMCPResult(
+            content=[{"type": "text", "text": "ok"}],
+        )
+
+        call_count = 0
+
+        async def side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 5:
+                return payment_required_result
+            return success_result
+
+        mock_mcp.call_tool.side_effect = side_effect
+        mock_payment.create_payment_payload.return_value = PAYLOAD
+
+        client = x402MCPClient(mock_mcp, mock_payment, auto_payment=True)
+        tasks = [client.call_tool(f"tool_{i}", {"i": i}) for i in range(5)]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        for r in results:
+            assert isinstance(r, MCPToolCallResult)
+
+    @pytest.mark.asyncio
+    async def test_async_concurrent_payment_required_then_free_tool(self):
+        """Mix of concurrent paid and free tool calls."""
+        mock_mcp = MockAsyncMCPClient()
+        mock_payment = MockAsyncPaymentClient()
+
+        paid_count = 0
+
+        async def side_effect(params, **kwargs):
+            nonlocal paid_count
+            name = params.get("name", "unknown")
+            if name.startswith("paid"):
+                paid_count += 1
+                if paid_count % 2 == 1:
+                    return _make_payment_required_result()
+                return _make_paid_success_result()
+            return MockMCPResult(content=[{"type": "text", "text": "free"}])
+
+        mock_mcp.call_tool.side_effect = side_effect
+        mock_payment.create_payment_payload.return_value = PAYLOAD
+
+        client = x402MCPClient(mock_mcp, mock_payment, auto_payment=True)
+        tasks = []
+        for i in range(10):
+            name = f"paid_tool_{i}" if i % 2 == 0 else f"free_tool_{i}"
+            tasks.append(client.call_tool(name, {}))
+
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        for r in results:
+            assert isinstance(r, MCPToolCallResult)
+
+    def test_sync_sequential_calls_independent(self):
+        """Sequential sync calls are independent (no shared state leakage)."""
+        mock_mcp = MockMCPClient()
+        mock_payment = MockPaymentClient()
+
+        # 4 calls: free1(1) + paid_initial(2) + paid_retry(3) + free2(4)
+        mock_mcp.call_tool.side_effect = [
+            MockMCPResult(content=[{"type": "text", "text": "free1"}]),
+            _make_payment_required_result(),
+            MockMCPResult(content=[{"type": "text", "text": "paid success"}]),
+            MockMCPResult(content=[{"type": "text", "text": "free2"}]),
+        ]
+        mock_payment.create_payment_payload.return_value = PAYLOAD
+
+        client = x402MCPClientSync(mock_mcp, mock_payment, auto_payment=True)
+
+        r1 = client.call_tool("free_tool", {})
+        r2 = client.call_tool("paid_tool", {})
+        r3 = client.call_tool("free_tool2", {})
+
+        assert r1.payment_made is False
+        assert r2.payment_made is True
+        assert r3.payment_made is False
+
+
+# ============================================================================
+# 6. get_tool_payment_requirements edge cases (async client only)
+# ============================================================================
+
+
+class TestGetToolPaymentRequirements:
+    """Tests for get_tool_payment_requirements edge cases (async client only)."""
+
+    @pytest.mark.asyncio
+    async def test_async_tool_returns_no_payment_requirements(self):
+        """Tool returns success (not an error) — free tool, no requirements."""
+        mock_mcp = MockAsyncMCPClient()
+        mock_payment = MockAsyncPaymentClient()
+
+        mock_mcp.call_tool.return_value = MockMCPResult(
+            content=[{"type": "text", "text": "no payment needed"}],
+            is_error=False,
+        )
+
+        client = x402MCPClient(mock_mcp, mock_payment, auto_payment=True)
+        result = await client.get_tool_payment_requirements("free_tool", {})
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_async_tool_raises_exception_during_probe(self):
+        """Tool raises an exception when probing for payment requirements."""
+        mock_mcp = MockAsyncMCPClient()
+        mock_payment = MockAsyncPaymentClient()
+
+        mock_mcp.call_tool.side_effect = RuntimeError("Tool probe failed")
+
+        client = x402MCPClient(mock_mcp, mock_payment, auto_payment=True)
+        with pytest.raises(RuntimeError, match="Tool probe failed"):
+            await client.get_tool_payment_requirements("broken_tool", {})
+
+    @pytest.mark.asyncio
+    async def test_async_tool_returns_partial_payment_requirements(self):
+        """Tool returns error with partial/invalid payment requirements JSON."""
+        mock_mcp = MockAsyncMCPClient()
+        mock_payment = MockAsyncPaymentClient()
+
+        mock_mcp.call_tool.return_value = MockMCPResult(
+            content=[{"type": "text", "text": '{"x402Version":2}'}],
+            is_error=True,
+        )
+
+        client = x402MCPClient(mock_mcp, mock_payment, auto_payment=True)
+        result = await client.get_tool_payment_requirements("partial_tool", {})
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_async_tool_returns_empty_error_content(self):
+        """Tool returns isError=True but with empty content."""
+        mock_mcp = MockAsyncMCPClient()
+        mock_payment = MockAsyncPaymentClient()
+
+        mock_mcp.call_tool.return_value = MockMCPResult(content=[], is_error=True)
+
+        client = x402MCPClient(mock_mcp, mock_payment, auto_payment=True)
+        result = await client.get_tool_payment_requirements("empty_error_tool", {})
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_async_probe_with_structured_content(self):
+        """Probe finds payment requirements in structuredContent."""
+        mock_mcp = MockAsyncMCPClient()
+        mock_payment = MockAsyncPaymentClient()
+
+        pr_dict = {
+            "x402Version": 2,
+            "accepts": [
+                {
+                    "scheme": "exact",
+                    "network": "eip155:84532",
+                    "amount": "500",
+                    "asset": "USDC",
+                    "payTo": "0xaddr",
+                    "maxTimeoutSeconds": 600,
+                }
+            ],
+        }
+
+        mock_mcp.call_tool.return_value = MockMCPResult(
+            content=[{"type": "text", "text": "Payment required"}],
+            is_error=True,
+            structured_content=pr_dict,
+        )
+
+        client = x402MCPClient(mock_mcp, mock_payment, auto_payment=True)
+        result = await client.get_tool_payment_requirements("structured_tool", {})
+
+        assert result is not None
+        assert result.x402_version == 2
+        assert len(result.accepts) == 1
+        assert result.accepts[0].scheme == "exact"
+
+    @pytest.mark.asyncio
+    async def test_async_probe_connection_error(self):
+        """Probe fails with connection error."""
+        mock_mcp = MockAsyncMCPClient()
+        mock_payment = MockAsyncPaymentClient()
+
+        mock_mcp.call_tool.side_effect = ConnectionError("Cannot connect")
+
+        client = x402MCPClient(mock_mcp, mock_payment, auto_payment=True)
+        with pytest.raises(ConnectionError, match="Cannot connect"):
+            await client.get_tool_payment_requirements("offline_tool", {})
+
+
+# ============================================================================
+# 7. Hook edge cases (async client only)
+# ============================================================================
+
+
+class TestHookEdgeCases:
+    """Tests for hook edge cases (x402MCPClient async only)."""
+
+    @pytest.mark.asyncio
+    async def test_async_payment_required_hook_raises_exception(self):
+        """Payment required hook raises an exception."""
+        mock_mcp = MockAsyncMCPClient()
+        mock_payment = MockAsyncPaymentClient()
+
+        mock_mcp.call_tool.return_value = _make_payment_required_result()
+        mock_payment.create_payment_payload.return_value = PAYLOAD
+
+        def bad_hook(ctx):
+            raise RuntimeError("Hook failed")
+
+        client = x402MCPClient(mock_mcp, mock_payment, auto_payment=True)
+        client.on_payment_required(bad_hook)
+
+        with pytest.raises(RuntimeError, match="Hook failed"):
+            await client.call_tool("tool", {})
+
+    @pytest.mark.asyncio
+    async def test_async_before_payment_hook_raises_exception(self):
+        """Before payment hook raises an exception."""
+        mock_mcp = MockAsyncMCPClient()
+        mock_payment = MockAsyncPaymentClient()
+
+        mock_mcp.call_tool.side_effect = [
+            _make_payment_required_result(),
+            MockMCPResult(content=[{"type": "text", "text": "ok"}]),
+        ]
+        mock_payment.create_payment_payload.return_value = PAYLOAD
+
+        def bad_before_hook(ctx):
+            raise RuntimeError("Before hook failed")
+
+        client = x402MCPClient(mock_mcp, mock_payment, auto_payment=True)
+        client.on_before_payment(bad_before_hook)
+
+        with pytest.raises(RuntimeError, match="Before hook failed"):
+            await client.call_tool("tool", {})
+
+    @pytest.mark.asyncio
+    async def test_async_after_payment_hook_raises_exception(self):
+        """After payment hook raises an exception — payment still completed."""
+        mock_mcp = MockAsyncMCPClient()
+        mock_payment = MockAsyncPaymentClient()
+
+        mock_mcp.call_tool.side_effect = [
+            _make_payment_required_result(),
+            _make_paid_success_result(),
+        ]
+        mock_payment.create_payment_payload.return_value = PAYLOAD
+
+        def bad_after_hook(ctx):
+            raise RuntimeError("After hook failed")
+
+        client = x402MCPClient(mock_mcp, mock_payment, auto_payment=True)
+        client.on_after_payment(bad_after_hook)
+
+        with pytest.raises(RuntimeError, match="After hook failed"):
+            await client.call_tool("tool", {})
+
+    @pytest.mark.asyncio
+    async def test_async_multiple_hooks_some_fail(self):
+        """Multiple payment_required hooks registered, first one fails."""
+        mock_mcp = MockAsyncMCPClient()
+        mock_payment = MockAsyncPaymentClient()
+
+        mock_mcp.call_tool.return_value = _make_payment_required_result()
+
+        hook_calls = []
+
+        def failing_hook(ctx):
+            hook_calls.append("failing")
+            raise RuntimeError("Hook 1 failed")
+
+        def second_hook(ctx):
+            hook_calls.append("second")
+            return PaymentRequiredHookResult(abort=True)
+
+        client = x402MCPClient(mock_mcp, mock_payment, auto_payment=True)
+        client.on_payment_required(failing_hook)
+        client.on_payment_required(second_hook)
+
+        with pytest.raises(RuntimeError, match="Hook 1 failed"):
+            await client.call_tool("tool", {})
+
+        # Only the first hook was called before it raised
+        assert hook_calls == ["failing"]
+
+    @pytest.mark.asyncio
+    async def test_async_payment_required_hook_modifies_context(self):
+        """Payment required hook modifies the context object."""
+        mock_mcp = MockAsyncMCPClient()
+        mock_payment = MockAsyncPaymentClient()
+
+        mock_mcp.call_tool.return_value = _make_payment_required_result()
+        mock_payment.create_payment_payload.return_value = PAYLOAD
+
+        seen_args = []
+
+        def observing_hook(ctx):
+            seen_args.append(ctx.arguments)
+            ctx.arguments["observed"] = True
+            return PaymentRequiredHookResult()
+
+        client = x402MCPClient(mock_mcp, mock_payment, auto_payment=True)
+        client.on_payment_required(observing_hook)
+
+        await client.call_tool("tool", {"original": "arg"})
+
+        assert len(seen_args) == 1
+        assert seen_args[0]["original"] == "arg"
+        assert seen_args[0]["observed"] is True
+
+    @pytest.mark.asyncio
+    async def test_async_after_hook_receives_correct_context(self):
+        """After payment hook receives correct context fields."""
+        mock_mcp = MockAsyncMCPClient()
+        mock_payment = MockAsyncPaymentClient()
+
+        mock_mcp.call_tool.side_effect = [
+            _make_payment_required_result(),
+            _make_paid_success_result(),
+        ]
+        mock_payment.create_payment_payload.return_value = PAYLOAD
+
+        received_contexts = []
+
+        def after_hook(ctx):
+            received_contexts.append(ctx)
+
+        client = x402MCPClient(mock_mcp, mock_payment, auto_payment=True)
+        client.on_after_payment(after_hook)
+
+        await client.call_tool("my_tool", {"arg": "val"})
+
+        assert len(received_contexts) == 1
+        ctx = received_contexts[0]
+        assert ctx.tool_name == "my_tool"
+        assert ctx.payment_payload is PAYLOAD
+        assert ctx.result is not None
+        assert ctx.settle_response is not None
+
+    @pytest.mark.asyncio
+    async def test_async_hook_returns_none_is_treated_as_falsy(self):
+        """Hook returning None is treated as falsy (no abort, no custom payment)."""
+        mock_mcp = MockAsyncMCPClient()
+        mock_payment = MockAsyncPaymentClient()
+
+        mock_mcp.call_tool.side_effect = [
+            _make_payment_required_result(),
+            _make_paid_success_result(),
+        ]
+        mock_payment.create_payment_payload.return_value = PAYLOAD
+
+        def noop_hook(ctx):
+            return None
+
+        client = x402MCPClient(mock_mcp, mock_payment, auto_payment=True)
+        client.on_payment_required(noop_hook)
+
+        result = await client.call_tool("tool", {})
+        assert result.payment_made is True
+
+    @pytest.mark.asyncio
+    async def test_async_before_and_after_hooks_both_called(self):
+        """Both before and after hooks are called in sequence."""
+        mock_mcp = MockAsyncMCPClient()
+        mock_payment = MockAsyncPaymentClient()
+
+        mock_mcp.call_tool.side_effect = [
+            _make_payment_required_result(),
+            _make_paid_success_result(),
+        ]
+        mock_payment.create_payment_payload.return_value = PAYLOAD
+
+        call_log = []
+
+        def before_hook(ctx):
+            call_log.append("before")
+
+        def after_hook(ctx):
+            call_log.append("after")
+
+        client = x402MCPClient(mock_mcp, mock_payment, auto_payment=True)
+        client.on_before_payment(before_hook)
+        client.on_after_payment(after_hook)
+
+        await client.call_tool("tool", {})
+
+        assert call_log == ["before", "after"]
+
+    @pytest.mark.asyncio
+    async def test_async_on_payment_requested_denies(self):
+        """on_payment_requested callback denies payment."""
+        mock_mcp = MockAsyncMCPClient()
+        mock_payment = MockAsyncPaymentClient()
+
+        mock_mcp.call_tool.return_value = _make_payment_required_result()
+
+        client = x402MCPClient(
+            mock_mcp,
+            mock_payment,
+            auto_payment=True,
+            on_payment_requested=lambda ctx: False,
+        )
+
+        with pytest.raises(PaymentRequiredError):
+            await client.call_tool("tool", {})
+
+        mock_payment.create_payment_payload.assert_not_called()
+
+
+# ============================================================================
+# 8. convert_mcp_result edge cases
+# ============================================================================
+
+
+class TestConvertMcpResultEdgeCases:
+    """Tests for convert_mcp_result with unusual input shapes."""
+
+    def test_object_with_no_spec(self):
+        """convert_mcp_result handles object with only desired attrs set."""
+        obj = Mock(spec=[])
+        obj.content = []
+        obj.isError = False
+        obj._meta = {}
+        obj.structuredContent = None
+
+        result = convert_mcp_result(obj)
+        assert result.is_error is False
+        assert result.content == []
+
+    def test_non_dict_meta(self):
+        """convert_mcp_result handles meta that is not a dict."""
+        obj = Mock(spec=[])
+        obj.content = [{"type": "text", "text": "ok"}]
+        obj.isError = False
+        obj._meta = "not_a_dict"
+        obj.structuredContent = None
+
+        result = convert_mcp_result(obj)
+        assert result.meta == {}
+
+    def test_none_content(self):
+        """convert_mcp_result handles None content."""
+        obj = Mock(spec=[])
+        obj.content = None
+        obj.isError = False
+        obj._meta = {}
+        obj.structuredContent = None
+
+        result = convert_mcp_result(obj)
+        assert result.content == []
+
+    def test_is_error_fallback_to_snake_case(self):
+        """convert_mcp_result falls back to is_error when isError is absent."""
+        obj = Mock(spec=[])
+        obj.content = []
+        obj._meta = {}
+        obj.structuredContent = None
+        del obj.isError
+        obj.is_error = True
+
+        result = convert_mcp_result(obj)
+        assert result.is_error is True
+
+    def test_no_error_attributes_defaults_false(self):
+        """convert_mcp_result defaults is_error to False when neither attr exists."""
+        obj = Mock(spec=[])
+        obj.content = []
+        obj._meta = {}
+        obj.structuredContent = None
+        del obj.isError
+        del obj.is_error
+
+        result = convert_mcp_result(obj)
+        assert result.is_error is False
+
+    def test_structured_content_passed_through(self):
+        """convert_mcp_result passes structuredContent through."""
+        sc = {"x402Version": 2, "accepts": []}
+        obj = Mock(spec=[])
+        obj.content = []
+        obj.isError = True
+        obj._meta = {}
+        obj.structuredContent = sc
+
+        result = convert_mcp_result(obj)
+        assert result.structured_content == sc
+
+    def test_content_with_non_list_value(self):
+        """convert_mcp_result handles content that is not a list."""
+        obj = Mock(spec=[])
+        obj.content = "not_a_list"
+        obj.isError = False
+        obj._meta = {}
+        obj.structuredContent = None
+
+        result = convert_mcp_result(obj)
+        assert result.content == []
+
+
+# ============================================================================
+# 9. extract_payment_required_from_error edge cases
+# ============================================================================
+
+
+class TestExtractPaymentRequiredFromError:
+    """Tests for extract_payment_required_from_error utility."""
+
+    def test_valid_402_error_with_data(self):
+        """Extract payment required from a valid 402 JSON-RPC error."""
+        error = {
+            "code": 402,
+            "data": {
+                "x402Version": 2,
+                "accepts": [
+                    {
+                        "scheme": "exact",
+                        "network": "eip155:84532",
+                        "amount": "1000",
+                        "asset": "USDC",
+                        "payTo": "0xaddr",
+                        "maxTimeoutSeconds": 300,
+                    }
+                ],
+            },
+        }
+        result = extract_payment_required_from_error(error)
+        assert result is not None
+        assert result.x402_version == 2
+
+    def test_non_dict_error(self):
+        """Non-dict error returns None."""
+        assert extract_payment_required_from_error("not a dict") is None
+        assert extract_payment_required_from_error(None) is None
+        assert extract_payment_required_from_error(42) is None
+
+    def test_non_402_code(self):
+        """Error with non-402 code returns None."""
+        error = {"code": 500, "data": {"x402Version": 2, "accepts": []}}
+        assert extract_payment_required_from_error(error) is None
+
+    def test_402_with_no_data(self):
+        """402 error with no data field returns None."""
+        error = {"code": 402}
+        assert extract_payment_required_from_error(error) is None
+
+    def test_402_with_non_object_data(self):
+        """402 error with data that is not a dict returns None."""
+        error = {"code": 402, "data": "not_an_object"}
+        assert extract_payment_required_from_error(error) is None
+
+    def test_402_with_empty_data(self):
+        """402 error with empty data dict returns None."""
+        error = {"code": 402, "data": {}}
+        assert extract_payment_required_from_error(error) is None
+
+
+# ============================================================================
+# 10. _extract_payment_required_from_object edge cases
+# ============================================================================
+
+
+class TestExtractPaymentRequiredFromObject:
+    """Tests for _extract_payment_required_from_object utility."""
+
+    def test_no_x402_version(self):
+        """Object without x402Version returns None."""
+        assert _extract_payment_required_from_object({"accepts": []}) is None
+
+    def test_no_accepts(self):
+        """Object with x402Version but no accepts returns None."""
+        assert _extract_payment_required_from_object({"x402Version": 2}) is None
+
+    def test_accepts_empty_list(self):
+        """Object with empty accepts list returns None."""
+        assert _extract_payment_required_from_object({"x402Version": 2, "accepts": []}) is None
+
+    def test_invalid_accepts_item(self):
+        """Object with malformed accepts item returns None."""
+        obj = {"x402Version": 2, "accepts": [{"scheme": None, "network": None}]}
+        result = _extract_payment_required_from_object(obj)
+        assert result is None
+
+    def test_snake_case_x402_version(self):
+        """Object with x402_version (snake_case) is handled."""
+        obj = {
+            "x402_version": 2,
+            "accepts": [
+                {
+                    "scheme": "exact",
+                    "network": "eip155:84532",
+                    "amount": "100",
+                    "asset": "USDC",
+                    "payTo": "0xaddr",
+                    "maxTimeoutSeconds": 120,
+                }
+            ],
+        }
+        result = _extract_payment_required_from_object(obj)
+        assert result is not None
+        assert result.x402_version == 2
+
+    def test_none_version_defaults_to_2(self):
+        """Object with accepts but x402Version is None defaults to 2."""
+        obj = {
+            "x402Version": None,
+            "accepts": [
+                {
+                    "scheme": "exact",
+                    "network": "eip155:84532",
+                    "amount": "100",
+                    "asset": "USDC",
+                    "payTo": "0xaddr",
+                    "maxTimeoutSeconds": 120,
+                }
+            ],
+        }
+        result = _extract_payment_required_from_object(obj)
+        assert result is not None
+        assert result.x402_version == 2
+
+    def test_valid_v2_object(self):
+        """Valid v2 payment required object."""
+        result = _extract_payment_required_from_object(VALID_PAYMENT_REQUIRED_DICT)
+        assert result is not None
+        assert result.x402_version == 2
+        assert len(result.accepts) == 1
+
+    def test_malformed_accepts_missing_required_fields(self):
+        """Accepts item with missing required fields returns None."""
+        obj = {
+            "x402Version": 2,
+            "accepts": [
+                {
+                    "scheme": "exact",
+                    "network": "eip155:84532",
+                    "amount": "100",
+                    "asset": "USDC",
+                    "payTo": "0xaddr",
+                    # maxTimeoutSeconds missing
+                }
+            ],
+        }
+        result = _extract_payment_required_from_object(obj)
+        assert result is None
+
+
+# ============================================================================
+# 11. MCPToolCallResult defaults
+# ============================================================================
+
+
+class TestMCPToolCallResultDefaults:
+    """Tests for MCPToolCallResult default values."""
+
+    def test_default_values(self):
+        """MCPToolCallResult has correct defaults when constructed manually."""
+        r = MCPToolCallResult(
+            content=[],
+            is_error=False,
+            payment_response=None,
+            payment_made=False,
+        )
+        assert r.content == []
+        assert r.is_error is False
+        assert r.payment_response is None
+        assert r.payment_made is False
+
+    def test_explicit_values(self):
+        """MCPToolCallResult accepts explicit values."""
+        r = MCPToolCallResult(
+            content=[{"type": "text", "text": "hi"}],
+            is_error=True,
+            payment_made=True,
+        )
+        assert len(r.content) == 1
+        assert r.is_error is True
+        assert r.payment_made is True
+
+    def test_partial_explicit(self):
+        """MCPToolCallResult accepts partial explicit values."""
+        r = MCPToolCallResult(
+            content=[],
+            payment_made=True,
+        )
+        assert r.content == []
+        assert r.payment_made is True
+        assert r.is_error is False
+        assert r.payment_response is None
+
+
+# ============================================================================
+# 12. PaymentRequiredError edge cases
+# ============================================================================
+
+
+class TestPaymentRequiredError:
+    """Tests for PaymentRequiredError edge cases."""
+
+    def test_error_attributes(self):
+        """PaymentRequiredError has correct attributes."""
+        pr = PaymentRequired(x402_version=2, accepts=[])
+        err = PaymentRequiredError("test message", pr)
+        assert err.code == 402
+        assert err.payment_required is pr
+        assert str(err) == "test message"
+
+    def test_error_without_payment_required(self):
+        """PaymentRequiredError can be created without payment_required."""
+        err = PaymentRequiredError("no payment info")
+        assert err.code == 402
+        assert err.payment_required is None
+
+    def test_error_is_exception(self):
+        """PaymentRequiredError is an Exception subclass."""
+        err = PaymentRequiredError("msg")
+        assert isinstance(err, Exception)
+
+
+# ============================================================================
+# 13. x402MCPSession._extract_payment_required edge cases
+# ============================================================================
+
+
+class TestX402MCPSessionExtractPaymentRequired:
+    """Tests for the legacy x402MCPSession._extract_payment_required method."""
+
+    def _make_session(self):
+        """Create a minimal x402MCPSession for testing."""
+        from x402.mcp.client import x402MCPSession
+
+        mock_session = Mock()
+        mock_x402_client = Mock()
+        return x402MCPSession(mock_session, mock_x402_client, auto_payment=True)
+
+    def test_structured_content_with_accepts(self):
+        """Extract from structuredContent that has accepts."""
+        session = self._make_session()
+
+        class R:
+            structuredContent = VALID_PAYMENT_REQUIRED_DICT
+            content = []
+
+        result = session._extract_payment_required(R())
+        assert result is not None
+
+    def test_structured_content_without_accepts(self):
+        """structuredContent present but no accepts key."""
+        session = self._make_session()
+
+        class R:
+            structuredContent = {"error": "something"}
+            content = []
+
+        result = session._extract_payment_required(R())
+        assert result is None
+
+    def test_content_text_with_json_accepts(self):
+        """Extract from content[0].text JSON with accepts."""
+        session = self._make_session()
+
+        class R:
+            structuredContent = None
+            content = [type("Item", (), {"text": VALID_PAYMENT_REQUIRED_JSON})()]
+
+        result = session._extract_payment_required(R())
+        assert result is not None
+
+    def test_content_text_without_json(self):
+        """Content text is not JSON."""
+        session = self._make_session()
+
+        class R:
+            structuredContent = None
+            content = [type("Item", (), {"text": "plain text"})()]
+
+        result = session._extract_payment_required(R())
+        assert result is None
+
+    def test_content_item_without_text(self):
+        """Content items have no text attribute."""
+        session = self._make_session()
+
+        class R:
+            structuredContent = None
+            content = [type("Item", (), {"data": "base64"})()]
+
+        result = session._extract_payment_required(R())
+        assert result is None
+
+    def test_no_content_attribute(self):
+        """Result has no content attribute at all."""
+        session = self._make_session()
+
+        class R:
+            structuredContent = None
+
+        result = session._extract_payment_required(R())
+        assert result is None
+
+    def test_empty_content(self):
+        """Result has empty content list."""
+        session = self._make_session()
+
+        class R:
+            structuredContent = None
+            content = []
+
+        result = session._extract_payment_required(R())
+        assert result is None
+
+    def test_fastmcp_wrapped_error_json(self):
+        """FastMCP wrapped error format with embedded JSON."""
+        session = self._make_session()
+
+        fastmcp_text = (
+            'Error executing tool get_weather: {"x402Version":2,'
+            '"accepts":[{"scheme":"exact","network":"eip155:84532",'
+            '"amount":"500","asset":"USDC","payTo":"0xaddr",'
+            '"maxTimeoutSeconds":120}]}'
+        )
+
+        class R:
+            structuredContent = None
+            content = [type("Item", (), {"text": fastmcp_text})()]
+
+        result = session._extract_payment_required(R())
+        assert result is not None
+
+
+# ============================================================================
+# 14. _try_extract_payment_json edge cases
+# ============================================================================
+
+
+class TestTryExtractPaymentJson:
+    """Tests for _try_extract_payment_json utility."""
+
+    def test_valid_json_with_accepts(self):
+        """Valid JSON with accepts key."""
+        from x402.mcp.client import _try_extract_payment_json
+
+        result = _try_extract_payment_json(VALID_PAYMENT_REQUIRED_JSON)
+        assert result is not None
+        assert "accepts" in result
+
+    def test_invalid_json(self):
+        """Invalid JSON string."""
+        from x402.mcp.client import _try_extract_payment_json
+
+        result = _try_extract_payment_json("not json {{{")
+        assert result is None
+
+    def test_valid_json_without_accepts(self):
+        """Valid JSON without accepts key."""
+        from x402.mcp.client import _try_extract_payment_json
+
+        result = _try_extract_payment_json('{"x402Version":2}')
+        assert result is None
+
+    def test_fastmcp_wrapped_format(self):
+        """FastMCP wrapped error format."""
+        from x402.mcp.client import _try_extract_payment_json
+
+        text = (
+            'Error executing tool get_weather: {"x402Version":2,'
+            '"accepts":[{"scheme":"exact","network":"eip155:84532",'
+            '"amount":"100","asset":"USDC","payTo":"0xaddr",'
+            '"maxTimeoutSeconds":300}]}'
+        )
+        result = _try_extract_payment_json(text)
+        assert result is not None
+        assert "accepts" in result
+
+    def test_fastmcp_format_no_accepts(self):
+        """FastMCP wrapped format but no accepts in JSON."""
+        from x402.mcp.client import _try_extract_payment_json
+
+        text = 'Error executing tool: {"x402Version":2,"error":"no accepts"}'
+        result = _try_extract_payment_json(text)
+        assert result is None
+
+    def test_empty_string(self):
+        """Empty string input."""
+        from x402.mcp.client import _try_extract_payment_json
+
+        result = _try_extract_payment_json("")
+        assert result is None
+
+    def test_json_array_extracts_inner_accepts(self):
+        """JSON array containing a dict with accepts — regex extracts inner dict."""
+        from x402.mcp.client import _try_extract_payment_json
+
+        result = _try_extract_payment_json('[{"accepts":[]}]')
+        # The regex matches {"accepts":[]} and returns it
+        assert result is not None
+        assert "accepts" in result
+
+    def test_nested_wrapper_json_returns_none(self):
+        """JSON with accepts nested under a wrapper key — not top-level."""
+        from x402.mcp.client import _try_extract_payment_json
+
+        text = '{"wrapper":{"x402Version":2,"accepts":[{"scheme":"exact","network":"eip155:84532","amount":"50","asset":"USDC","payTo":"0x1","maxTimeoutSeconds":60}]}}'
+        result = _try_extract_payment_json(text)
+        # Regex matches the whole string but parsed dict has "wrapper" not "accepts" at top
+        assert result is None
+
+
+# ============================================================================
+# 15. create_payment_required_error
+# ============================================================================
+
+
+class TestCreatePaymentRequiredError:
+    """Tests for create_payment_required_error utility."""
+
+    def test_creates_error_with_custom_message(self):
+        from x402.mcp.utils import create_payment_required_error
+
+        pr = PaymentRequired(x402_version=2, accepts=[])
+        err = create_payment_required_error(pr, "custom msg")
+        assert str(err) == "custom msg"
+        assert err.payment_required is pr
+
+    def test_creates_error_with_default_message(self):
+        from x402.mcp.utils import create_payment_required_error
+
+        pr = PaymentRequired(x402_version=2, accepts=[])
+        err = create_payment_required_error(pr)
+        assert str(err) == "Payment required"
+        assert err.code == 402
+
+
+# ============================================================================
+# 16. is_payment_required_error
+# ============================================================================
+
+
+class TestIsPaymentRequiredError:
+    """Tests for is_payment_required_error utility."""
+
+    def test_returns_true_for_payment_required_error(self):
+        from x402.mcp.utils import is_payment_required_error
+
+        err = PaymentRequiredError("test")
+        assert is_payment_required_error(err) is True
+
+    def test_returns_false_for_generic_exception(self):
+        from x402.mcp.utils import is_payment_required_error
+
+        assert is_payment_required_error(RuntimeError("test")) is False
+
+    def test_returns_false_for_non_exception(self):
+        from x402.mcp.utils import is_payment_required_error
+
+        assert is_payment_required_error("not an exception") is False
+
+
+# ============================================================================
+# 17. Auto-payment disabled warnings
+# ============================================================================
+
+
+class TestAutoPaymentDisabled:
+    """Tests for auto_payment=False behavior."""
+
+    @pytest.mark.asyncio
+    async def test_async_no_auto_payment_no_hook_raises(self):
+        """Async client with auto_payment=False and no hooks raises PaymentRequiredError."""
+        mock_mcp = MockAsyncMCPClient()
+        mock_payment = MockAsyncPaymentClient()
+
+        mock_mcp.call_tool.return_value = _make_payment_required_result()
+
+        with pytest.warns(UserWarning, match="auto_payment=False"):
+            client = x402MCPClient(
+                mock_mcp, mock_payment, auto_payment=False, on_payment_requested=None
+            )
+
+        with pytest.raises(PaymentRequiredError) as exc_info:
+            await client.call_tool("tool", {})
+
+        assert exc_info.value.code == 402
+
+    @pytest.mark.asyncio
+    async def test_async_auto_payment_true_no_warning(self):
+        """Async client with auto_payment=True does not warn."""
+        mock_mcp = MockAsyncMCPClient()
+        mock_payment = MockAsyncPaymentClient()
+
+        mock_mcp.call_tool.return_value = MockMCPResult(
+            content=[{"type": "text", "text": "ok"}],
+            is_error=False,
+        )
+
+        # Should not warn
+        client = x402MCPClient(mock_mcp, mock_payment, auto_payment=True)
+        result = await client.call_tool("tool", {})
+        assert result.payment_made is False
+
+    def test_sync_auto_payment_false_no_payment(self):
+        """Sync client with auto_payment=False does not create payment."""
+        mock_mcp = MockMCPClient()
+        mock_payment = MockPaymentClient()
+
+        mock_mcp.call_tool.return_value = _make_payment_required_result()
+
+        client = x402MCPClientSync(mock_mcp, mock_payment, auto_payment=False)
+        result = client.call_tool("tool", {})
+
+        assert result.payment_made is False
+        assert result.is_error is True
+        mock_payment.create_payment_payload.assert_not_called()

--- a/python/x402/replay_protection.py
+++ b/python/x402/replay_protection.py
@@ -1,0 +1,115 @@
+"""Replay protection store for x402 resource servers.
+
+Provides server-side enforcement to prevent payment proof replay attacks
+during the HTTP-layer TOCTOU window (between verification and settlement).
+
+See specs/extensions/replay-protection.md for the full specification.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import threading
+import time
+from typing import Protocol, runtime_checkable
+
+# Default TTL for nonce entries (5 minutes).
+# Matches PendingSettlementStore TTL — both cover the verify→settle window.
+REPLAY_PROTECTION_TTL_SECONDS = 300.0
+
+
+@runtime_checkable
+class ReplayProtectionStore(Protocol):
+    """Protocol for a replay protection store.
+
+    Implementations must be safe for concurrent use.
+    """
+
+    def is_duplicate(self, nonce: str) -> bool:
+        """Check if nonce was already seen. If not, record it and return False.
+
+        Returns True when the nonce is a replay (already seen and not expired).
+        """
+        ...
+
+    def stats(self) -> dict:
+        """Return store stats for monitoring."""
+        ...
+
+
+class InMemoryReplayProtectionStore:
+    """Default ReplayProtectionStore implementation.
+
+    A lock-protected, per-process dict with lazy TTL pruning.
+    Never performs network I/O — suitable for single-instance resource servers.
+    Multi-instance deployments should inject a shared, network-backed
+    ReplayProtectionStore implementation (e.g. Redis).
+    """
+
+    def __init__(self, ttl: float = REPLAY_PROTECTION_TTL_SECONDS) -> None:
+        self._seen: dict[str, float] = {}  # nonce -> monotonic timestamp
+        self._lock = threading.Lock()
+        self._ttl = ttl
+
+    def is_duplicate(self, nonce: str) -> bool:
+        with self._lock:
+            self._prune()
+            if nonce in self._seen:
+                return True  # REPLAY DETECTED
+            self._seen[nonce] = time.monotonic()
+            return False
+
+    def stats(self) -> dict:
+        with self._lock:
+            self._prune()
+            return {
+                "active_nonces": len(self._seen),
+                "ttl_seconds": self._ttl,
+                "store": "in_memory",
+            }
+
+    def _prune(self) -> None:
+        """Remove entries older than TTL. Caller must hold lock."""
+        cutoff = time.monotonic() - self._ttl
+        expired = [k for k, v in self._seen.items() if v < cutoff]
+        for k in expired:
+            del self._seen[k]
+
+
+def extract_nonce(payload: dict) -> str:
+    """Extract a deterministic nonce from a payment payload.
+
+    The nonce is used as the replay protection key. For schemes where
+    the authorization nonce is directly available (EIP-3009, Permit2),
+    it is used directly. For opaque payloads, a SHA-256 hash is used.
+
+    Args:
+        payload: The payment payload dict (from PAYMENT-SIGNATURE header).
+
+    Returns:
+        A string nonce suitable for replay detection.
+    """
+    # Try EIP-3009 authorization nonce
+    if "authorization" in payload:
+        auth = payload["authorization"]
+        if isinstance(auth, dict) and "nonce" in auth:
+            return str(auth["nonce"]).strip().lower()
+
+    # Try Permit2 authorization nonce
+    if "permit2Authorization" in payload:
+        p2 = payload["permit2Authorization"]
+        if isinstance(p2, dict) and "nonce" in p2:
+            return str(p2["nonce"]).strip().lower()
+
+    # Fallback: hash the entire payload
+    import json
+    normalized = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:16]
+
+
+__all__ = [
+    "REPLAY_PROTECTION_TTL_SECONDS",
+    "ReplayProtectionStore",
+    "InMemoryReplayProtectionStore",
+    "extract_nonce",
+]

--- a/python/x402/tests/test_replay_protection.py
+++ b/python/x402/tests/test_replay_protection.py
@@ -1,0 +1,157 @@
+"""Tests for x402 replay protection."""
+
+import time
+
+from x402.replay_protection import (
+    InMemoryReplayProtectionStore,
+    extract_nonce,
+)
+
+
+class TestInMemoryReplayProtectionStore:
+    """Test the in-memory replay protection store."""
+
+    def test_first_use_returns_false(self):
+        store = InMemoryReplayProtectionStore()
+        assert store.is_duplicate("nonce-1") is False
+
+    def test_second_use_returns_true(self):
+        store = InMemoryReplayProtectionStore()
+        store.is_duplicate("nonce-1")
+        assert store.is_duplicate("nonce-1") is True
+
+    def test_different_nonces_both_pass(self):
+        store = InMemoryReplayProtectionStore()
+        assert store.is_duplicate("nonce-1") is False
+        assert store.is_duplicate("nonce-2") is False
+
+    def test_same_nonce_different_stores_pass(self):
+        store1 = InMemoryReplayProtectionStore()
+        store2 = InMemoryReplayProtectionStore()
+        store1.is_duplicate("nonce-1")
+        # Different store — not a replay
+        assert store2.is_duplicate("nonce-1") is False
+
+    def test_stats_tracks_active_nonces(self):
+        store = InMemoryReplayProtectionStore()
+        stats = store.stats()
+        assert stats["active_nonces"] == 0
+
+        store.is_duplicate("nonce-1")
+        stats = store.stats()
+        assert stats["active_nonces"] == 1
+
+        store.is_duplicate("nonce-2")
+        stats = store.stats()
+        assert stats["active_nonces"] == 2
+
+    def test_stats_includes_ttl(self):
+        store = InMemoryReplayProtectionStore(ttl=600)
+        stats = store.stats()
+        assert stats["ttl_seconds"] == 600
+
+    def test_ttl_expiry_allows_reuse(self):
+        store = InMemoryReplayProtectionStore(ttl=0.1)  # 100ms
+        store.is_duplicate("nonce-1")
+        time.sleep(0.15)
+        # Nonce expired — should pass again
+        assert store.is_duplicate("nonce-1") is False
+
+    def test_prune_removes_expired(self):
+        store = InMemoryReplayProtectionStore(ttl=0.1)
+        store.is_duplicate("nonce-1")
+        store.is_duplicate("nonce-2")
+        assert store.stats()["active_nonces"] == 2
+
+        time.sleep(0.15)
+        # Trigger prune via stats
+        stats = store.stats()
+        assert stats["active_nonces"] == 0
+
+    def test_store_type_in_stats(self):
+        store = InMemoryReplayProtectionStore()
+        assert store.stats()["store"] == "in_memory"
+
+
+class TestExtractNonce:
+    """Test nonce extraction from payment payloads."""
+
+    def test_eip3009_nonce(self):
+        payload = {
+            "authorization": {
+                "nonce": "0xf3746613c2d920b5fdabc0856f2aeb2d4f88ee6037b8cc5d04a71a4462f13480"
+            }
+        }
+        nonce = extract_nonce(payload)
+        assert nonce == "0xf3746613c2d920b5fdabc0856f2aeb2d4f88ee6037b8cc5d04a71a4462f13480"
+
+    def test_permit2_nonce(self):
+        payload = {
+            "permit2Authorization": {
+                "nonce": "33247007178036348590600198031289925668252061821958005840077069883511451257277"
+            }
+        }
+        nonce = extract_nonce(payload)
+        assert nonce == "33247007178036348590600198031289925668252061821958005840077069883511451257277"
+
+    def test_fallback_hash(self):
+        payload = {"signature": "0xabc123", "data": "some-value"}
+        nonce1 = extract_nonce(payload)
+        nonce2 = extract_nonce(payload)
+        # Same payload → same hash
+        assert nonce1 == nonce2
+        # Hash is 16 hex chars
+        assert len(nonce1) == 16
+
+    def test_different_payloads_different_hashes(self):
+        p1 = {"signature": "0xaaa"}
+        p2 = {"signature": "0xbbb"}
+        assert extract_nonce(p1) != extract_nonce(p2)
+
+    def test_nonce_normalization(self):
+        """Whitespace and case are normalized."""
+        payload1 = {"authorization": {"nonce": "  0xABC  "}}
+        payload2 = {"authorization": {"nonce": "0xabc"}}
+        assert extract_nonce(payload1) == extract_nonce(payload2)
+
+    def test_eip3009_takes_precedence(self):
+        """If both authorization and permit2Authorization exist, prefer EIP-3009."""
+        payload = {
+            "authorization": {"nonce": "0xaaa"},
+            "permit2Authorization": {"nonce": "0xbbb"},
+        }
+        nonce = extract_nonce(payload)
+        assert nonce == "0xaaa"
+
+
+class TestReplayProtectionIntegration:
+    """Integration tests combining store + nonce extraction."""
+
+    def test_full_flow_first_request(self):
+        store = InMemoryReplayProtectionStore()
+        payload = {
+            "authorization": {
+                "nonce": "0xf3746613c2d920b5fdabc0856f2aeb2d4f88ee6037b8cc5d04a71a4462f13480"
+            }
+        }
+        nonce = extract_nonce(payload)
+        assert store.is_duplicate(nonce) is False
+
+    def test_full_flow_duplicate_rejected(self):
+        store = InMemoryReplayProtectionStore()
+        payload = {
+            "authorization": {
+                "nonce": "0xf3746613c2d920b5fdabc0856f2aeb2d4f88ee6037b8cc5d04a71a4462f13480"
+            }
+        }
+        nonce = extract_nonce(payload)
+        store.is_duplicate(nonce)
+        assert store.is_duplicate(nonce) is True
+
+    def test_full_flow_different_proofs_pass(self):
+        store = InMemoryReplayProtectionStore()
+        p1 = {"authorization": {"nonce": "0xaaa"}}
+        p2 = {"authorization": {"nonce": "0xbbb"}}
+
+        assert store.is_duplicate(extract_nonce(p1)) is False
+        assert store.is_duplicate(extract_nonce(p2)) is False

--- a/python/x402/tests/unit/http/middleware/test_django.py
+++ b/python/x402/tests/unit/http/middleware/test_django.py
@@ -1,0 +1,535 @@
+"""Unit tests for x402.http.middleware.django - Django middleware."""
+
+from __future__ import annotations
+
+import json
+import threading
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Skip all tests if django not installed
+django = pytest.importorskip("django")
+
+from django.conf import settings as django_settings
+from django.http import HttpRequest, JsonResponse, HttpResponse
+
+from x402 import x402FacilitatorSync, x402ResourceServerSync
+from x402.http.facilitator_client_base import FacilitatorResponseError
+from x402.http.middleware.django import (
+    DjangoAdapter,
+    X402PaymentMiddleware,
+    _json_error_response,
+    payment_middleware,
+    set_settlement_overrides,
+)
+from x402.http.types import (
+    HTTPProcessResult,
+    HTTPResponseInstructions,
+    PaymentOption,
+    ProcessSettleResult,
+    RouteConfig,
+)
+from x402.schemas import PaymentPayload, PaymentRequirements
+from x402.schemas.hooks import (
+    CompletedSettlement,
+    PaymentCancellationDispatcher,
+    VerifiedPaymentCancelOptions,
+)
+
+from ....mocks import (
+    CashFacilitatorClientSync,
+    CashSchemeNetworkFacilitator,
+    CashSchemeNetworkServer,
+)
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def make_payment_requirements() -> PaymentRequirements:
+    """Helper to create valid PaymentRequirements."""
+    return PaymentRequirements(
+        scheme="exact",
+        network="eip155:8453",
+        asset="0x0000000000000000000000000000000000000000",
+        amount="1000000",
+        pay_to="0x1234567890123456789012345678901234567890",
+        max_timeout_seconds=300,
+    )
+
+
+def make_v2_payload(signature: str = "0xmock") -> PaymentPayload:
+    """Helper to create valid V2 PaymentPayload."""
+    return PaymentPayload(
+        x402_version=2,
+        payload={"signature": signature},
+        accepted=make_payment_requirements(),
+    )
+
+
+def make_mock_django_request(
+    method: str = "GET",
+    path: str = "/api/test",
+    meta: dict[str, str] | None = None,
+    get_params: dict[str, str] | None = None,
+    body: bytes | None = None,
+) -> MagicMock:
+    """Create a mock Django HttpRequest object."""
+    mock_request = MagicMock(spec=HttpRequest)
+    mock_request.method = method
+    mock_request.path = path
+    mock_request.build_absolute_uri = MagicMock(return_value=f"https://example.com{path}")
+
+    # Django stores headers in META with HTTP_ prefix
+    meta_dict = {}
+    if meta:
+        for key, value in meta.items():
+            # Convert to Django META format
+            django_key = "HTTP_" + key.replace("-", "_").upper()
+            meta_dict[django_key] = value
+    mock_request.META = meta_dict
+
+    # Query params
+    mock_request.GET = get_params or {}
+
+    # Body
+    mock_request.body = body or b""
+
+    # Response helpers
+    mock_request.x402_payment_payload = None
+    mock_request.x402_payment_requirements = None
+
+    return mock_request
+
+
+# =============================================================================
+# Adapter Tests
+# =============================================================================
+
+
+class TestDjangoAdapter:
+    """Tests for DjangoAdapter."""
+
+    def test_get_header_normal(self):
+        """Test getting a normal header."""
+        request = make_mock_django_request(meta={"X-Custom": "value"})
+        adapter = DjangoAdapter(request)
+        assert adapter.get_header("X-Custom") == "value"
+
+    def test_get_header_content_type(self):
+        """Test getting Content-Type header (no HTTP_ prefix in META)."""
+        request = make_mock_django_request(meta={"Content-Type": "application/json"})
+        adapter = DjangoAdapter(request)
+        assert adapter.get_header("Content-Type") == "application/json"
+
+    def test_get_header_content_length(self):
+        """Test getting Content-Length header."""
+        request = make_mock_django_request(meta={"Content-Length": "100"})
+        adapter = DjangoAdapter(request)
+        assert adapter.get_header("Content-Length") == "100"
+
+    def test_get_header_missing(self):
+        """Test getting a missing header returns None."""
+        request = make_mock_django_request()
+        adapter = DjangoAdapter(request)
+        assert adapter.get_header("X-Missing") is None
+
+    def test_get_method(self):
+        """Test getting HTTP method."""
+        request = make_mock_django_request(method="POST")
+        adapter = DjangoAdapter(request)
+        assert adapter.get_method() == "POST"
+
+    def test_get_path(self):
+        """Test getting request path."""
+        request = make_mock_django_request(path="/api/weather")
+        adapter = DjangoAdapter(request)
+        assert adapter.get_path() == "/api/weather"
+
+    def test_get_url(self):
+        """Test getting full URL."""
+        request = make_mock_django_request(path="/api/weather")
+        adapter = DjangoAdapter(request)
+        assert adapter.get_url() == "https://example.com/api/weather"
+
+    def test_get_accept_header(self):
+        """Test getting Accept header."""
+        request = make_mock_django_request(meta={"Accept": "application/json"})
+        adapter = DjangoAdapter(request)
+        assert adapter.get_accept_header() == "application/json"
+
+    def test_get_user_agent(self):
+        """Test getting User-Agent header."""
+        request = make_mock_django_request(meta={"User-Agent": "TestBot/1.0"})
+        adapter = DjangoAdapter(request)
+        assert adapter.get_user_agent() == "TestBot/1.0"
+
+    def test_get_query_params(self):
+        """Test getting query parameters."""
+        request = make_mock_django_request(get_params={"q": "test", "page": "1"})
+        adapter = DjangoAdapter(request)
+        params = adapter.get_query_params()
+        assert params["q"] == "test"
+        assert params["page"] == "1"
+
+    def test_get_query_param(self):
+        """Test getting a single query parameter."""
+        request = make_mock_django_request(get_params={"q": "test"})
+        adapter = DjangoAdapter(request)
+        assert adapter.get_query_param("q") == "test"
+
+    def test_get_body_json(self):
+        """Test getting JSON body."""
+        body = json.dumps({"key": "value"}).encode("utf-8")
+        request = make_mock_django_request(body=body)
+        adapter = DjangoAdapter(request)
+        assert adapter.get_body() == {"key": "value"}
+
+    def test_get_body_empty(self):
+        """Test getting empty body."""
+        request = make_mock_django_request(body=b"")
+        adapter = DjangoAdapter(request)
+        assert adapter.get_body() is None
+
+    def test_get_body_invalid_json(self):
+        """Test getting invalid JSON body."""
+        request = make_mock_django_request(body=b"not json")
+        adapter = DjangoAdapter(request)
+        assert adapter.get_body() is None
+
+
+# =============================================================================
+# Response Helper Tests
+# =============================================================================
+
+
+class TestJsonErrorResponse:
+    """Tests for _json_error_response helper."""
+
+    def test_basic_error(self):
+        """Test basic error response."""
+        response = _json_error_response(402, "Payment required")
+        assert response.status_code == 402
+        assert json.loads(response.content) == {"error": "Payment required"}
+
+    def test_error_with_headers(self):
+        """Test error response with extra headers."""
+        response = _json_error_response(502, "Bad Gateway", {"X-Custom": "value"})
+        assert response.status_code == 502
+        assert response["X-Custom"] == "value"
+
+
+# =============================================================================
+# Extension Check Tests
+# =============================================================================
+
+
+class TestCheckIfBazaarNeeded:
+    """Tests for _check_if_bazaar_needed helper."""
+
+    def test_returns_false_for_empty_extensions(self):
+        """Test that routes without extensions return False."""
+        from x402.http.middleware._bazaar_utils import check_if_bazaar_needed
+
+        route = RouteConfig(
+            accepts=PaymentOption(
+                scheme="exact",
+                pay_to="0x1234567890123456789012345678901234567890",
+                price="$0.01",
+                network="eip155:8453",
+            ),
+        )
+        assert check_if_bazaar_needed(route) is False
+
+
+# =============================================================================
+# Middleware Integration Tests
+# =============================================================================
+
+
+class TestX402PaymentMiddleware:
+    """Integration tests for X402PaymentMiddleware."""
+
+    def _make_middleware(
+        self,
+        routes: dict | None = None,
+        server: x402ResourceServerSync | None = None,
+    ):
+        """Create middleware with mock server."""
+        if routes is None:
+            routes = {}
+        if server is None:
+            server = x402ResourceServerSync(CashFacilitatorClientSync())
+            server.register("eip155:8453", CashSchemeNetworkServer())
+
+        from x402.http.types import RouteConfig, PaymentOption
+
+        if routes and not isinstance(list(routes.values())[0], RouteConfig):
+            route_config = {}
+            for pattern, config in routes.items():
+                accepts = config.get("accepts", {})
+                route_config[pattern] = RouteConfig(
+                    accepts=PaymentOption(
+                        scheme=accepts.get("scheme", "exact"),
+                        pay_to=accepts.get("payTo", "0x1234567890123456789012345678901234567890"),
+                        price=accepts.get("price", "$0.01"),
+                        network=accepts.get("network", "eip155:8453"),
+                    ),
+                )
+            routes = route_config
+
+        from x402.http.middleware.django import X402PaymentMiddleware
+
+        # Create middleware class with injected server
+        http_server = x402.http.x402_http_server.x402HTTPResourceServerSync(server, routes)
+
+        class InjectedMiddleware:
+            def __init__(self, get_response=None):
+                self._get_response = get_response
+                self._http_server = http_server
+
+            def __call__(self, request):
+                adapter = DjangoAdapter(request)
+                context = __import__("x402.http.types", fromlist=["HTTPRequestContext"]).HTTPRequestContext(
+                    adapter=adapter,
+                    path=request.path,
+                    method=request.method,
+                    payment_header=(
+                        adapter.get_header("payment-signature")
+                        or adapter.get_header("x-payment")
+                    ),
+                )
+
+                if not self._http_server.requires_payment(context):
+                    return self._get_response(request)
+
+                result = self._http_server.process_http_request(context)
+
+                if result.type == "no-payment-required":
+                    return self._get_response(request)
+
+                if result.type == "payment-error":
+                    return JsonResponse(
+                        content=result.response.body or {},
+                        status=result.response.status,
+                        headers=result.response.headers,
+                    )
+
+                if result.type == "payment-verified":
+                    request.x402_payment_payload = result.payment_payload
+                    request.x402_payment_requirements = result.payment_requirements
+                    return self._get_response(request)
+
+                return self._get_response(request)
+
+        return InjectedMiddleware
+
+    def test_free_route_passes_through(self):
+        """Test that routes not matching any pattern pass through."""
+        middleware = self._make_middleware(routes={})
+
+        request = make_mock_django_request(method="GET", path="/api/free")
+        response = HttpResponse("OK")
+
+        def get_response(req):
+            return response
+
+        mw = middleware(get_response)
+        result = mw(request)
+        assert result == response
+
+    def test_payment_required_returns_402(self):
+        """Test that payment-required routes return 402."""
+        routes = {
+            "GET /api/paid/*": {
+                "accepts": {
+                    "scheme": "exact",
+                    "payTo": "0x1234567890123456789012345678901234567890",
+                    "price": "$0.01",
+                    "network": "eip155:8453",
+                }
+            }
+        }
+
+        middleware = self._make_middleware(routes=routes)
+        request = make_mock_django_request(method="GET", path="/api/paid/weather")
+
+        def get_response(req):
+            return HttpResponse("OK")
+
+        mw = middleware(get_response)
+        result = mw(request)
+
+        # Should get 402 with payment required
+        assert result.status_code == 402
+
+    def test_payment_verified_attaches_to_request(self):
+        """Test that verified payment attaches payload to request."""
+        from x402.http.types import RouteConfig, PaymentOption
+
+        # Create a server that returns "already paid" (cash scheme)
+        routes = {
+            "GET /api/paid/*": RouteConfig(
+                accepts=PaymentOption(
+                    scheme="cash",
+                    pay_to="0x1234567890123456789012345678901234567890",
+                    price="$0.01",
+                    network="eip155:8453",
+                ),
+            ),
+        }
+
+        server = x402ResourceServerSync(CashFacilitatorClientSync())
+        server.register("eip155:8453", CashSchemeNetworkServer())
+
+        http_server = x402.http.x402_http_server.x402HTTPResourceServerSync(server, routes)
+
+        request = make_mock_django_request(method="GET", path="/api/paid/data")
+
+        def get_response(req):
+            # Check that payment info was attached
+            assert hasattr(req, "x402_payment_payload")
+            return HttpResponse('{"data": "value"}', content_type="application/json")
+
+        from x402.http.types import HTTPRequestContext
+
+        adapter = DjangoAdapter(request)
+        context = HTTPRequestContext(
+            adapter=adapter,
+            path=request.path,
+            method=request.method,
+            payment_header=(
+                adapter.get_header("payment-signature")
+                or adapter.get_header("x-payment")
+            ),
+        )
+
+        # Process through http server
+        result = http_server.process_http_request(context)
+
+        if result.type == "payment-verified":
+            request.x402_payment_payload = result.payment_payload
+            request.x402_payment_requirements = result.payment_requirements
+            response = get_response(request)
+            assert response.status_code == 200
+
+    def test_set_settlement_overrides(self):
+        """Test setting settlement overrides on response."""
+        response = HttpResponse("OK")
+        set_settlement_overrides(response, {"amount": "500"})
+        assert response["x402-settlement-overrides"] == '{"amount": "500"}'
+
+    def test_facilitator_error_returns_502(self):
+        """Test that facilitator errors return 502."""
+        mock_facilitator = MagicMock()
+        mock_facilitator.get_supported_capabilities = MagicMock(
+            side_effect=FacilitatorResponseError("Service unavailable", 503)
+        )
+
+        server = x402ResourceServerSync(mock_facilitator)
+        routes = {
+            "GET /api/paid/*": {
+                "accepts": {
+                    "scheme": "exact",
+                    "payTo": "0x1234567890123456789012345678901234567890",
+                    "price": "$0.01",
+                    "network": "eip155:8453",
+                }
+            }
+        }
+
+        from x402.http.types import RouteConfig, PaymentOption
+
+        route_config = {
+            "GET /api/paid/*": RouteConfig(
+                accepts=PaymentOption(
+                    scheme="exact",
+                    pay_to="0x1234567890123456789012345678901234567890",
+                    price="$0.01",
+                    network="eip155:8453",
+                ),
+            ),
+        }
+
+        http_server = x402.http.x402_http_server.x402HTTPResourceServerSync(server, route_config)
+
+        request = make_mock_django_request(method="GET", path="/api/paid/data")
+
+        def get_response(req):
+            return HttpResponse("OK")
+
+        from x402.http.types import HTTPRequestContext
+
+        adapter = DjangoAdapter(request)
+        context = HTTPRequestContext(
+            adapter=adapter,
+            path=request.path,
+            method=request.method,
+            payment_header=(
+                adapter.get_header("payment-signature")
+                or adapter.get_header("x-payment")
+            ),
+        )
+
+        if http_server.requires_payment(context):
+            try:
+                result = http_server.process_http_request(context)
+            except FacilitatorResponseError as error:
+                response = _json_error_response(502, str(error))
+                assert response.status_code == 502
+
+
+# =============================================================================
+# Factory Function Tests
+# =============================================================================
+
+
+class TestPaymentMiddlewareFactory:
+    """Tests for payment_middleware factory function."""
+
+    def test_factory_returns_class(self):
+        """Test that factory returns a middleware class."""
+        from x402.http.types import RouteConfig, PaymentOption
+
+        routes = {
+            "GET /api/test/*": RouteConfig(
+                accepts=PaymentOption(
+                    scheme="exact",
+                    pay_to="0x1234567890123456789012345678901234567890",
+                    price="$0.01",
+                    network="eip155:8453",
+                ),
+            ),
+        }
+
+        server = x402ResourceServerSync(CashFacilitatorClientSync())
+        server.register("eip155:8453", CashSchemeNetworkServer())
+
+        middleware_class = payment_middleware(routes, server)
+        assert callable(middleware_class)
+
+    def test_factory_creates_callable_instance(self):
+        """Test that factory-created middleware can be instantiated."""
+        from x402.http.types import RouteConfig, PaymentOption
+
+        routes = {
+            "GET /api/test/*": RouteConfig(
+                accepts=PaymentOption(
+                    scheme="exact",
+                    pay_to="0x1234567890123456789012345678901234567890",
+                    price="$0.01",
+                    network="eip155:8453",
+                ),
+            ),
+        }
+
+        server = x402ResourceServerSync(CashFacilitatorClientSync())
+        server.register("eip155:8453", CashSchemeNetworkServer())
+
+        middleware_class = payment_middleware(routes, server)
+        instance = middleware_class(lambda req: HttpResponse("OK"))
+        assert callable(instance)

--- a/specs/extensions/replay-protection.md
+++ b/specs/extensions/replay-protection.md
@@ -1,0 +1,302 @@
+# Extension: `replay-protection`
+
+## Summary
+
+The `replay-protection` extension adds server-side enforcement to prevent payment proof replay attacks during the HTTP-layer TOCTOU window — the time between payment verification and blockchain settlement.
+
+While on-chain nonces (EIP-3009, Permit2) prevent replay **after** settlement, and the `payment-identifier` extension provides client-side idempotency keys, neither prevents a malicious client from submitting the same valid payment proof to multiple endpoints or servers before settlement completes.
+
+This extension provides a server-side mechanism that:
+1. Extracts a deterministic nonce from the payment proof
+2. Tracks seen nonces in a server-side store
+3. Rejects duplicate proofs with `409 Conflict` before any processing
+
+---
+
+## Motivation
+
+### The TOCTOU Window
+
+The x402 payment flow has a window between verification and settlement:
+
+```
+Client → Resource Server: PAYMENT-SIGNATURE header
+Resource Server → Facilitator: /verify
+Facilitator → Resource Server: valid
+                              ← TOCTOU WINDOW →
+Resource Server → Facilitator: /settle
+Facilitator → Blockchain: broadcast
+```
+
+During this window (typically 100-2000ms), the same payment proof could be:
+- Submitted to the same server multiple times (replay)
+- Submitted to different servers (parallel spend attempt)
+- Intercepted and replayed by a network attacker
+
+On-chain nonces prevent double-spending **after** settlement, but during the TOCTOU window, the same proof can trigger multiple verify/settle cycles, wasting gas and potentially causing confusion.
+
+### Why `payment-identifier` Is Not Sufficient
+
+The existing `payment-identifier` extension is:
+- **Optional** — servers cannot enforce it without client cooperation
+- **Client-generated** — a malicious client can send different identifiers for the same proof
+- **Response-caching focused** — designed for idempotency, not security enforcement
+
+### What `replay-protection` Adds
+
+- **Mandatory server-side enforcement** — the server tracks seen nonces regardless of client behavior
+- **Proof-derived nonces** — extracted from the cryptographic proof itself, not client-provided
+- **Instant rejection** — `409 Conflict` before facilitator call, saving gas and processing
+
+---
+
+## Specification
+
+### Nonce Extraction
+
+The nonce is extracted deterministically from the payment proof:
+
+| Scheme | Nonce Source | Derivation |
+|--------|-------------|------------|
+| `exact` (EIP-3009) | `payload.authorization.nonce` | Direct use (32-byte hex) |
+| `exact` (Permit2) | `payload.permit2Authorization.nonce` | Direct use (uint256) |
+| `exact` (ERC-7710) | `payload.permissionContext` | SHA-256 hash (opaque bytes) |
+| `upto` | `payload.authorization.nonce` | Direct use (32-byte hex) |
+| `batch-settlement` | Voucher signature | SHA-256 of signed voucher |
+
+For schemes where the nonce is not directly available (or is opaque), the server computes:
+```
+nonce_hash = SHA-256(normalize(payload))[:16]
+```
+
+Where `normalize()` strips whitespace and lowercases hex strings.
+
+### Server-Side Store
+
+Servers maintain a `ReplayProtectionStore`:
+
+```python
+class ReplayProtectionStore(Protocol):
+    """Thread-safe store for tracking seen payment nonces."""
+
+    def is_duplicate(self, nonce: str) -> bool:
+        """Check if nonce was already seen. If not, record it and return False."""
+        ...
+
+    def stats(self) -> dict:
+        """Return store stats for monitoring."""
+        ...
+```
+
+The store must be:
+- **Thread-safe** — safe for concurrent HTTP requests
+- **TTL-based** — entries expire after a configurable period (default: 300 seconds)
+- **Per-process** for single-instance servers, or **shared** (e.g., Redis) for multi-instance
+
+### Extension Registration
+
+Servers advertise support in `PaymentRequired`:
+
+```json
+{
+  "extensions": {
+    "replay-protection": {
+      "info": {
+        "required": true,
+        "ttl_seconds": 300
+      }
+    }
+  }
+}
+```
+
+### Client Behavior
+
+Clients do NOT need to send anything special for replay-protection. The server extracts nonces from the existing `PaymentPayload` fields.
+
+However, clients that also use `payment-identifier` benefit from:
+- Client-side idempotency (same proof, same id → cached response)
+- Server-side enforcement (same proof, any id → `409 Conflict`)
+
+### Response Codes
+
+| Scenario | Response |
+|----------|----------|
+| New nonce | Process normally |
+| Duplicate nonce (same endpoint) | `409 Conflict` |
+| Duplicate nonce (different endpoint) | `409 Conflict` |
+| Duplicate nonce after TTL expiry | Process normally (nonce evicted) |
+
+### `409 Conflict` Response Body
+
+```json
+{
+  "error": "Payment proof already used",
+  "detail": "Each payment proof can only be used once. This proof was previously submitted.",
+  "nonce": "e99a18c428cb38d5f260853678922e03",
+  "hint": "Generate a new payment proof for this request."
+}
+```
+
+---
+
+## Integration with Existing Components
+
+### Relationship to `PendingSettlementStore`
+
+The `PendingSettlementStore` tracks **broadcast-but-not-confirmed** transactions for retry. The `ReplayProtectionStore` tracks **verified-but-not-settled** proofs for replay prevention. They serve different purposes:
+
+| Store | Purpose | Key | TTL |
+|-------|---------|-----|-----|
+| `PendingSettlementStore` | Retry failed settlements | tx_hash | 300s |
+| `ReplayProtectionStore` | Block replay attacks | proof_nonce | 300s |
+
+### Relationship to `payment-identifier`
+
+| Feature | `payment-identifier` | `replay-protection` |
+|---------|---------------------|---------------------|
+| Direction | Client → Server | Server-side only |
+| Enforcement | Optional | Mandatory |
+| Nonce source | Client-generated | Proof-derived |
+| Purpose | Idempotency | Security |
+| Can coexist | Yes | Yes |
+
+---
+
+## Implementation Guide
+
+### Python SDK
+
+Add to `python/x402/replay_protection.py`:
+
+```python
+import hashlib
+import threading
+import time
+
+class InMemoryReplayProtectionStore:
+    """Default replay protection store (single-instance)."""
+
+    def __init__(self, ttl: int = 300):
+        self._seen: dict[str, float] = {}
+        self._lock = threading.Lock()
+        self._ttl = ttl
+
+    def is_duplicate(self, nonce: str) -> bool:
+        with self._lock:
+            self._prune()
+            if nonce in self._seen:
+                return True
+            self._seen[nonce] = time.monotonic()
+            return False
+
+    def stats(self) -> dict:
+        with self._lock:
+            self._prune()
+            return {"active_nonces": len(self._seen), "ttl_seconds": self._ttl}
+
+    def _prune(self):
+        cutoff = time.monotonic() - self._ttl
+        expired = [k for k, v in self._seen.items() if v < cutoff]
+        for k in expired:
+            del self._seen[k]
+```
+
+### Integration Point
+
+In `x402ResourceServer.verify_payment()`, before calling the facilitator:
+
+```python
+# Check replay protection
+if self._replay_store and self._replay_store.is_duplicate(extracted_nonce):
+    return ResourceVerifyResponse(
+        is_valid=False,
+        invalid_reason="Payment proof already used",
+    )
+```
+
+---
+
+## Security Analysis
+
+### What This Prevents
+
+1. **HTTP-layer replay** — same proof submitted to same server multiple times
+2. **Parallel spend** — same proof submitted to different endpoints before settlement
+3. **Gas waste** — facilitator doesn't waste gas verifying already-seen proofs
+
+### What This Does NOT Prevent
+
+1. **Post-settlement replay** — on-chain nonces handle this
+2. **Client-side proof sharing** — if a client shares their proof, others can use it once (until first settlement)
+3. **Sybil attacks** — multiple clients creating multiple proofs (requires rate limiting)
+
+### Trust Assumptions
+
+- The server is trusted to maintain the store honestly
+- The store is per-process (or shared via Redis for multi-instance)
+- TTL-based expiry is acceptable (not permanent deduplication)
+
+---
+
+## Test Vectors
+
+### Test 1: First Request Passes
+
+```json
+// Request 1
+POST /v1/premium-data
+X-PAYMENT: {"scheme":"exact","network":"eip155:8453",...}
+
+// Response: 200 OK
+```
+
+### Test 2: Duplicate Rejected
+
+```json
+// Request 1 (same proof)
+POST /v1/premium-data
+X-PAYMENT: {"scheme":"exact","network":"eip155:8453",...}
+
+// Response: 200 OK
+
+// Request 2 (identical proof)
+POST /v1/premium-data
+X-PAYMENT: {"scheme":"exact","network":"eip155:8453",...}
+
+// Response: 409 Conflict
+```
+
+### Test 3: Different Proofs Both Pass
+
+```json
+// Request 1 (proof A)
+POST /v1/premium-data
+X-PAYMENT: {"scheme":"exact","network":"eip155:8453","payload":{"authorization":{"nonce":"0xaaa..."},...}}
+
+// Response: 200 OK
+
+// Request 2 (proof B)
+POST /v1/premium-data
+X-PAYMENT: {"scheme":"exact","network":"eip155:8453","payload":{"authorization":{"nonce":"0xbbb..."},...}}
+
+// Response: 200 OK
+```
+
+### Test 4: TTL Expiry
+
+```json
+// Request 1
+POST /v1/premium-data
+X-PAYMENT: {...}
+
+// Response: 200 OK
+
+// Wait 301 seconds (TTL = 300s)
+
+// Request 2 (same proof)
+POST /v1/premium-data
+X-PAYMENT: {...}
+
+// Response: 200 OK (nonce evicted)
+```


### PR DESCRIPTION
## Summary

Adds 107 edge case tests for the MCP client module covering scenarios that were previously untested.

## What is Tested

- **Malformed payment required responses** (13 tests): Invalid JSON, missing accepts, empty content, FastMCP errors
- **Network/connection errors** (9 tests): ConnectionError, TimeoutError, OSError propagation and retry failures
- **Payment creation failures** (6 tests): Exceptions, None/invalid payloads, timeouts
- **Settlement failures** (8 tests): success=False, empty/missing response fields
- **Concurrent access** (3 tests): Async gather, sequential independence
- **get_tool_payment_requirements** (6 tests): Free tools, exceptions, structured content
- **Hook edge cases** (9 tests): Exceptions, multiple hooks, context modification, wrong return types
- **Utility functions** (37 tests): convert_mcp_result, extract helpers, _try_extract_payment_json
- **Auto-payment disabled** (3 tests): Warning behavior, PaymentRequiredError raising

## Notes

The existing test_client.py has 8 pre-existing failures where x402MCPClientSync is used with methods (on_payment_required, on_before_payment, get_tool_payment_requirements) that only exist on the async client x402MCPClient. These are not addressed in this PR.