### PR TITLE
fix(stellar): preserve RPC response details on submission failure

### DIFF
--- a/typescript/packages/mechanisms/stellar/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/stellar/src/exact/facilitator/scheme.ts
@@ -337,11 +337,24 @@ export class ExactStellarScheme implements SchemeNetworkFacilitator {
       const sendResult = await server.sendTransaction(txToSubmit);
 
       if (sendResult.status !== "PENDING") {
+        // Distinguish retryable (TRY_AGAIN_LATER) from permanent (ERROR)
+        // failures. TRY_AGAIN_LATER means nothing reached the ledger, nothing
+        // was spent, and the caller should retry. ERROR with txBadSeq means
+        // the payload is stale and must not be retried. Both arrived as the
+        // same opaque string before this fix.
+        const isRetryable = sendResult.status === "TRY_AGAIN_LATER";
+        const errorResultDetail = sendResult.errorResult
+          ? ` — ${JSON.stringify(sendResult.errorResult)}`
+          : "";
+
         return {
           success: false,
           network: payload.accepted.network,
           transaction: "",
-          errorReason: "settle_exact_stellar_transaction_submission_failed",
+          errorReason: isRetryable
+            ? "settle_exact_stellar_submission_retryable"
+            : "settle_exact_stellar_transaction_submission_failed",
+          errorMessage: `Submission status: ${sendResult.status}${errorResultDetail}. latestLedger: ${sendResult.latestLedger ?? "unknown"}`,
           payer,
         };
       }


### PR DESCRIPTION
Closes #3125

When `sendTransaction` returns a non-PENDING status, the settle method discards the entire Soroban RPC response and returns a single constant `errorReason`. This makes it impossible to distinguish:

- **TRY_AGAIN_LATER** — nothing reached the ledger, nothing was spent, **retry is safe**
- **ERROR** with `txBadSeq` — the payload is stale, **retry will never succeed**

Both arrived as the same opaque string `settle_exact_stellar_transaction_submission_failed`, causing ~1 in 3 settlements on testnet to fail silently.

**Fix:**
- `TRY_AGAIN_LATER` → `errorReason: 'settle_exact_stellar_submission_retryable'`
- `ERROR` → `errorReason: 'settle_exact_stellar_transaction_submission_failed'`
- `errorMessage` now includes RPC status, errorResult, and latestLedger for diagnosis