### PR TITLE
spec: §5.3.5 receiver obligation on an unresolved settlement

### DIFF
--- a/specs/x402-specification-v2.md
+++ b/specs/x402-specification-v2.md
@@ -251,6 +251,60 @@ The `SettleResponse` schema contains the following fields:
 | `amount`      | `string`  | Optional | The actual amount settled in atomic units (omitted if not applicable) |
 | `extensions`  | `object`  | Optional | Protocol extensions data                                              |
 
+**5.3.5 Receiver Obligation on an Unresolved Settlement**
+
+A **receiver** — a resource server, or any party that dispatched a settle and is
+deciding whether to issue a new payment challenge — holds, for an authorization
+`A`, one of three things: a terminal answer, a non-terminal answer, or nothing.
+The rules in this section govern the last two.
+
+`A` is **unresolved** for a receiver when any of the following holds:
+
+- the `SettleResponse` for `A` carries `errorReason: settlement_pending` (see
+  [§9 Error Handling](#9-error-handling)), which is non-terminal by definition;
+- no `SettleResponse` was received at all — a timeout, a dropped connection, or
+  any other transport failure; or
+- a `SettleResponse` was received but cannot be interpreted under this
+  specification.
+
+While `A` is unresolved, a receiver:
+
+- **MUST NOT** issue a new payment challenge for the request `A` was presented
+  against;
+- **MUST NOT** present the outcome to the payer as a failed payment;
+- **MUST**, on a subsequent request for the same intent, re-present `A` itself
+  to the facilitator rather than requiring the payer to authorize again.
+
+**Failure to resolve, receiver side.** A receiver that cannot establish the
+outcome of `A` MUST treat it as unresolved. Neither the absence of a
+`SettleResponse`, nor a transport failure, nor `success: false` accompanied by
+an empty `transaction`, is evidence that `A` did not settle.
+
+**Leaving the unresolved state.** A receiver MAY issue a new payment challenge
+for that request only once one of the following holds:
+
+1. it has reconciled `A` against its `transaction` on `network` and established,
+   under that network's finality rule, that `A` did not settle and can no longer
+   settle; or
+2. it has **withdrawn or invalidated `A` by an action it performed** — for
+   example cancelling the authorization on-chain, or a facilitator-side
+   cancellation whose confirmation it holds — so that `A` can no longer settle.
+
+A receiver MUST NOT infer either condition from elapsed time alone, from the
+absence of a response, or from the repetition of a non-terminal answer. Clause 2
+exists so that a payer whose authorization cannot presently complete is not left
+permanently unaskable: the receiver's remedy is to end `A` explicitly and
+challenge afresh, never to assume `A` has died.
+
+**This obligation does not depend on client behaviour.** It is not conditioned
+on the client re-presenting the same authorization. A conforming client will
+re-present; a non-conforming one will authorize again; the receiver's duty is
+identical in both cases, because the receiver is the party that holds the prior
+authorization and can therefore act on it. Stating the rule conditionally would
+invite the reading that a client-side idempotency key discharges it, and for the
+case where the client's process does not survive the lost reply — which is
+frequently the same event that lost it — that reading does not hold.
+
 **5.4 VerifyResponse Schema**
 
 


### PR DESCRIPTION
Opened at @zjzJoez's suggestion on zjzJoez/x402#1, as its own PR against `main` rather than as a rider on #3325. #3325 was filed and reviewed on one line — vocabulary only, no flow semantics — and I tried to widen that line twice. This is the obligation on its own number, where it can be argued or rejected on its own terms.

## What it says

§5.3 is entirely about what an emitter may claim. Nothing yet says what a reader owes in return. This is that: while an authorization is **unresolved**, a receiver must not challenge again for the same request, must not present the outcome to the payer as a failed payment, and must re-present the authorization rather than ask the payer to sign a new one.

Unresolved means one of three things: `errorReason: settlement_pending`, no `SettleResponse` at all, or one that cannot be interpreted.

## Why it is worth a normative rule

The failure it addresses is not a client bug. A receiver gets something it cannot resolve — a dropped connection, a `success: false` with an empty `transaction`, a 5xx after broadcast — and answers with a fresh `402` for the same intent. The payer then produces a **new** authorization with a new nonce, which every replay guard correctly admits, because at the protocol boundary it is a different payment. Nothing in the bytes distinguishes "same purchase, authorized again after a lost response" from "a second purchase".

That is why the duty has to sit on the receiver. A facilitator cannot infer the payer's intent, and client-side idempotency is bounded by process lifetime — the lost reply is very often caused by the same event that ended the process. The receiver is the only party holding the prior authorization, so it is the only one that can decline to ask for a new one.

## Scope and dependencies

- **Written in `main`'s vocabulary.** The only state it names is `errorReason: settlement_pending`, already normative in §9. Nothing here depends on #3325's `status` field, `statusAnchor`, or the six-state table.
- **Numbering.** §5.3.5 leaves room for #3325's §5.3.3–§5.3.4. If #3325 does not land, renumber this to §5.3.3; no wording changes.
- **+54 lines, one file, no schema change**, no new field, no change to any existing rule.

## Two defects fixed rather than carried over

@zjzJoez reviewed the earlier draft and found both. They are corrected here, and I would rather name them than let a reader assume this text is the same one:

1. **A clause I had publicly retracted was still in the draft** — permitting a receiver to satisfy the obligation by resolving the authorization against an anchor, as an *alternative* to honouring it. I retracted that on 2026-09-04 as too permissive for a normative clause, and then left it standing. It is gone.
2. **The unresolved state had no exit.** As drafted, a payer whose authorization could not presently complete became permanently unaskable: the merchant could neither collect, nor challenge again, nor offer a different asset. The rule now has an explicit exit — reconcile and establish the authorization can no longer settle, **or** withdraw or invalidate it by an action the receiver performs. Never an inference from elapsed time or from silence. That keeps "must not conclude it will clear" intact while leaving the merchant a legal move.

## Prior discussion

The one-line reader rule from this thread was taken into #3325's branch by @zjzJoez at `7e2c7bc`, credited to me, @glennquinting and @jywy78kgrf-create. This PR is the fuller obligation that rule is the summary of, and it is deliberately not proposing anything about conformance testing — a conformance regime argued by someone who ships a conformance battery is self-dealing however carefully it is worded, so I am not re-filing that section here.

Field context is on #3208 and #3325; I have kept empirical claims out of the normative text entirely.

cc @zjzJoez @glennquinting @0xultravioleta