### PR TITLE
fix(extensions): preserve mcp:// scheme URLs in extractDiscoveryInfo

### DIFF
--- a/typescript/packages/extensions/src/bazaar/facilitator.ts
+++ b/typescript/packages/extensions/src/bazaar/facilitator.ts
@@ -573,12 +573,20 @@ export function extractDiscoveryInfo(
     return null;
   }
 
-  // Strip query params (?) and hash sections (#) for discovery cataloging
-  const url = new URL(resourceUrl);
-  // If a routeTemplate is present (dynamic route), use it as the canonical path
-  const canonicalUrl = routeTemplate
-    ? `${url.origin}${routeTemplate}`
-    : `${url.origin}${url.pathname}`;
+  // Strip query params (?) and hash sections (#) for discovery cataloging.
+  // Non-standard schemes (e.g. mcp://) produce an opaque origin via the URL
+  // constructor, so we use the raw resource URL directly for those.
+  let canonicalUrl: string;
+  if (resourceUrl.startsWith("mcp://")) {
+    // MCP URLs are opaque to WHATWG URL parsing; the raw value is already canonical.
+    canonicalUrl = resourceUrl;
+  } else {
+    const url = new URL(resourceUrl);
+    // If a routeTemplate is present (dynamic route), use it as the canonical path
+    canonicalUrl = routeTemplate
+      ? `${url.origin}${routeTemplate}`
+      : `${url.origin}${url.pathname}`;
+  }
 
   // Extract description and mimeType from resource info (v2) or requirements (v1)
   let description: string | undefined;

--- a/typescript/packages/extensions/test/bazaar.test.ts
+++ b/typescript/packages/extensions/test/bazaar.test.ts
@@ -1644,6 +1644,43 @@ describe("Bazaar Discovery Extension", () => {
       expect(discovered).not.toBeNull();
       expect(discovered!.resourceUrl).toBe("https://mcp.example.com/tools");
     });
+
+    it("should preserve mcp:// scheme URLs as canonical without opaque origin corruption", () => {
+      const declared = declareDiscoveryExtension({
+        toolName: "financial_analysis",
+        description: "Analyze financial data",
+        inputSchema: {
+          type: "object",
+          properties: {
+            ticker: { type: "string" },
+          },
+        },
+      });
+
+      const extension = declared.bazaar;
+
+      const paymentPayload = {
+        x402Version: 2,
+        scheme: "exact",
+        network: "eip155:8453" as unknown,
+        payload: {},
+        accepted: {} as unknown,
+        resource: {
+          url: "mcp://tool/financial_analysis",
+          description: "MCP Tool",
+          mimeType: "application/json",
+        },
+        extensions: {
+          [BAZAAR.key]: extension,
+        },
+      };
+
+      const discovered = extractDiscoveryInfo(paymentPayload, {} as unknown);
+
+      expect(discovered).not.toBeNull();
+      expect(discovered!.resourceUrl).toBe("mcp://tool/financial_analysis");
+      expect((discovered as DiscoveredMCPResource).toolName).toBe("financial_analysis");
+    });
   });
 
   describe("validateAndExtract - MCP", () => {


### PR DESCRIPTION
Closes #3121

## Problem

`extractDiscoveryInfo` uses `new URL()` to build the canonical `resourceUrl`. Non-standard schemes like `mcp://` produce an opaque origin (`"null"`) via the WHATWG URL constructor, corrupting the canonical URL:



This breaks every facilitator that catalogs MCP resources using the documented `mcp://tool/{toolName}` convention.

## Fix

Skip URL parsing entirely for `mcp://` URLs and use the raw `resourceUrl` directly, since it is already in canonical form.

## Changes

- `facilitator.ts`: Added `mcp://` scheme check before `new URL()` call
- `bazaar.test.ts`: Added regression test confirming `mcp://` URLs are preserved as-is

## Verification

- [x] All existing bazaar tests pass
- [x] New regression test passes
- [x] No `mcp://` URL goes through `new URL()` parsing