### PR TITLE
docs: add sendcheck-verify to third-party SDKs

### DIFF
--- a/docs/dev-tools/third-party-sdks.md
+++ b/docs/dev-tools/third-party-sdks.md
@@ -8,3 +8,4 @@ description: "Community-maintained x402 SDKs."
 | [Mogami](https://mogami.gitbook.io/mogami) | Java x402 stack | Java | [GitHub](https://github.com/mogami-tech/) |
 | [x402-rs](https://github.com/x402-rs/x402-rs/blob/main/README.md) | Rust toolkit for x402 | Rust | [GitHub](https://github.com/x402-rs/x402-rs) |
 | [x402-rails](https://github.com/quiknode-labs/x402-rails/blob/main/README.md) | x402 for Rails applications by Quicknode | Ruby | [GitHub](https://github.com/quiknode-labs/x402-rails) |
+| [sendcheck-verify](https://github.com/pennyforgeorg/sendcheck-verify) | Node.js x402 verify-before-pay client with drift-proof service-card attestation (key pinning) | JavaScript | [GitHub](https://github.com/pennyforgeorg/sendcheck-verify) |


### PR DESCRIPTION
Adds sendcheck-verify to the third-party SDK list.

sendcheck-verify is a zero-dependency Node.js (ESM + CJS) client for the x402 protocol: it verifies the merchant's signed service card (ES256 JWS over payTo and per-route maxPrice) and the 402 payment challenge cryptographically before paying, and pins the key so settlement cannot be silently re-routed (drift-proof). It ships as @pennyforgeorg/sendcheck-verify on the npm GitHub registry.

AI-assisted contribution per CONTRIBUTING.md: drafted by an agent, human-reviewed; the row links only to the public repo.
