### PR TITLE
fix(axios): preserve base paths and params in payment hook URLs

### DIFF
--- a/typescript/.changeset/axios-hook-request-url.md
+++ b/typescript/.changeset/axios-hook-request-url.md
@@ -1,0 +1,5 @@
+---
+"@x402/axios": patch
+---
+
+Fixed payment-required hook URLs to use Axios base-path joining and query serialization when the transport does not expose a final response URL.

--- a/typescript/packages/http/axios/src/index.test.ts
+++ b/typescript/packages/http/axios/src/index.test.ts
@@ -1,4 +1,4 @@
-import {
+import axios, {
   AxiosError,
   AxiosHeaders,
   AxiosInstance,
@@ -115,6 +115,7 @@ describe("wrapAxiosWithPayment()", () => {
         },
       },
       request: vi.fn(),
+      getUri: axios.getUri,
     } as unknown as AxiosInstance;
 
     // Create mock client

--- a/typescript/packages/http/axios/src/index.ts
+++ b/typescript/packages/http/axios/src/index.ts
@@ -9,11 +9,13 @@ type AxiosHeaderRecord = Record<string, string>;
  * Resolves the final absolute URL for an Axios 402 response.
  *
  * @param config - Original Axios request configuration
+ * @param axiosInstance - Axios instance used to serialize the request URL
  * @param response - Axios error response, if present
  * @returns Absolute request URL (prefers final URL after redirects)
  */
 function resolveAxiosRequestUrl(
   config: InternalAxiosRequestConfig,
+  axiosInstance: AxiosInstance,
   response?: AxiosError["response"],
 ): string {
   const responseUrl =
@@ -27,13 +29,13 @@ function resolveAxiosRequestUrl(
   const url = config.url ?? "";
   if (config.baseURL) {
     try {
-      return new URL(url, config.baseURL).href;
+      return new URL(axiosInstance.getUri(config)).href;
     } catch {
       return url || config.baseURL;
     }
   }
 
-  return url;
+  return axiosInstance.getUri(config);
 }
 
 /**
@@ -178,7 +180,7 @@ export function wrapAxiosWithPayment(
         }
 
         // Run payment required hooks
-        const requestUrl = resolveAxiosRequestUrl(originalConfig, error.response);
+        const requestUrl = resolveAxiosRequestUrl(originalConfig, axiosInstance, error.response);
         const hookHeaders = await httpClient.handlePaymentRequired(paymentRequired, requestUrl);
         if (hookHeaders) {
           const hookConfig = createX402RetryConfig(originalConfig);

--- a/typescript/packages/http/axios/src/requestUrl.test.ts
+++ b/typescript/packages/http/axios/src/requestUrl.test.ts
@@ -1,0 +1,86 @@
+import { createServer } from "node:http";
+import { AddressInfo } from "node:net";
+import axios from "axios";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { wrapAxiosWithPayment, x402Client, x402HTTPClient } from "./index";
+
+describe("payment-required request URL", () => {
+  let origin: string;
+  const server = createServer((req, res) => {
+    if (req.headers["x-test-access"]) {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ path: req.url }));
+      return;
+    }
+    const challenge = {
+      x402Version: 2,
+      resource: { url: `${origin}${req.url}` },
+      accepts: [],
+    };
+    res.writeHead(402, {
+      "payment-required": Buffer.from(JSON.stringify(challenge)).toString("base64"),
+    });
+    res.end();
+  });
+
+  beforeAll(async () => {
+    await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+    origin = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) =>
+      server.close(error => (error ? reject(error) : resolve())),
+    );
+  });
+
+  it.each([
+    ["fetch", "/v1", "/quote", "/v1/quote?city=Seoul"],
+    ["fetch", "/v1", "quote", "/v1/quote?city=Seoul"],
+    ["fetch", "/v1/", "/quote", "/v1/quote?city=Seoul"],
+    ["fetch", "", "/quote", "/quote?city=Seoul"],
+    ["http", "/v1", "/quote", "/v1/quote?city=Seoul"],
+  ])("matches %s request with base %s and path %s", async (transport, basePath, path, expected) => {
+    let hookUrl: string | undefined;
+    const client = new x402HTTPClient(new x402Client()).onPaymentRequired(async context => {
+      hookUrl = context.requestUrl;
+      return { headers: { "X-Test-Access": "yes" } };
+    });
+    const api = wrapAxiosWithPayment(
+      axios.create({
+        baseURL: basePath ? `${origin}${basePath}` : undefined,
+        adapter: transport,
+        proxy: false,
+      }),
+      client,
+    );
+    const response = await api.get(basePath ? path : `${origin}${path}`, {
+      params: { city: "Seoul" },
+    });
+
+    expect(response.data.path).toBe(expected);
+    expect(hookUrl).toBe(`${origin}${response.data.path}`);
+  });
+
+  it("uses the instance's default params and custom serializer", async () => {
+    let hookUrl: string | undefined;
+    const client = new x402HTTPClient(new x402Client()).onPaymentRequired(async context => {
+      hookUrl = context.requestUrl;
+      return { headers: { "X-Test-Access": "yes" } };
+    });
+    const api = wrapAxiosWithPayment(
+      axios.create({
+        baseURL: `${origin}/v1`,
+        adapter: "fetch",
+        proxy: false,
+        params: { tag: ["a", "b"] },
+        paramsSerializer: { serialize: params => `tag=${params.tag.join(",")}` },
+      }),
+      client,
+    );
+    const response = await api.get("/quote");
+
+    expect(response.data.path).toBe("/v1/quote?tag=a,b");
+    expect(hookUrl).toBe(`${origin}${response.data.path}`);
+  });
+});


### PR DESCRIPTION
## Description

`onPaymentRequired` receives an incorrect `requestUrl` when the Axios transport does not expose `responseURL` or `res.responseUrl`. With the real Axios fetch adapter, `baseURL: "http://localhost/v1"`, `url: "/quote"`, and `params: { city: "Seoul" }`, the server receives `/v1/quote?city=Seoul`, but the hook receives `/quote` without the base path or query.

The fallback uses WHATWG URL resolution instead of Axios URL joining and ignores `params`/`paramsSerializer`. Use the calling instance's `getUri(config)` for that fallback, preserving the existing preference for transport-provided final URLs and the invalid-base fallback.

This affects resource-scoped payment-required hooks. No signing or settlement changes, and no payment-loss claim.

## Tests

Reproduced with published `@x402/axios@2.25.0` and upstream `04c750e32e2c4dce658289a901710fd721e5d1a9`, using Node 22.22.3 and Axios 1.20.0.

Added a loopback HTTP server regression test using the real Axios instance and real x402 HTTP client. The hook supplies a test access header, so no wallet, facilitator or transaction is used. Coverage includes base-path slash variants, absolute URLs with query parameters, instance-default params/custom serialization, and a passing default HTTP-adapter control.

- Final tests on original source: 5 fail / 35 pass.
- Patched Axios package: 40/40 pass; coverage thresholds pass (100% lines/functions/statements, 98.55% branches).
- Axios package `tsc --noEmit`, changed-file ESLint and Prettier: pass.
- Tests were run with isolated npm dependencies rather than a full workspace install; other SDKs and live-payment E2E were not run.

From `typescript/packages/http/axios`, the checks are `vitest run --coverage` and `tsc --noEmit` using the installed binaries. The new `src/requestUrl.test.ts` is the self-contained reproduction.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass (affected Axios package)
- [x] My commits are signed (GitHub verified)
- [x] I added a changelog fragment for user-facing changes

AI assistance was used for investigation, implementation, and tests. I have reviewed the Axios changes and am marking this PR ready for maintainer review.
