### PR TITLE
fix(facilitator): validate request schemas before processing

### DIFF
--- a/typescript/site/app/facilitator/settle/route.ts
+++ b/typescript/site/app/facilitator/settle/route.ts
@@ -1,4 +1,5 @@
-import { PaymentPayload, PaymentRequirements, SettleResponse } from "@x402/core/types";
+import { SettleResponse } from "@x402/core/types";
+import { parsePaymentPayload, parsePaymentRequirements } from "@x402/core/schemas";
 import { getFacilitator } from "../index";
 
 /**
@@ -9,13 +10,10 @@ import { getFacilitator } from "../index";
  */
 export async function POST(req: Request) {
   // Parse request body - only use "unknown:unknown" if parsing fails
-  let paymentPayload: PaymentPayload | undefined;
-  let paymentRequirements: PaymentRequirements | undefined;
+  let body: Record<string, unknown>;
 
   try {
-    const body = await req.json();
-    paymentPayload = body.paymentPayload as PaymentPayload;
-    paymentRequirements = body.paymentRequirements as PaymentRequirements;
+    body = await req.json();
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     console.error("Failed to parse request body:", errorMessage);
@@ -33,7 +31,7 @@ export async function POST(req: Request) {
   }
 
   // Check for missing parameters
-  if (!paymentPayload || !paymentRequirements) {
+  if (!body.paymentPayload || !body.paymentRequirements) {
     return Response.json(
       {
         success: false,
@@ -42,14 +40,49 @@ export async function POST(req: Request) {
         error: "Missing paymentPayload or paymentRequirements",
         transaction: "",
         // Use network from paymentRequirements if available, otherwise unknown
-        network: (paymentRequirements?.network || "unknown:unknown") as `${string}:${string}`,
+        network: ((body.paymentRequirements as Record<string, unknown>)?.network ||
+          "unknown:unknown") as `${string}:${string}`,
       } as SettleResponse,
       { status: 400 },
     );
   }
 
-  // At this point we know we have both paymentPayload and paymentRequirements
-  const network = paymentRequirements.network;
+  // Validate schemas before forwarding to the facilitator.
+  // Without this, a malformed v2 payload (e.g. missing `accepted`) would
+  // produce an opaque 500 deep inside the scheme handler instead of a
+  // clear 400 the caller can fix.
+  const payloadResult = parsePaymentPayload(body.paymentPayload);
+  if (!payloadResult.success) {
+    return Response.json(
+      {
+        success: false,
+        errorReason: "invalid_payment_payload",
+        errorMessage: `paymentPayload validation failed: ${payloadResult.error.issues.map(i => i.message).join(", ")}`,
+        error: payloadResult.error.message,
+        transaction: "",
+        network: "unknown:unknown" as `${string}:${string}`,
+      } as SettleResponse,
+      { status: 400 },
+    );
+  }
+
+  const requirementsResult = parsePaymentRequirements(body.paymentRequirements);
+  if (!requirementsResult.success) {
+    return Response.json(
+      {
+        success: false,
+        errorReason: "invalid_payment_requirements",
+        errorMessage: `paymentRequirements validation failed: ${requirementsResult.error.issues.map(i => i.message).join(", ")}`,
+        error: requirementsResult.error.message,
+        transaction: "",
+        network: "unknown:unknown" as `${string}:${string}`,
+      } as SettleResponse,
+      { status: 400 },
+    );
+  }
+
+  // At this point we know we have both validated paymentPayload and paymentRequirements
+  const network = requirementsResult.data.network;
 
   try {
     const facilitator = await getFacilitator();
@@ -58,7 +91,10 @@ export async function POST(req: Request) {
     // - Validate payment was verified (onBeforeSettle - will abort if not)
     // - Check verification timeout (onBeforeSettle)
     // - Clean up tracking (onAfterSettle / onSettleFailure)
-    const response: SettleResponse = await facilitator.settle(paymentPayload, paymentRequirements);
+    const response: SettleResponse = await facilitator.settle(
+      payloadResult.data,
+      requirementsResult.data,
+    );
 
     return Response.json(response);
   } catch (error) {

--- a/typescript/site/app/facilitator/verify/route.ts
+++ b/typescript/site/app/facilitator/verify/route.ts
@@ -1,4 +1,5 @@
-import { VerifyResponse, PaymentPayload, PaymentRequirements } from "@x402/core/types";
+import { VerifyResponse } from "@x402/core/types";
+import { parsePaymentPayload, parsePaymentRequirements } from "@x402/core/schemas";
 import { getFacilitator } from "../index";
 
 /**
@@ -9,13 +10,10 @@ import { getFacilitator } from "../index";
  */
 export async function POST(req: Request) {
   // Parse request body - handle JSON parsing errors separately
-  let paymentPayload: PaymentPayload | undefined;
-  let paymentRequirements: PaymentRequirements | undefined;
+  let body: Record<string, unknown>;
 
   try {
-    const body = await req.json();
-    paymentPayload = body.paymentPayload as PaymentPayload;
-    paymentRequirements = body.paymentRequirements as PaymentRequirements;
+    body = await req.json();
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     console.error("Failed to parse request body:", errorMessage);
@@ -31,7 +29,7 @@ export async function POST(req: Request) {
   }
 
   // Check for missing parameters
-  if (!paymentPayload || !paymentRequirements) {
+  if (!body.paymentPayload || !body.paymentRequirements) {
     return Response.json(
       {
         isValid: false,
@@ -43,13 +41,46 @@ export async function POST(req: Request) {
     );
   }
 
+  // Validate schemas before forwarding to the facilitator.
+  // Without this, a malformed v2 payload (e.g. missing `accepted`) would
+  // produce an opaque 500 deep inside the scheme handler instead of a
+  // clear 400 the caller can fix.
+  const payloadResult = parsePaymentPayload(body.paymentPayload);
+  if (!payloadResult.success) {
+    return Response.json(
+      {
+        isValid: false,
+        invalidReason: "invalid_payment_payload",
+        invalidMessage: `paymentPayload validation failed: ${payloadResult.error.issues.map(i => i.message).join(", ")}`,
+        error: payloadResult.error.message,
+      } as VerifyResponse,
+      { status: 400 },
+    );
+  }
+
+  const requirementsResult = parsePaymentRequirements(body.paymentRequirements);
+  if (!requirementsResult.success) {
+    return Response.json(
+      {
+        isValid: false,
+        invalidReason: "invalid_payment_requirements",
+        invalidMessage: `paymentRequirements validation failed: ${requirementsResult.error.issues.map(i => i.message).join(", ")}`,
+        error: requirementsResult.error.message,
+      } as VerifyResponse,
+      { status: 400 },
+    );
+  }
+
   try {
     const facilitator = await getFacilitator();
 
     // Hooks will automatically:
     // - Track verified payment (onAfterVerify)
     // - Extract and catalog discovery info (onAfterVerify)
-    const response: VerifyResponse = await facilitator.verify(paymentPayload, paymentRequirements);
+    const response: VerifyResponse = await facilitator.verify(
+      payloadResult.data,
+      requirementsResult.data,
+    );
 
     return Response.json(response);
   } catch (error) {


### PR DESCRIPTION
Closes #3015

The hosted facilitator routes cast request body fields with `as` type assertions, skipping all runtime validation. A malformed v2 payload (missing `accepted`, wrong field names) crashes deep in scheme handlers producing opaque HTTP 500 errors.

This PR adds Zod schema validation using the existing `parsePaymentPayload` and `parsePaymentRequirements` from `@x402/core/schemas`.

**Before:** Malformed request -> 500 `unexpected_error` with `Cannot read properties of undefined`
**After:** Malformed request -> 400 with specific Zod validation message (e.g. `paymentPayload validation failed: Required`)

Changes:
- `verify/route.ts`: Replace `as` casts with `parsePaymentPayload` + `parsePaymentRequirements` safe parsing
- `settle/route.ts`: Same validation, plus preserved error shape for settlement failure responses