### PR TITLE
fix(stellar): reject areFeesSponsored: false at construction time

### DIFF
--- a/typescript/packages/mechanisms/stellar/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/stellar/src/exact/facilitator/scheme.ts
@@ -146,6 +146,19 @@ export class ExactStellarScheme implements SchemeNetworkFacilitator {
 
     // Apply configuration options (with defaults)
     this.rpcConfig = rpcConfig;
+
+    // The spec only supports areFeesSponsored: true. Setting it to false
+    // silently breaks every settlement: the client throws
+    // "Exact scheme requires areFeesSponsored to be true" with no hint
+    // that the facilitator, not the client, is misconfigured. Fail fast
+    // at construction time instead.
+    if (areFeesSponsored === false) {
+      throw new Error(
+        "ExactStellarScheme: areFeesSponsored: false is not supported by the x402 spec. " +
+          "The client will reject payments with areFeesSponsored: false. " +
+          "Remove the option or set it to true.",
+      );
+    }
     this.areFeesSponsored = areFeesSponsored ?? true;
     this.maxTransactionFeeStroops = maxTransactionFeeStroops ?? DEFAULT_MAX_TRANSACTION_FEE_STROOPS;
     this.selectSigner = selectSigner ?? roundRobinSelectSigner();

--- a/typescript/packages/mechanisms/stellar/test/unit/facilitator-accessors.test.ts
+++ b/typescript/packages/mechanisms/stellar/test/unit/facilitator-accessors.test.ts
@@ -54,16 +54,15 @@ describe("ExactStellarScheme - getExtra", () => {
     expect(mockRpcClient.getLatestLedger).not.toHaveBeenCalled();
   });
 
-  it("should use custom areFeesSponsored", () => {
+  it("should reject areFeesSponsored: false with a clear error", () => {
     const signer = createEd25519Signer(
       "SDV3OZOPGIO6GQAVI7T6ZJ7NSNFB26JX6QZYCI64TBC7BAZY6FQVAXXK",
       STELLAR_TESTNET_CAIP2,
     );
 
-    scheme = new ExactStellarScheme([signer], { areFeesSponsored: false });
-
-    const result = scheme.getExtra(STELLAR_TESTNET_CAIP2);
-    expect(result).toEqual({ areFeesSponsored: false });
+    expect(() => new ExactStellarScheme([signer], { areFeesSponsored: false })).toThrow(
+      /areFeesSponsored: false is not supported/,
+    );
   });
 
   it("should return consistent areFeesSponsored with multiple signers", () => {


### PR DESCRIPTION
Closes #3333

`ExactStellarScheme`'s facilitator constructor accepts `areFeesSponsored: false` without validation, even though the spec only supports `true` and the client throws on `false`.

A facilitator built this way boots without error, advertises `areFeesSponsored: false` on `/supported`, and then every settlement attempt fails with a client-side error that gives no indication the facilitator is misconfigured.

**Fix:** Throw a clear error at construction time when `areFeesSponsored: false` is passed, explaining that the spec only supports `true`.

**Before:** `new ExactStellarScheme([signer], { areFeesSponsored: false })` → boots OK, all settlements fail silently
**After:** `new ExactStellarScheme([signer], { areFeesSponsored: false })` → throws with actionable message