### PR TITLE
fix(python): bound x402[mcp] to mcp<2

### DIFF
--- a/python/x402/changelog.d/3425.bugfix.md
+++ b/python/x402/changelog.d/3425.bugfix.md
@@ -1,0 +1,1 @@
+Bounded the `x402[mcp]` extra to `mcp<2`; mcp 2.x removed `mcp.server.fastmcp`, breaking server-side paid tools on a fresh install.

--- a/python/x402/pyproject.toml
+++ b/python/x402/pyproject.toml
@@ -54,7 +54,8 @@ tvm = [
 ]
 
 # MCP (Model Context Protocol) integration
-mcp = ["mcp>=1.0.0"]
+# Upper bound: mcp 2.x removed mcp.server.fastmcp, which x402.mcp.server imports.
+mcp = ["mcp>=1.0.0,<2"]
 
 # Extensions - optional functionality
 extensions = [
@@ -98,7 +99,7 @@ dev = [
     "pytoniq-core>=0.1.36",
     "PyNaCl>=1.5.0",
     # MCP dependencies
-    "mcp>=1.26.0",
+    "mcp>=1.26.0,<2",
     "nest-asyncio>=1.6.0",
     # Extensions dependencies
     "jsonschema>=4.0.0",

--- a/python/x402/tests/unit/mcp/test_mcp_dependency.py
+++ b/python/x402/tests/unit/mcp/test_mcp_dependency.py
@@ -1,0 +1,16 @@
+"""Guards the mcp import path x402.mcp.server depends on.
+
+mcp 2.x removed mcp.server.fastmcp in favour of mcp.server.mcpserver. The
+x402[mcp] extra is bounded to mcp<2 so installs keep resolving a major that
+provides it; this fails if that bound is dropped.
+"""
+
+from __future__ import annotations
+
+
+def test_fastmcp_import_path_available() -> None:
+    """mcp.server.fastmcp must provide the names x402.mcp.server imports."""
+    from mcp.server.fastmcp import Context, FastMCP
+
+    assert Context is not None
+    assert FastMCP is not None

--- a/python/x402/uv.lock
+++ b/python/x402/uv.lock
@@ -1089,7 +1089,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -4005,7 +4005,7 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'tvm'", specifier = ">=0.28.1" },
     { name = "idna", marker = "extra == 'extensions'", specifier = ">=3.4" },
     { name = "jsonschema", marker = "extra == 'extensions'", specifier = ">=4.0.0" },
-    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0.0" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0.0,<2" },
     { name = "nest-asyncio", specifier = ">=1.6.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pynacl", marker = "extra == 'extensions'", specifier = ">=1.5.0" },
@@ -4038,7 +4038,7 @@ dev = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "idna", specifier = ">=3.4" },
     { name = "jsonschema", specifier = ">=4.0.0" },
-    { name = "mcp", specifier = ">=1.26.0" },
+    { name = "mcp", specifier = ">=1.26.0,<2" },
     { name = "mypy", specifier = ">=1.0.0" },
     { name = "nest-asyncio", specifier = ">=1.6.0" },
     { name = "pynacl", specifier = ">=1.5.0" },


### PR DESCRIPTION
## Description

`x402[mcp]` declared `mcp>=1.0.0` with no upper bound. mcp 2.x removed
`mcp.server.fastmcp`, which `python/x402/mcp/server.py` imports at lines 8 and
92, so a fresh `pip install x402[mcp]` resolved mcp 2.2.0 and every
server-side paid tool failed at import. `uv.lock` pinned 1.27.2, which is why
CI never saw it.

Bounds the extra to `mcp<2`, and the dev group with it so CI cannot drift onto
an unsupported major either. mcp's own import error recommends this pin:

```
ModuleNotFoundError: No module named 'mcp.server.fastmcp'. This is mcp 2.x,
where FastMCP was renamed to MCPServer ... or pin 'mcp<2' to keep running v1 code.
```

Supporting mcp 2.x is a separate change — it needs `mcp.server.mcpserver.MCPServer`
and a decision about whether the SDK carries both majors. This PR only stops
fresh installs from landing on a major the code cannot import.

Closes #3261

## Tests

`uv run pytest tests/unit` from `python/x402/`: **2148 passed**.
`uvx ruff check` clean, `uvx ruff format --check` clean.

Resolver behaviour, before and after the bound:

```
$ uv pip compile - <<<'mcp>=1.0.0'      → mcp==2.2.0   (import fails)
$ uv pip compile - <<<'mcp>=1.0.0,<2'   → mcp==1.30.0  (import works)
```

Reproduced the original failure against a clean `mcp==2.2.0` install:
`mcp.server.fastmcp` is absent, `mcp.server.mcpserver` provides `MCPServer`
and `Context`.

`tests/unit/mcp/test_mcp_dependency.py` imports the two names
`x402.mcp.server` needs, so the bound cannot be dropped silently.

Note: `uv lock` also removed a stale `python_full_version < '3.11'` marker
from `typing-extensions` in `uv.lock`. That is unrelated to this change —
`typing_extensions>=4.0.0` is an unconditional dependency, so the marker was
incorrect. Happy to strip it if you would rather keep the diff to mcp only.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [ ] I added a changelog fragment for user-facing changes (docs-only changes can skip)

Changelog fragment follows once this PR has a number, since Towncrier names it
`<PR>.bugfix.md`.

---

AI disclosure, per CONTRIBUTING: this change was drafted with Claude Code. The
diagnosis was verified independently against a clean mcp 2.2.0 install and the
resolver output shown above, and I have reviewed the diff.
