### PR TITLE
fix(mcp): prefer .meta over ._meta in convert_mcp_result for MCP SDK 2.x

### DIFF
--- a/python/x402/mcp/tests/test_utils.py
+++ b/python/x402/mcp/tests/test_utils.py
@@ -457,3 +457,52 @@ def test_convert_mcp_result_missing_attrs():
     assert result.is_error is False
     assert result.meta == {}
     assert result.structured_content is None
+
+
+def test_convert_mcp_result_prefers_meta_over_dunder_meta():
+    """MCP SDK 2.x exposes ``.meta`` (Pydantic field); ``._meta`` is the wire
+    alias only present in 1.x JSON transport.  convert_mcp_result must prefer
+    ``.meta`` so settlement metadata is not silently dropped.
+
+    Regression test for https://github.com/x402-foundation/x402/issues/3149
+    """
+    from x402.mcp.utils import convert_mcp_result
+
+    class McpSdk2Result:
+        """Simulates MCP SDK 2.x CallToolResult with .meta field."""
+        content = [{"type": "text", "text": "paid result"}]
+        isError = False
+        meta = {"x402/payment-response": {"success": True, "transaction": "0xabc"}}
+        structuredContent = None
+
+    result = convert_mcp_result(McpSdk2Result())
+    assert result.meta == {"x402/payment-response": {"success": True, "transaction": "0xabc"}}
+
+
+def test_convert_mcp_result_fallback_to_dunder_meta():
+    """MCP SDK 1.x only exposes ``._meta`` (no ``.meta`` attribute).
+    convert_mcp_result must fall back to ``._meta`` for backwards compat."""
+    from x402.mcp.utils import convert_mcp_result
+
+    class McpSdk1Result:
+        """Simulates MCP SDK 1.x result with only _meta."""
+        content = [{"type": "text", "text": "old result"}]
+        isError = False
+        _meta = {"legacy_key": "legacy_val"}
+
+    result = convert_mcp_result(McpSdk1Result())
+    assert result.meta == {"legacy_key": "legacy_val"}
+
+
+def test_convert_mcp_result_meta_takes_precedence():
+    """When both .meta and ._meta exist, .meta must win."""
+    from x402.mcp.utils import convert_mcp_result
+
+    class BothMetaResult:
+        content = []
+        isError = False
+        meta = {"correct": True}
+        _meta = {"stale": True}
+
+    result = convert_mcp_result(BothMetaResult())
+    assert result.meta == {"correct": True}

--- a/python/x402/mcp/utils.py
+++ b/python/x402/mcp/utils.py
@@ -383,8 +383,11 @@ def convert_mcp_result(mcp_result: Any) -> "MCPToolResult":
     if is_error is None:
         is_error = getattr(mcp_result, "is_error", False)
 
-    # Extract meta
-    meta = getattr(mcp_result, "_meta", {})
+    # Extract meta — prefer .meta (MCP SDK 2.x Pydantic field) over
+    # ._meta (wire alias that only exists in 1.x JSON transport).
+    meta = getattr(mcp_result, "meta", None)
+    if meta is None:
+        meta = getattr(mcp_result, "_meta", None)
     if not isinstance(meta, dict):
         meta = {}
 


### PR DESCRIPTION
## Summary

Fixes #3149 — settlement metadata silently dropped when using the standard Python MCP SDK .

## Problem

 reads  to extract payment metadata. However, the standard MCP Python SDK 2.x  is a Pydantic model that exposes the field as ;  is only its wire alias for JSON serialization and does not exist as a Python attribute.

This means when a server wrapper returns a successful paid result, the client never sees the settlement response —  is always .

## Fix



## Tests

Adds 3 regression tests:
- **test_convert_mcp_result_prefers_meta_over_dunder_meta** — MCP SDK 2x  attribute
- **test_convert_mcp_result_fallback_to_dunder_meta** — MCP SDK 1x  fallback
- **test_convert_mcp_result_meta_takes_precedence** —  wins when both exist

All 24 tests pass.

## Impact

- **Unblocks** anyone using  with  (the default install resolves to 2.x now)
- **No breaking changes** — backwards compatible with MCP SDK 1.x via fallback
- Low-risk, targeted fix