### PR TITLE
fix(mcp): add MCP SDK 2.x compatibility for server wrapper

### DIFF
--- a/python/x402/mcp/server.py
+++ b/python/x402/mcp/server.py
@@ -3,12 +3,32 @@
 Provides create_payment_wrapper() to add x402 payment verification
 and settlement to FastMCP tool handlers.
 
-Example:
+Works with both MCP SDK 1.x (FastMCP) and 2.x (MCPServer).
+
+Example (MCP SDK 1.x):
     ```python
     from mcp.server.fastmcp import FastMCP
     from x402.mcp import create_payment_wrapper
 
     mcp = FastMCP("my-server")
+    wrapper = create_payment_wrapper(
+        resource_server,
+        accepts=weather_accepts,
+        resource=ResourceInfo(url="mcp://tool/get_weather", description="Get weather"),
+    )
+
+    @mcp.tool(name="get_weather", description="Get current weather")
+    @wrapper
+    async def get_weather(city: str) -> str:
+        return json.dumps({"city": city, "weather": "sunny", "temperature": 72})
+    ```
+
+Example (MCP SDK 2.x):
+    ```python
+    from mcp.server.mcpserver import MCPServer
+    from x402.mcp import create_payment_wrapper
+
+    mcp = MCPServer("my-server")
     wrapper = create_payment_wrapper(
         resource_server,
         accepts=weather_accepts,
@@ -88,8 +108,12 @@ def create_payment_wrapper(
     Returns:
         A decorator to apply to a FastMCP tool handler function.
     """
-    # Lazy import mcp types so the module can be imported without mcp installed
-    from mcp.server.fastmcp import Context
+    # Lazy import mcp types so the module can be imported without mcp installed.
+    # MCP SDK 2.x renamed FastMCP to MCPServer and moved Context.
+    try:
+        from mcp.server.fastmcp import Context
+    except (ImportError, ModuleNotFoundError):
+        from mcp.server.mcpserver import Context
 
     from mcp.types import CallToolResult, TextContent
 

--- a/python/x402/mcp/tests/test_utils.py
+++ b/python/x402/mcp/tests/test_utils.py
@@ -457,3 +457,52 @@ def test_convert_mcp_result_missing_attrs():
     assert result.is_error is False
     assert result.meta == {}
     assert result.structured_content is None
+
+
+def test_convert_mcp_result_prefers_meta_over_dunder_meta():
+    """MCP SDK 2.x exposes ``.meta`` (Pydantic field); ``._meta`` is the wire
+    alias only present in 1.x JSON transport.  convert_mcp_result must prefer
+    ``.meta`` so settlement metadata is not silently dropped.
+
+    Regression test for https://github.com/x402-foundation/x402/issues/3149
+    """
+    from x402.mcp.utils import convert_mcp_result
+
+    class McpSdk2Result:
+        """Simulates MCP SDK 2.x CallToolResult with .meta field."""
+        content = [{"type": "text", "text": "paid result"}]
+        isError = False
+        meta = {"x402/payment-response": {"success": True, "transaction": "0xabc"}}
+        structuredContent = None
+
+    result = convert_mcp_result(McpSdk2Result())
+    assert result.meta == {"x402/payment-response": {"success": True, "transaction": "0xabc"}}
+
+
+def test_convert_mcp_result_fallback_to_dunder_meta():
+    """MCP SDK 1.x only exposes ``._meta`` (no ``.meta`` attribute).
+    convert_mcp_result must fall back to ``._meta`` for backwards compat."""
+    from x402.mcp.utils import convert_mcp_result
+
+    class McpSdk1Result:
+        """Simulates MCP SDK 1.x result with only _meta."""
+        content = [{"type": "text", "text": "old result"}]
+        isError = False
+        _meta = {"legacy_key": "legacy_val"}
+
+    result = convert_mcp_result(McpSdk1Result())
+    assert result.meta == {"legacy_key": "legacy_val"}
+
+
+def test_convert_mcp_result_meta_takes_precedence():
+    """When both .meta and ._meta exist, .meta must win."""
+    from x402.mcp.utils import convert_mcp_result
+
+    class BothMetaResult:
+        content = []
+        isError = False
+        meta = {"correct": True}
+        _meta = {"stale": True}
+
+    result = convert_mcp_result(BothMetaResult())
+    assert result.meta == {"correct": True}

--- a/python/x402/mcp/utils.py
+++ b/python/x402/mcp/utils.py
@@ -383,8 +383,11 @@ def convert_mcp_result(mcp_result: Any) -> "MCPToolResult":
     if is_error is None:
         is_error = getattr(mcp_result, "is_error", False)
 
-    # Extract meta
-    meta = getattr(mcp_result, "_meta", {})
+    # Extract meta — prefer .meta (MCP SDK 2.x Pydantic field) over
+    # ._meta (wire alias that only exists in 1.x JSON transport).
+    meta = getattr(mcp_result, "meta", None)
+    if meta is None:
+        meta = getattr(mcp_result, "_meta", None)
     if not isinstance(meta, dict):
         meta = {}
 


### PR DESCRIPTION
## Summary

Fixes #3261 — create_payment_wrapper() fails to import on any clean install with MCP SDK 2.x.

## Problem

MCP SDK 2.x renamed FastMCP to MCPServer and moved Context from mcp.server.fastmcp to mcp.server.mcpserver. The x402 server wrapper imported Context exclusively from the 1.x path:



Since x402 declares mcp>=1.0.0 with no upper bound, a fresh install resolves to mcp 2.x (currently 2.2.0). Every paid MCP tool wrapper fails at import time.

## Fix



Also updates the module docstring with 2.x examples (MCPServer instead of FastMCP).

## Testing

Verified that create_payment_wrapper() imports successfully with mcp 2.2.0 installed.

## Impact

- **Unblocks** anyone doing a clean install of x402[mcp] with the default mcp version
- **No breaking changes** — backwards compatible with mcp 1.x
- Minimal change, maximum impact