### PR TITLE
fix(evm): validate channel state shape in processPaymentResponse

### DIFF
--- a/typescript/packages/mechanisms/evm/src/batch-settlement/client/channel.ts
+++ b/typescript/packages/mechanisms/evm/src/batch-settlement/client/channel.ts
@@ -208,11 +208,30 @@ export async function processPaymentResponse(
   if (chargedAmount !== undefined && typeof chargedAmount !== "string") {
     throw new Error("invalid chargedAmount: not a non-negative integer");
   }
+
+  // Defensive: validate chargedAmount is a valid integer string before BigInt
+  // conversion. A malformed server response could cause an uncaught TypeError.
+  if (chargedAmount !== undefined && !/^\d+$/.test(chargedAmount)) {
+    throw new Error("invalid chargedAmount: not a non-negative integer");
+  }
+
   const channelState = settle.extra?.channelState as BatchSettlementChannelStateExtra | undefined;
+
+  // Validate channelState shape before use. A server response with a partial
+  // channelState (e.g. missing chargedCumulativeAmount) should not crash the
+  // client — skip the state update instead.
+  const chargedCumulativeAmount = channelState?.chargedCumulativeAmount;
+  if (
+    chargedCumulativeAmount !== undefined &&
+    (typeof chargedCumulativeAmount !== "string" || !/^\d+$/.test(chargedCumulativeAmount))
+  ) {
+    return;
+  }
+
   await updateChannelFromSettle(storage, {
     server: {
       chargedAmount,
-      chargedCumulativeAmount: channelState?.chargedCumulativeAmount,
+      chargedCumulativeAmount,
     },
     local,
   });


### PR DESCRIPTION
Closes #3188

`processPaymentResponse` reads the `PAYMENT-RESPONSE` header and delegates to `updateChannelFromSettle` with server-reported `chargedAmount` and `channelState.chargedCumulativeAmount`. A malformed server response (partial `channelState`, non-numeric values) could cause an uncaught TypeError during BigInt conversion.

**Fix:** Add defensive validation before BigInt conversion:
1. Validate `chargedAmount` is a digit-only string
2. Validate `channelState.chargedCumulativeAmount` shape — skip state update on malformed data instead of crashing

A client should never throw while handling a payment response it cannot interpret. Skipping the state update leaves the caller able to recover from the chain.