### PR TITLE
docs(spec): state the CAIP-2 reference grammar in §11.1 (dots are not allowed)

### DIFF
--- a/specs/x402-specification-v2.md
+++ b/specs/x402-specification-v2.md
@@ -630,6 +630,11 @@ Networks in x402 v2 use CAIP-2 (Chain Agnostic Improvement Proposal) format: `na
 
 **Format:** `{namespace}:{reference}` (e.g., `eip155:8453` for Base mainnet)
 
+CAIP-2 constrains both halves: `namespace` matches `[-a-z0-9]{3,8}` and `reference` matches
+`[-_a-zA-Z0-9]{1,32}`. Note that `.` is not permitted in either, so a domain name is not a valid
+reference: `acme:api.example.com` is malformed and a conformant client will reject it. A
+network scoped to a domain has to carry that domain somewhere other than the network identifier.
+
 Non-blockchain networks are encouraged to follow the CAIP-2 format (e.g., `ach:us`, `sepa:eu`).
 
 Both EVM and Solana networks are supported by the reference implementations, e.g.:


### PR DESCRIPTION
## What this changes

Six lines in §11.1. It states the CAIP-2 grammar the section already relies on, and gives one
counter-example.

## Why

§11.1 encourages non-blockchain networks to follow CAIP-2 but does not restate the grammar. When a
network is scoped to a domain, the obvious identifier to reach for is the domain, and
`acme:api.example.com` is malformed: CAIP-2 defines `reference` as `[-_a-zA-Z0-9]{1,32}`, which
excludes `.`.

The failure is quiet. A conformant client rejects the payment requirements, and nothing in this
document tells the implementer why. We hit exactly this while binding a ledger-backed network and
had to go read CAIP-2 to find it.

No normative change: the constraint already comes from CAIP-2. This only makes it visible where
someone will need it.

## Context

Opened alongside #3435, which describes the binding and asks a separate, harder question about
where a payee-side commission belongs in the scheme taxonomy. This PR stands on its own and does
not depend on that answer.

Posted by the Claude agent that built the integration, on behalf of the Nyx5 project
(https://github.com/Nicoiakl/nyx5).
