### PR TITLE
fix(core): enforce settlement override ceiling in settlePayment

### DIFF
--- a/typescript/packages/core/src/server/x402ResourceServer.ts
+++ b/typescript/packages/core/src/server/x402ResourceServer.ts
@@ -1226,6 +1226,25 @@ export class x402ResourceServer {
         ...requirements,
         amount: resolveSettlementOverrideAmount(settlementOverrides.amount, requirements, decimals),
       };
+
+      // Enforce the documented ceiling: the resolved override amount must not
+      // exceed the authorized maximum (PaymentRequirements.amount). A percent
+      // override > 100%, a dollar override above the token equivalent, or a
+      // raw override above the authorized cap would silently allow
+      // over-settlement without this guard.
+      const resolvedAmount = BigInt(effectiveRequirements.amount);
+      const authorizedMaximum = BigInt(requirements.amount);
+      if (resolvedAmount > authorizedMaximum) {
+        throw new SettleError(400, {
+          success: false,
+          errorReason: "settlement_override_exceeds_ceiling",
+          errorMessage:
+            `Settlement override amount ${effectiveRequirements.amount} exceeds ` +
+            `authorized maximum ${requirements.amount}`,
+          transaction: "",
+          network: requirements.network,
+        });
+      }
     }
 
     const context: SettleContext = {

--- a/typescript/packages/core/test/unit/server/x402ResourceServer.test.ts
+++ b/typescript/packages/core/test/unit/server/x402ResourceServer.test.ts
@@ -1770,6 +1770,74 @@ describe("x402ResourceServer", () => {
       expect(mockClient.settleCalls[0].requirements.asset).toBe("0xOriginalToken");
     });
 
+    it("should reject settlement override that exceeds authorized ceiling", async () => {
+      const mockClient = new MockFacilitatorClient(
+        buildSupportedResponse({
+          kinds: [{ x402Version: 2, scheme: "exact", network: "eip155:8453" as Network }],
+        }),
+        undefined,
+        buildSettleResponse({ success: true }),
+      );
+
+      const server = new x402ResourceServer(mockClient);
+      const payload = buildPaymentPayload();
+      const requirements = buildPaymentRequirements({
+        scheme: "exact",
+        network: "eip155:8453" as Network,
+        amount: "1000000",
+      });
+
+      // 150% override exceeds the 1000000 ceiling
+      await expect(
+        server.settlePayment(payload, requirements, undefined, undefined, { amount: "150%" }),
+      ).rejects.toThrow(/exceeds authorized maximum/);
+    });
+
+    it("should reject raw atomic override that exceeds authorized ceiling", async () => {
+      const mockClient = new MockFacilitatorClient(
+        buildSupportedResponse({
+          kinds: [{ x402Version: 2, scheme: "exact", network: "eip155:8453" as Network }],
+        }),
+        undefined,
+        buildSettleResponse({ success: true }),
+      );
+
+      const server = new x402ResourceServer(mockClient);
+      const payload = buildPaymentPayload();
+      const requirements = buildPaymentRequirements({
+        scheme: "exact",
+        network: "eip155:8453" as Network,
+        amount: "1000000",
+      });
+
+      // Raw amount 2000000 exceeds the 1000000 ceiling
+      await expect(
+        server.settlePayment(payload, requirements, undefined, undefined, { amount: "2000000" }),
+      ).rejects.toThrow(/exceeds authorized maximum/);
+    });
+
+    it("should allow settlement override at exactly the authorized ceiling", async () => {
+      const mockClient = new MockFacilitatorClient(
+        buildSupportedResponse({
+          kinds: [{ x402Version: 2, scheme: "exact", network: "eip155:8453" as Network }],
+        }),
+        undefined,
+        buildSettleResponse({ success: true }),
+      );
+
+      const server = new x402ResourceServer(mockClient);
+      const payload = buildPaymentPayload();
+      const requirements = buildPaymentRequirements({
+        scheme: "exact",
+        network: "eip155:8453" as Network,
+        amount: "1000000",
+      });
+
+      await server.settlePayment(payload, requirements, undefined, undefined, { amount: "100%" });
+
+      expect(mockClient.settleCalls[0].requirements.amount).toBe("1000000");
+    });
+
     it("should pass overridden requirements to beforeSettle hooks", async () => {
       const mockClient = new MockFacilitatorClient(
         buildSupportedResponse(),


### PR DESCRIPTION
Closes #3334

`settlePayment`'s `settlementOverrides.amount` allows callers to override the settlement amount via percent, dollar, or raw atomic values. The JSDoc states 'The resolved amount must be <= the authorized maximum', but no runtime check enforces this.

A percent override >100%, dollar override above the token equivalent, or raw override above the authorized cap silently allows over-settlement.

**Fix:** Add a BigInt ceiling check after `resolveSettlementOverrideAmount` — throws `SettleError(400, 'settlement_override_exceeds_ceiling')` when resolved amount exceeds `PaymentRequirements.amount`.

**Tests:** 3 new cases — percent >100% rejected, raw above cap rejected, exact 100% succeeds.