### PR TITLE
fix(hono): preserve repeated query parameter values

### DIFF
--- a/typescript/.changeset/preserve-hono-query-values.md
+++ b/typescript/.changeset/preserve-hono-query-values.md
@@ -1,0 +1,5 @@
+---
+"@x402/hono": patch
+---
+
+Preserved all values of repeated query parameters in the request adapter while keeping single values as strings.

--- a/typescript/packages/http/hono/src/adapter.test.ts
+++ b/typescript/packages/http/hono/src/adapter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { Context } from "hono";
+import { Context, Hono } from "hono";
 import { HonoAdapter } from "./adapter";
 
 /**
@@ -32,11 +32,12 @@ function createMockContext(
       method: options.method || "GET",
       path: url.pathname,
       url: url.toString(),
-      query: vi.fn((name?: string) => {
-        if (name === undefined) {
-          return query;
-        }
-        return query[name];
+      query: vi.fn((name?: string) => (name === undefined ? query : query[name])),
+      queries: vi.fn((name?: string) => {
+        const values = Object.fromEntries(
+          Object.entries(query).map(([key, value]) => [key, [value]]),
+        );
+        return name === undefined ? values : values[name];
       }),
       json: vi.fn().mockResolvedValue(options.body),
     },
@@ -113,6 +114,17 @@ describe("HonoAdapter", () => {
   });
 
   describe("getQueryParams", () => {
+    it.each([
+      ["tag=a&tag=b&city=Seoul", { tag: ["a", "b"], city: "Seoul" }],
+      ["tag=&tag=b", { tag: ["", "b"] }],
+      ["tag=a%20b&tag=c%2Bd", { tag: ["a b", "c+d"] }],
+    ])("preserves repeated parameters in %s", async (query, expected) => {
+      const app = new Hono();
+      app.get("/", c => c.json(new HonoAdapter(c).getQueryParams()));
+      const response = await app.request(`http://localhost/?${query}`);
+      expect(await response.json()).toEqual(expected);
+    });
+
     it("returns all query parameters", () => {
       const c = createMockContext({ query: { foo: "bar", baz: "qux" } });
       const adapter = new HonoAdapter(c);
@@ -127,6 +139,13 @@ describe("HonoAdapter", () => {
   });
 
   describe("getQueryParam", () => {
+    it("preserves repeated values when looking up a parameter by name", async () => {
+      const app = new Hono();
+      app.get("/", c => c.json({ tag: new HonoAdapter(c).getQueryParam("tag") }));
+      const response = await app.request("http://localhost/?tag=&tag=b");
+      expect(await response.json()).toEqual({ tag: ["", "b"] });
+    });
+
     it("returns single value for single param", () => {
       const c = createMockContext({ query: { city: "NYC" } });
       const adapter = new HonoAdapter(c);

--- a/typescript/packages/http/hono/src/adapter.ts
+++ b/typescript/packages/http/hono/src/adapter.ts
@@ -73,13 +73,12 @@ export class HonoAdapter implements HTTPAdapter {
    * @returns Record of query parameter key-value pairs
    */
   getQueryParams(): Record<string, string | string[]> {
-    const query = this.c.req.query();
-    // Convert single values to match the interface
-    const result: Record<string, string | string[]> = {};
-    for (const [key, value] of Object.entries(query)) {
-      result[key] = value;
-    }
-    return result;
+    return Object.fromEntries(
+      Object.entries(this.c.req.queries()).map(([key, values]) => [
+        key,
+        values.length === 1 ? values[0] : values,
+      ]),
+    );
   }
 
   /**
@@ -89,7 +88,9 @@ export class HonoAdapter implements HTTPAdapter {
    * @returns The query parameter value(s) or undefined
    */
   getQueryParam(name: string): string | string[] | undefined {
-    return this.c.req.query(name);
+    const values = this.c.req.queries(name);
+    if (!values || values.length === 0) return undefined;
+    return values.length === 1 ? values[0] : values;
   }
 
   /**


### PR DESCRIPTION
## Description

For `GET /quote?tag=a&tag=b`, Hono exposes both values through `c.req.queries('tag')`, but the x402 adapter returns only `'a'` from `getQueryParam('tag')` and `getQueryParams().tag`. Payment hooks can therefore receive different input from the downstream handler.

Use Hono's `queries()` API, retaining strings for single values, arrays for repeated values, and `undefined` for absent parameters. Public signatures remain unchanged.

## Tests

Reproduced with published `@x402/hono@2.25.0`, Hono 4.13.7, Node 22.22.3, and upstream `04c750e32e2c4dce658289a901710fd721e5d1a9`. The reproduction used real Hono middleware and an `onProtectedRequest` hook; no wallet, facilitator or payment was involved.

- Final adapter tests on unchanged source: 4 fail / 15 pass.
- Patched package: 77/77 tests pass, including coverage thresholds; adapter coverage is 100%.
- New regression cases use real Hono requests for repeated, empty, and decoded values.
- Changed-file ESLint and Prettier pass.
- Full package typecheck still reports three pre-existing errors in `lineTerminatorBypass.test.ts` and `malformedPathBypass.test.ts`; original and patched outputs are identical.

Checks used isolated npm dependencies, not a full monorepo installation. From `typescript/packages/http/hono`: `vitest run --coverage` and `tsc --noEmit` using the installed binaries. No live-payment E2E was run.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass (affected Hono package)
- [x] My commits are signed (GitHub verified)
- [x] I added a changelog fragment for user-facing changes

AI assistance was used for investigation, implementation, and testing. I have personally reviewed these changes and am marking this PR ready for maintainer review.
