### PR TITLE
fix(next): preserve leading empty query parameter values

### DIFF
--- a/typescript/.changeset/preserve-next-empty-query-values.md
+++ b/typescript/.changeset/preserve-next-empty-query-values.md
@@ -1,0 +1,5 @@
+---
+"@x402/next": patch
+---
+
+Preserved leading empty values in repeated query parameters returned by the request adapter.

--- a/typescript/packages/http/next/src/adapter.test.ts
+++ b/typescript/packages/http/next/src/adapter.test.ts
@@ -94,6 +94,16 @@ describe("NextAdapter", () => {
   });
 
   describe("getQueryParams", () => {
+    it.each([
+      ["tag=&tag=b", ["", "b"]],
+      ["tag=&tag=", ["", ""]],
+      ["tag=&tag=b&tag=c", ["", "b", "c"]],
+    ])("preserves empty values in %s", (query, expected) => {
+      const adapter = new NextAdapter(new NextRequest(`https://example.com/api?${query}`));
+      expect(adapter.getQueryParams()).toEqual({ tag: expected });
+      expect(adapter.getQueryParams().tag).toEqual(adapter.getQueryParam("tag"));
+    });
+
     it("returns all query parameters", () => {
       const req = createMockRequest({ url: "https://example.com/api?foo=bar&baz=qux" });
       const adapter = new NextAdapter(req);

--- a/typescript/packages/http/next/src/adapter.ts
+++ b/typescript/packages/http/next/src/adapter.ts
@@ -76,7 +76,7 @@ export class NextAdapter implements HTTPAdapter {
     const params: Record<string, string | string[]> = {};
     this.req.nextUrl.searchParams.forEach((value, key) => {
       const existing = params[key];
-      if (existing) {
+      if (existing !== undefined) {
         if (Array.isArray(existing)) {
           existing.push(value);
         } else {


### PR DESCRIPTION
## Description

For `GET /quote?tag=&tag=b`, `getQueryParams()` returns `{ tag: 'b' }`, but `getQueryParam('tag')` and the downstream Next.js handler retain `['', 'b']`.

The adapter tests an existing value for truthiness, treating an empty string as absent. Check `existing !== undefined` instead. The fix is scoped to preserving leading empty values and does not change the public scalar/array interface.

This is separate from body-consumption issue #3445 and PR #3451; no body-handling code is changed.

## Tests

Reproduced with published `@x402/next@2.25.0`, Next.js 16.2.6, Node 22.22.3, and upstream `04c750e32e2c4dce658289a901710fd721e5d1a9`, using `NextRequest`, `withX402FromHTTPServer`, and a protected-request hook. No payment was involved.

- Final adapter tests on unchanged source: 3 fail / 17 pass.
- Patched package: 94/94 tests pass, including coverage thresholds; adapter coverage is 100%.
- Regression cases cover an initial empty value, two empty values, and an initial empty value followed by two nonempty values.
- Changed-file ESLint and Prettier pass.
- Full package typecheck still reports four pre-existing errors in `index.test.ts` and `utils.test.ts`; original and patched outputs are identical.

Checks used isolated npm dependencies, not a full monorepo installation. From `typescript/packages/http/next`: `vitest run --coverage` and `tsc --noEmit` using the installed binaries. A deployed Next.js server and live-payment E2E were not tested.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass (affected Next.js package)
- [x] My commits are signed (GitHub verified)
- [x] I added a changelog fragment for user-facing changes

AI assistance was used for investigation, implementation, and testing. I have personally reviewed these changes and am marking this PR ready for maintainer review.
