### PR TITLE
fix(evm): make viem optional for server-only installs

### DIFF
--- a/typescript/.changeset/quiet-servers-rest.md
+++ b/typescript/.changeset/quiet-servers-rest.md
@@ -1,0 +1,5 @@
+---
+"@x402/evm": patch
+---
+
+Made viem optional for exact EVM server-only installations.

--- a/typescript/packages/mechanisms/evm/README.md
+++ b/typescript/packages/mechanisms/evm/README.md
@@ -5,6 +5,12 @@ EVM (Ethereum Virtual Machine) implementation of the x402 payment protocol using
 ## Installation
 
 ```bash
+npm install @x402/evm viem
+```
+
+`viem` is optional for consumers that import only `@x402/evm/exact/server`:
+
+```bash
 npm install @x402/evm
 ```
 

--- a/typescript/packages/mechanisms/evm/package.json
+++ b/typescript/packages/mechanisms/evm/package.json
@@ -45,12 +45,20 @@
     "typescript": "^5.7.3",
     "vite": "^6.2.6",
     "vite-tsconfig-paths": "^5.1.4",
-    "vitest": "^3.2.7"
+    "vitest": "^3.2.7",
+    "viem": "^2.48.11"
   },
   "dependencies": {
     "@x402/core": "workspace:~",
-    "viem": "^2.48.11",
     "zod": "^3.24.2"
+  },
+  "peerDependencies": {
+    "viem": "^2.48.11"
+  },
+  "peerDependenciesMeta": {
+    "viem": {
+      "optional": true
+    }
   },
   "exports": {
     ".": {

--- a/typescript/packages/mechanisms/evm/test/unit/package.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/package.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import packageJson from "../../package.json";
+
+type PackageManifest = {
+  dependencies: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  peerDependenciesMeta?: Record<string, { optional?: boolean }>;
+};
+
+const manifest = packageJson as PackageManifest;
+
+describe("@x402/evm package manifest", () => {
+  it("keeps viem optional for server-only consumers", () => {
+    expect(manifest.dependencies).not.toHaveProperty("viem");
+    expect(manifest.peerDependencies?.viem).toBe("^2.48.11");
+    expect(manifest.peerDependenciesMeta?.viem?.optional).toBe(true);
+  });
+});

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -1482,9 +1482,6 @@ importers:
       '@x402/core':
         specifier: workspace:~
         version: link:../../core
-      viem:
-        specifier: ^2.48.11
-        version: 2.48.11(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)
       zod:
         specifier: ^3.24.2
         version: 3.25.76
@@ -1531,6 +1528,9 @@ importers:
       typescript:
         specifier: ^5.7.3
         version: 5.9.2
+      viem:
+        specifier: ^2.48.11
+        version: 2.48.11(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)
       vite:
         specifier: ^6.2.6
         version: 6.3.5(@types/node@22.18.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.1)


### PR DESCRIPTION
## Description

Makes `viem` optional so consumers that use only `@x402/evm/exact/server` do not install the EVM client stack.

- move `viem` from a required dependency to an optional peer while keeping it available for development
- document when consumers need to install `viem`
- add a package-manifest regression test and patch changeset

Closes #3416

## Tests

- `pnpm --filter @x402/evm test` (40 files, 1,113 tests passed)
- `pnpm --filter @x402/evm build`
- packed the package, installed it in a clean consumer without `viem`, and loaded `@x402/evm/exact/server` through both CommonJS and ESM
- changed-file ESLint and Prettier checks
- `pnpm test` completed 56/57 Turbo tasks; the concurrent Cardano task failed, then passed separately with all 299 tests

## Checklist

- [x] I have formatted and linted my code
- [ ] All new and existing tests pass
- [x] My commits are signed (required for merge)
- [x] I added a changelog fragment for user-facing changes

## AI assistance

Significant AI assistance was used for analysis and implementation. The resulting diff was inspected and validated with tests, a production build, and a clean package-install check.