### PR TITLE
fix(python): default HTTPFacilitatorClient timeout to 90s

### DIFF
--- a/python/x402/changelog.d/3409.bugfix.md
+++ b/python/x402/changelog.d/3409.bugfix.md
@@ -1,0 +1,1 @@
+HTTPFacilitatorClient now defaults to a 90s per-request timeout so long settle() calls can finish.

--- a/python/x402/http/facilitator_client_base.py
+++ b/python/x402/http/facilitator_client_base.py
@@ -23,6 +23,9 @@ from .constants import DEFAULT_FACILITATOR_URL
 if TYPE_CHECKING:
     pass
 
+# Default per-request timeout for facilitator HTTP calls, in seconds
+DEFAULT_TIMEOUT = 90.0
+
 
 # ============================================================================
 # Auth Provider Protocol
@@ -135,7 +138,7 @@ class FacilitatorConfig:
     """Configuration for HTTP facilitator client."""
 
     url: str = DEFAULT_FACILITATOR_URL
-    timeout: float = 30.0
+    timeout: float = DEFAULT_TIMEOUT
     http_client: Any = None  # Optional httpx.Client or httpx.AsyncClient
     auth_provider: AuthProvider | None = None
     identifier: str | None = None
@@ -157,7 +160,7 @@ class HTTPFacilitatorClientBase:
             auth_provider = CreateHeadersAuthProvider(create_headers) if create_headers else None
 
             self._url = url.rstrip("/")
-            self._timeout = 30.0
+            self._timeout = DEFAULT_TIMEOUT
             self._auth_provider = auth_provider
             self._identifier = self._url
             self._http_client = None

--- a/python/x402/tests/unit/http/test_facilitator_client.py
+++ b/python/x402/tests/unit/http/test_facilitator_client.py
@@ -216,3 +216,9 @@ def test_sync_settle_raises_facilitator_response_error_for_invalid_schema():
         match="Facilitator settle returned invalid data",
     ):
         client.settle(make_v2_payload(), make_payment_requirements())
+
+
+def test_defaults_timeout_to_90_seconds():
+    assert HTTPFacilitatorClient()._timeout == 90.0
+    assert HTTPFacilitatorClient(FacilitatorConfig(timeout=5.0))._timeout == 5.0
+    assert HTTPFacilitatorClient({})._timeout == 90.0


### PR DESCRIPTION
Port of https://github.com/x402-foundation/x402/pull/3392 from TypeScript to Python SDK.

TypeScript `HTTPFacilitatorClient` now waits 90s per facilitator request so a long `settle()` can finish. Python `HTTPFacilitatorClientBase` still defaulted to 30s in `FacilitatorConfig` and the dict constructor, so the same traffic could time out in Python. This raises the Python default to 90s and still honors an explicit `timeout` override. Hono and Next body buffering from #3392 is TypeScript-only and is not part of this port. Tracking issue: https://github.com/x402-foundation/x402/issues/3405 (this PR does not close it).

AI disclosure: Automated by @phdargen. Use your own judgement