### PR TITLE
fix(next): preserve request body when reading through the adapter

### DIFF
--- a/typescript/.changeset/next-preserve-request-body.md
+++ b/typescript/.changeset/next-preserve-request-body.md
@@ -1,0 +1,5 @@
+---
+"@x402/next": patch
+---
+
+Fixed Next.js adapter body reads consuming the request body before the route handler could read it.

--- a/typescript/packages/http/next/src/adapter.test.ts
+++ b/typescript/packages/http/next/src/adapter.test.ts
@@ -134,7 +134,7 @@ describe("NextAdapter", () => {
   });
 
   describe("getBody", () => {
-    it("returns parsed JSON body", async () => {
+    it("returns parsed JSON body without consuming the original request", async () => {
       const body = { data: "test" };
       const req = new NextRequest("https://example.com/api", {
         method: "POST",
@@ -143,6 +143,31 @@ describe("NextAdapter", () => {
       });
       const adapter = new NextAdapter(req);
       expect(await adapter.getBody()).toEqual(body);
+      expect(await req.json()).toEqual(body);
+    });
+
+    it("returns parsed JSON body on repeated calls", async () => {
+      const body = { data: "test" };
+      const req = new NextRequest("https://example.com/api", {
+        method: "POST",
+        body: JSON.stringify(body),
+        headers: { "Content-Type": "application/json" },
+      });
+      const adapter = new NextAdapter(req);
+      expect(await adapter.getBody()).toEqual(body);
+      expect(await adapter.getBody()).toEqual(body);
+    });
+
+    it("returns undefined for invalid JSON without consuming the original request", async () => {
+      const body = "invalid JSON";
+      const req = new NextRequest("https://example.com/api", {
+        method: "POST",
+        body,
+        headers: { "Content-Type": "application/json" },
+      });
+      const adapter = new NextAdapter(req);
+      expect(await adapter.getBody()).toBeUndefined();
+      expect(await req.text()).toBe(body);
     });
 
     it("returns undefined when body parsing fails", async () => {

--- a/typescript/packages/http/next/src/adapter.ts
+++ b/typescript/packages/http/next/src/adapter.ts
@@ -109,7 +109,7 @@ export class NextAdapter implements HTTPAdapter {
    */
   async getBody(): Promise<unknown> {
     try {
-      return await this.req.json();
+      return await this.req.clone().json();
     } catch {
       return undefined;
     }


### PR DESCRIPTION
## Description

Closes #3445.

Read JSON from a clone in `NextAdapter.getBody()` so payment hooks can inspect the body without consuming the request passed to the route handler. This also allows repeated adapter reads before the handler runs. Parsing failures still return `undefined`.

The tests cover downstream readability, repeated reads, and preservation of malformed JSON. Includes a patch changeset for `@x402/next`; no public API or spec changes.

## Tests

- Confirmed all three regression checks fail before the fix and pass after it.
- Reproduced the hook-to-handler failure with the real HTTP server and wrapper; both the control and hook-body-read cases succeed after the fix.
- All 93 `@x402/next` tests pass with coverage thresholds met. Package lint, changed-file formatting, and ESM/CJS builds with type declarations pass.
- Production source and the adapter tests pass type-checking. Full-package `tsc --noEmit` reports four existing errors in `index.test.ts` and `utils.test.ts`, identical on main and with this fix.

Validated on Windows with Node 24.14.1 and Next.js 16.2.6 using the frozen workspace lockfile. The full monorepo suite was not run.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass (`@x402/next`)
- [x] My commits are signed (required for merge)
- [x] I added a changelog fragment for user-facing changes

AI disclosure: I used Codex to help with the implementation, tests, and validation.
