### PR TITLE
fix(extensions): decode-until-stable in isValidRouteTemplate

### DIFF
--- a/typescript/packages/extensions/src/bazaar/facilitator.ts
+++ b/typescript/packages/extensions/src/bazaar/facilitator.ts
@@ -45,6 +45,9 @@ const ROUTE_TEMPLATE_REGEX = /^\/[a-zA-Z0-9_/:.\-~%]+$/;
  * - Must not contain ".." (path traversal)
  * - Must not contain "://" (URL injection)
  *
+ * Percent-encoding is decoded iteratively until stable before the traversal and
+ * injection checks run, so double-encoded payloads like %252e%252e are caught.
+ *
  * @param value - The raw routeTemplate string from the client payload
  * @returns true if the value is a valid routeTemplate, false otherwise
  *
@@ -53,13 +56,23 @@ const ROUTE_TEMPLATE_REGEX = /^\/[a-zA-Z0-9_/:.\-~%]+$/;
 export function isValidRouteTemplate(value: string | undefined): value is string {
   if (!value) return false;
   if (!ROUTE_TEMPLATE_REGEX.test(value)) return false;
-  // Decode percent-encoding before traversal checks so that %2e%2e is caught.
-  let decoded: string;
-  try {
-    decoded = decodeURIComponent(value);
-  } catch {
-    return false;
-  }
+
+  // Decode percent-encoding iteratively until stable. A single decode pass
+  // does not catch double-encoded payloads (e.g. %252e%252e decodes to %2e%2e
+  // on the first pass, which still passes the ".." check). Looping until the
+  // string stops changing ensures every layer of encoding is stripped.
+  let decoded = value;
+  let prev: string;
+  do {
+    prev = decoded;
+    try {
+      decoded = decodeURIComponent(decoded);
+    } catch {
+      // Malformed percent-encoding — reject.
+      return false;
+    }
+  } while (decoded !== prev);
+
   if (decoded.includes("..")) return false;
   if (decoded.includes("://")) return false;
   return true;

--- a/typescript/packages/extensions/test/bazaar.test.ts
+++ b/typescript/packages/extensions/test/bazaar.test.ts
@@ -2139,6 +2139,22 @@ describe("Bazaar Discovery Extension", () => {
       expect(isValidRouteTemplate("/users/%2e%2e/admin")).toBe(false);
       expect(isValidRouteTemplate("/users/%2E%2E/admin")).toBe(false);
     });
+
+    it("rejects double-percent-encoded traversal sequences", () => {
+      // %252e decodes to %2e, which decodes to . — single-decode misses this
+      expect(isValidRouteTemplate("/foo/%252e%252e%252fsecret")).toBe(false);
+      expect(isValidRouteTemplate("/foo/%252e%252e/admin")).toBe(false);
+    });
+
+    it("rejects double-percent-encoded scheme injection", () => {
+      // %253a%252f%252f decodes to ://  — single-decode misses this
+      expect(isValidRouteTemplate("/foo%253a%252f%252fevil.example.com/bar")).toBe(false);
+    });
+
+    it("rejects triple-encoded traversal", () => {
+      // %25252e%25252e decodes through 3 layers to ..
+      expect(isValidRouteTemplate("/a/%25252e%25252e/b")).toBe(false);
+    });
   });
 
   describe("isValidServiceName", () => {


### PR DESCRIPTION
Closes #3169

`isValidRouteTemplate` applies a single `decodeURIComponent` pass before checking for `..` (traversal) and `://` (scheme injection). A double-encoded payload like `%252e%252e` decodes to `%2e%2e` on the first pass — still no literal `..` — and passes validation.

**Fix:** Decode iteratively until the string stops changing. The regex character set limits encoding depth, so the loop terminates quickly.

**Before:** `/foo/%252e%252e%252fsecret` → accepted (single decode produces `%2e%2e`)
**After:** `/foo/%252e%252e%252fsecret` → rejected (decodes to `/foo/../secret`)

Adds 3 regression tests: double-encoded traversal, double-encoded scheme injection, triple-encoded traversal.