### PR TITLE
feat(evm): add Celo USDT and USAT as default assets; link Celo facilitator page

### DIFF
--- a/docs/dev-tools/facilitators.md
+++ b/docs/dev-tools/facilitators.md
@@ -21,7 +21,7 @@ If you are evaluating a mainnet EVM route, decide on your production facilitator
 | ---- | ----------- | 
 | [Built on Stellar](https://developers.stellar.org/docs/build/apps/x402/built-on-stellar) | Free, public x402 facilitator for Stellar |
 | [CDP Facilitator](https://docs.cdp.coinbase.com/x402/docs/quickstart-sellers) | Coinbase-hosted facilitator with KYT/OFAC checks on every transaction |
-| [Celo Facilitator](https://docs.celo.org/build-on-celo/build-with-ai/x402) | Gasless x402 facilitator for Celo Mainnet, accepting USDC and USD₮ via EIP-3009 |
+| [Celo Facilitator](https://x402.celo.org) | Gasless x402 facilitator for Celo Mainnet (API: `https://api.x402.celo.org`), accepting USDC, USD₮ and USA₮ via EIP-3009 |
 | [Corbits](https://corbits.dev) | Production-grade multi-network, multi-token facilitator supporting EVM and Solana |
 | [Dexter](https://dexter.cash/facilitator) | Free public x402 facilitator across Solana and EVM chains with no fees and no account required |
 | [Fireblocks Facilitator](https://developers.fireblocks.com/docs/x402-facilitator-overview) | Open-source and hosted facilitator with Fireblocks vault settlement; private keys never leave Fireblocks |

--- a/go/.changes/unreleased/added-20260912-celo-usdt-default-asset.yaml
+++ b/go/.changes/unreleased/added-20260912-celo-usdt-default-asset.yaml
@@ -1,0 +1,3 @@
+kind: added
+body: Add Celo mainnet USDT and USAT (EIP-3009) as default assets for eip155:42220 so "$0.10 USDT" and "$0.10 USAT" resolve on Celo; bare "$0.10" still resolves to USDC.
+time: 2026-09-12T12:00:00Z

--- a/go/mechanisms/evm/default_assets.go
+++ b/go/mechanisms/evm/default_assets.go
@@ -88,6 +88,8 @@ var DefaultAssets = map[string][]DefaultAssetInfo{
 	},
 	"eip155:42220": {
 		{Asset: "0xcebA9300f2b948710d2653dD7B07f33A8B32118C", Name: "USDC", Version: "2", Decimals: 6, Symbol: "USDC"},
+		{Asset: "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e", Name: "Tether USD", Version: "1", Decimals: 6, Symbol: "USDT"},
+		{Asset: "0xD2ab3C9A02DBBAB236BfEC45D1d755DF4267F771", Name: "Tether America USD", Version: "1", Decimals: 6, Symbol: "USAT"},
 	},
 	"eip155:11142220": {
 		{Asset: "0x01C5C0122039549AD1493B8220cABEdD739BC44E", Name: "USDC", Version: "2", Decimals: 6, Symbol: "USDC"},

--- a/python/x402/changelog.d/celo-usdt-default-asset.feature.md
+++ b/python/x402/changelog.d/celo-usdt-default-asset.feature.md
@@ -1,0 +1,1 @@
+Add Celo mainnet USDT and USAT (EIP-3009) as default assets for `eip155:42220` so `"$0.10 USDT"` and `"$0.10 USAT"` resolve on Celo; bare `"$0.10"` still resolves to USDC.

--- a/python/x402/mechanisms/evm/default_assets.py
+++ b/python/x402/mechanisms/evm/default_assets.py
@@ -244,7 +244,21 @@ DEFAULT_ASSETS: dict[str, list[ExactDefaultAssetInfo]] = {
             "decimals": 6,
             "symbol": "USDC",
         },
-    ],  # Celo mainnet USDC (EIP-3009 supported)
+        {
+            "asset": "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e",
+            "name": "Tether USD",
+            "version": "1",
+            "decimals": 6,
+            "symbol": "USDT",
+        },
+        {
+            "asset": "0xD2ab3C9A02DBBAB236BfEC45D1d755DF4267F771",
+            "name": "Tether America USD",
+            "version": "1",
+            "decimals": 6,
+            "symbol": "USAT",
+        },
+    ],  # Celo mainnet USDC, USDT, USAT (EIP-3009 supported)
     "eip155:11142220": [
         {
             "asset": "0x01C5C0122039549AD1493B8220cABEdD739BC44E",

--- a/typescript/.changeset/celo-usdt-default-asset.md
+++ b/typescript/.changeset/celo-usdt-default-asset.md
@@ -1,0 +1,5 @@
+---
+"@x402/evm": patch
+---
+
+Add Celo mainnet USDT (`0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e`) and USAT (`0xD2ab3C9A02DBBAB236BfEC45D1d755DF4267F771`), both EIP-3009, as default assets for `eip155:42220`, so `"$0.10 USDT"` and `"$0.10 USAT"` resolve on Celo. Bare `"$0.10"` still resolves to USDC.

--- a/typescript/packages/mechanisms/evm/src/defaultAssets.ts
+++ b/typescript/packages/mechanisms/evm/src/defaultAssets.ts
@@ -255,7 +255,21 @@ export const DEFAULT_ASSETS: DefaultAssetTable<ExactDefaultAssetInfo> = {
       decimals: 6,
       symbol: "USDC",
     },
-  ], // Celo mainnet USDC (EIP-3009 supported)
+    {
+      asset: "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e",
+      name: "Tether USD",
+      version: "1",
+      decimals: 6,
+      symbol: "USDT",
+    },
+    {
+      asset: "0xD2ab3C9A02DBBAB236BfEC45D1d755DF4267F771",
+      name: "Tether America USD",
+      version: "1",
+      decimals: 6,
+      symbol: "USAT",
+    },
+  ], // Celo mainnet USDC, USDT, USAT (EIP-3009 supported)
   "eip155:11142220": [
     {
       asset: "0x01C5C0122039549AD1493B8220cABEdD739BC44E",


### PR DESCRIPTION
## Summary

Adds Celo mainnet USDT and USAT as default assets for `eip155:42220` (USDC was added in #3025), and points the facilitators page at the Celo facilitator's own site.

## Changes

- `typescript/packages/mechanisms/evm/src/defaultAssets.ts`, `go/mechanisms/evm/default_assets.go`, `python/x402/mechanisms/evm/default_assets.py`: two entries after Celo USDC, same shape.
  - USDT `0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e`, 6 decimals, EIP-712 `Tether USD` / `1`
  - USAT `0xD2ab3C9A02DBBAB236BfEC45D1d755DF4267F771`, 6 decimals, EIP-712 `Tether America USD` / `1`
- `docs/dev-tools/facilitators.md`: Celo row links to https://x402.celo.org (API `https://api.x402.celo.org`), "USDC, USD₮ and USA₮ via EIP-3009".
- Changesets: `@x402/evm` patch, Go `added`, Python feature fragment.

## Verification

On-chain, against `https://forno.celo.org`, for both tokens: `decimals()` = 6; `name()` as above; `version()` reverts on both (hence the pinned `"1"`); `DOMAIN_SEPARATOR()` equals the value recomputed from (name, `"1"`, 42220, address) — exact match for both; `transferWithAuthorization` selector present in each proxy's implementation bytecode; `authorizationState()` answers. Control: Celo has an 18-decimal fee-currency adapter with the same name/symbol for each Tether token (`0x0357EE22…` for USAT); the entries above are the 6-decimal tokens, confirmed by the `decimals()` reads.

Both tokens have been settling through the Celo facilitator on mainnet since July (USDT) and August (USAT).

Tests: `go test ./...` in `go/mechanisms/evm`; `pytest` for the default-asset module; `pnpm --filter @x402/evm test` (1112 tests); eslint on `defaultAssets.ts`. The two pre-existing `tsc` errors in `src/utils.ts` (`Crypto`) are unchanged from `main`.

Note: no chain in the tables had more than one entry before this; the second and third entries mirror the first. Happy to add a test pinning the Celo entries if you want one.

Prepared with AI assistance; every value above was read from the chain and the tests were run before opening.
