### PR TITLE
fix(core): emit payment-error header on rejected payments

### DIFF
--- a/typescript/packages/core/src/http/x402HTTPResourceServer.ts
+++ b/typescript/packages/core/src/http/x402HTTPResourceServer.ts
@@ -1339,12 +1339,19 @@ export class x402HTTPResourceServer {
   private createHTTPPaymentRequiredResponse(paymentRequired: PaymentRequired): {
     headers: Record<string, string>;
   } {
-    return {
-      headers: {
-        "PAYMENT-REQUIRED": encodePaymentRequiredHeader(paymentRequired),
-        "Cache-Control": PAYMENT_REQUIRED_CACHE_CONTROL,
-      },
+    const headers: Record<string, string> = {
+      "PAYMENT-REQUIRED": encodePaymentRequiredHeader(paymentRequired),
+      "Cache-Control": PAYMENT_REQUIRED_CACHE_CONTROL,
     };
+
+    // Emit payment-error header when there is a rejection reason, so clients
+    // can distinguish "no payment sent" from "payment rejected" in a single
+    // request/response cycle without needing server-side log access.
+    if (paymentRequired.error) {
+      headers["payment-error"] = paymentRequired.error;
+    }
+
+    return { headers };
   }
 
   /**


### PR DESCRIPTION
Closes #3148

The x402 middleware advertises `payment-error` in `access-control-expose-headers` on every 402 response, but the header is never actually set. This makes 'no payment sent' and 'payment rejected' indistinguishable from the client side.

**Fix:** Add `payment-error` header to `createHTTPPaymentRequiredResponse` when `PaymentRequired.error` is set.

**Behavior:**
- Initial 402 (no payment sent): `PaymentRequired.error` is unset → no `payment-error` header (backward compatible)
- Rejection (bad signature, stale nonce, etc.): `PaymentRequired.error` is set → `payment-error` header carries the machine-readable reason

This allows clients to distinguish failure modes in a single request/response cycle without server-side log access.